### PR TITLE
Add a workflow to test publishing of mapping files

### DIFF
--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -1,0 +1,40 @@
+name: Test Publishing UUID
+
+on:
+  push:
+    branches:
+      - master
+      - feat/gradle-plugin-v2
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  publish:
+    if: ${{ github.repository == 'getsentry/sentry-android-gradle-plugin'}}
+    runs-on: ubuntu-latest
+
+    env:
+      AUTO_UPLOAD: true
+      AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Files
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ matrix.os }}
+          restore-keys: |
+            cache-gradle-
+
+      - name: Setup API Key
+        run: |
+          echo "\nauth.token=$AUTH_TOKEN" >> ./examples/android-gradle/sentry.properties
+          echo "\nauth.token=$AUTH_TOKEN" >> ./examples/android-gradle-kts/sentry.properties
+
+      - name: Run the persistSentryProguardUuids task
+        run: ./gradlew persistSentryProguardUuidsForReleaseRelease

--- a/examples/android-gradle-kts/build.gradle.kts
+++ b/examples/android-gradle-kts/build.gradle.kts
@@ -14,10 +14,11 @@ android {
     buildTypes {
         getByName("release") {
             minifyEnabled(true)
+            proguardFiles.add(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }
 }
 
 sentry {
-    autoUpload = false
+    autoUpload = System.getenv("AUTO_UPLOAD")?.toBoolean() ?: false
 }

--- a/examples/android-gradle-kts/src/main/AndroidManifest.xml
+++ b/examples/android-gradle-kts/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.example.sampleapp"/>
+          package="com.example.sampleapp">
+    <application>
+        <activity android:name=".MainActivity"/>
+    </application>
+</manifest>

--- a/examples/android-gradle-kts/src/main/java/com/example/sampleapp/MainActivity.java
+++ b/examples/android-gradle-kts/src/main/java/com/example/sampleapp/MainActivity.java
@@ -1,0 +1,7 @@
+package com.example.sampleapp;
+
+import android.app.Activity;
+
+public class MainActivity extends Activity {
+
+}

--- a/examples/android-gradle/build.gradle
+++ b/examples/android-gradle/build.gradle
@@ -25,10 +25,12 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            proguardFiles getDefaultProguardFile(
+              'proguard-android-optimize.txt')
         }
     }
 }
 
 sentry {
-    autoUpload = false
+    autoUpload = System.getenv("AUTO_UPLOAD") ?: false
 }

--- a/examples/android-gradle/src/main/AndroidManifest.xml
+++ b/examples/android-gradle/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.example.sampleapp"/>
+          package="com.example.sampleapp">
+    <application>
+        <activity android:name=".MainActivity"/>
+    </application>
+</manifest>

--- a/examples/android-gradle/src/main/java/com/example/sampleapp/MainActivity.java
+++ b/examples/android-gradle/src/main/java/com/example/sampleapp/MainActivity.java
@@ -1,0 +1,7 @@
+package com.example.sampleapp;
+
+import android.app.Activity;
+
+public class MainActivity extends Activity {
+
+}


### PR DESCRIPTION
I'm adding a workflow to test end-to-end that the publishing works fine.
This workflow relies on the API token secret and works only on merge and PRs within the upstream repo.

For external PRs it won't run (as the secret won't be available) as it would just fail.

I've done a test run on my fork with a dummy token here: https://github.com/cortinico/sentry-android-gradle-plugin/runs/2034278777?check_suite_focus=true