### PR TITLE
Fix broken validatePlugin check

### DIFF
--- a/plugin-build/src/main/groovy/io/sentry/android/gradle/SentryProguardConfigTask.groovy
+++ b/plugin-build/src/main/groovy/io/sentry/android/gradle/SentryProguardConfigTask.groovy
@@ -1,12 +1,14 @@
 package io.sentry.android.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 import com.android.build.gradle.api.ApplicationVariant
 
 class SentryProguardConfigTask extends DefaultTask {
 
+    @Internal
     ApplicationVariant applicationVariant
 
     SentryProguardConfigTask() {


### PR DESCRIPTION
The `validatePlugin` task is currently broken as there is a non annotated property inside a task. I'm fixing it.