### PR TITLE
Make sure the `assembleRelease` task is invoked

### DIFF
--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -32,4 +32,4 @@ jobs:
             cache-gradle-
 
       - name: Run the persistSentryProguardUuids task
-        run: ./gradlew persistSentryProguardUuidsForReleaseRelease
+        run: ./gradlew assembleRelease persistSentryProguardUuidsForReleaseRelease


### PR DESCRIPTION
Calling `persistSentryProguardUuidsForReleaseRelease` directly will result in not having a mapping file, so I'm adding `assembleRelease` to the build step.