### PR TITLE
Fix failing Gradle tests on Windows 

### DIFF
--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -32,6 +32,7 @@ class SentryPluginTest(
 
         val pluginClasspath = PluginUnderTestMetadataReading.readImplementationClasspath()
             .joinToString(separator = ", ") { "\"$it\"" }
+            .replace(File.separator, "/")
 
         appBuildFile = File(testProjectDir.root, "app/build.gradle")
         rootBuildFile = testProjectDir.writeFile("build.gradle") {


### PR DESCRIPTION
Just a small test as tests are failing on Windows due to a path separator issue.
Here the run on my fork: https://github.com/cortinico/sentry-android-gradle-plugin/actions/runs/634024107