### PR TITLE
Fix flaky test failures for `ZipFile`

### DIFF
--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -9,10 +9,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.io.File
-import java.util.UUID
-import java.util.zip.ZipFile
 import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
 
 @Suppress("FunctionName")
 @RunWith(Parameterized::class)
@@ -113,10 +110,10 @@ class SentryPluginTest(
         runner.appendArguments(":app:assembleRelease")
 
         runner.build()
-        val uuid1 = verifyProguardUuid()
+        val uuid1 = verifyProguardUuid(testProjectDir.root)
 
         runner.build()
-        val uuid2 = verifyProguardUuid()
+        val uuid2 = verifyProguardUuid(testProjectDir.root)
 
         assertNotEquals(uuid1, uuid2)
     }
@@ -127,26 +124,10 @@ class SentryPluginTest(
             .appendArguments(":app:assembleRelease")
             .build()
 
-        verifyProguardUuid()
-    }
-
-    private fun verifyProguardUuid(variant: String = "release"): UUID {
-        val apk = testProjectDir.root.resolve("app/build/outputs/apk/$variant/app-$variant-unsigned.apk")
-        val sentryProperties = with(ZipFile(apk)) {
-            val entry = getEntry("assets/sentry-debug-meta.properties")
-            assertNotNull(entry, "Asset not included")
-            getInputStream(entry).bufferedReader().use {
-                it.readText()
-            }
-        }
-        val matcher = assetPattern.matchEntire(sentryProperties)
-        assertNotNull(matcher, "$sentryProperties does not match pattern $assetPattern")
-        return UUID.fromString(matcher.groupValues[1])
+        verifyProguardUuid(testProjectDir.root)
     }
 
     companion object {
-        private val assetPattern =
-            Regex("""^io\.sentry\.ProguardUuids=([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$""".trimMargin())
 
         @Parameterized.Parameters(name = "AGP {0}, Gradle {1}")
         @JvmStatic

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
@@ -1,0 +1,51 @@
+package io.sentry.android.gradle
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.nio.charset.Charset
+import java.util.UUID
+import java.util.zip.ZipInputStream
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private val ASSET_PATTERN =
+    Regex("""^io\.sentry\.ProguardUuids=([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$""".trimMargin())
+
+internal fun verifyProguardUuid(rootFile: File, variant: String = "release"): UUID {
+    val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant-unsigned.apk")
+    val sentryProperties = extractZip(apk, "assets/sentry-debug-meta.properties")
+    val matcher = ASSET_PATTERN.matchEntire(sentryProperties)
+
+    assertTrue("Properties file is missing from the APK") { sentryProperties.isNotBlank() }
+    assertNotNull(matcher, "$sentryProperties does not match pattern $ASSET_PATTERN")
+
+    return UUID.fromString(matcher.groupValues[1])
+}
+
+private fun extractZip(zipFile: File, fileToExtract: String): String {
+    ZipInputStream(FileInputStream(zipFile)).use { zis ->
+        var entry = zis.nextEntry
+        while (entry != null) {
+            if (entry.name == fileToExtract) {
+                return readZippedContent(zis)
+            }
+            zis.closeEntry()
+            entry = zis.nextEntry
+        }
+    }
+    return ""
+}
+
+private fun readZippedContent(zipInputStream: ZipInputStream): String {
+    val baos = ByteArrayOutputStream()
+    val content = ByteArray(1024)
+    var len: Int = zipInputStream.read(content)
+    while (len > 0) {
+        baos.write(content, 0, len)
+        len = zipInputStream.read(content)
+    }
+    val stringContent = baos.toString(Charset.defaultCharset().name())
+    baos.close()
+    return stringContent
+}


### PR DESCRIPTION
It seems that tests are failing on the `ZipFile` when trying to read an asset file from the APK.
I'm updating them to use `ZipInputStream` here.

A green run on CI is here: https://github.com/cortinico/sentry-android-gradle-plugin/actions/runs/651464179