### PR TITLE
Allow module level sentry properties file

### DIFF
--- a/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -25,7 +25,7 @@ class SentryPlugin implements Plugin<Project> {
      */
     static String getSentryCli(Project project) {
         // if a path is provided explicitly use that first
-        def propertiesFile = "${project.rootDir.toPath()}/sentry.properties"
+        def propertiesFile = getPropertiesFile(project)
         project.logger.info("propertiesFile: ${propertiesFile}")
 
         Properties sentryProps = new Properties()
@@ -114,6 +114,15 @@ class SentryPlugin implements Plugin<Project> {
         }
 
         return "sentry-cli"
+    }
+
+    static String getPropertiesFile(Project project) {
+        def projectProperties = new File("${project.getProjectDir.toPath()}/sentry.properties")
+        if (projectProperties.exists()) {
+            return projectProperties.toPath().toString()
+        } else {
+            return "${project.rootDir.toPath()}/sentry.properties"
+        }
     }
 
     /**
@@ -471,6 +480,7 @@ class SentryPlugin implements Plugin<Project> {
                 "${project.projectDir}/src/${buildTypeName}/${flavorName}/${propName}",
                 "${project.projectDir}/src/${flavorName}/${buildTypeName}/${propName}",
                 "${project.projectDir}/src/${flavorName}/${propName}",
+                "${project.projectDir}/${propName}",
                 "${project.rootDir.toPath()}/src/${flavorName}/${propName}",
         ] + possibleProps + [
                 "${project.rootDir.toPath()}/src/${buildTypeName}/${propName}",

--- a/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -117,7 +117,7 @@ class SentryPlugin implements Plugin<Project> {
     }
 
     static String getPropertiesFile(Project project) {
-        def projectProperties = new File("${project.getProjectDir.toPath()}/sentry.properties")
+        def projectProperties = new File("${project.getProjectDir().toPath()}/sentry.properties")
         if (projectProperties.exists()) {
             return projectProperties.toPath().toString()
         } else {


### PR DESCRIPTION
## Problem
The sentry gradle plugin does not seem to support multiple application modules in the same gradle project very cleanly. I read https://github.com/getsentry/sentry-android-gradle-plugin/issues/5 but the solution suggested there did not seem ideal.

## Solution
Allow the sentry.properties file to exist in all currently supported locations, as well as the module's directory.

Ie, both of the following paths would be supported:
```
.
├── app-1
├── app-2
└── sentry.properties

.
├── app-1
│   └── sentry.properties
└── app-2
    └── sentry.properties
```

## Verification

I built a snapshot of the gradle plugin and applied it to my own project (already set up to use sentry). I built release APKs of the app with `sentry.properties` in the root gradle directory, and another with it in the application gradle module directory Crashed the app intentionally on both APKs built, and in the sentry web UI I was able to see the crash events with the crashes properly de-obfuscated.