### PR TITLE
Export the Cli provider outside the plugin

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -1,0 +1,108 @@
+package io.sentry.android.gradle
+
+import org.gradle.api.Project
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.Properties
+
+internal object SentryCliProvider {
+    /**
+     * Return the correct sentry-cli executable path to use for the given project.  This
+     * will look for a sentry-cli executable in a local node_modules in case it was put
+     * there by sentry-react-native or others before falling back to the global installation.
+     */
+    @JvmStatic
+    fun getSentryCliPath(project: Project): String {
+        // If a path is provided explicitly use that first.
+        project.logger.info("[sentry] Searching cli from sentry.properties file...")
+
+        searchCliInPropertiesFile(project)?.let {
+            project.logger.info("[sentry] cli Found: $it")
+            return@getSentryCliPath it
+        } ?: project.logger.warn("[sentry] sentry-cli not found in sentry.properties file")
+
+        // next up try a packaged version of sentry-cli
+        val cliSuffix = getCliSuffix()
+        project.logger.info("[sentry] cliSuffix is $cliSuffix")
+
+        if (!cliSuffix.isNullOrBlank()) {
+            val resourcePath = "/bin/sentry-cli-$cliSuffix"
+
+            // if we are not in a jar, we can use the file directly
+            project.logger.info("[sentry] Searching for $resourcePath in resources folder...")
+
+            searchCliInResources(resourcePath)?.let {
+                project.logger.info("[sentry] cli Found: $it")
+                return@getSentryCliPath it
+            } ?: project.logger.warn("[sentry] Failed to load sentry-cli from resource folder")
+
+            // otherwise we need to unpack into a file
+            project.logger.info("[sentry] Trying to load cli from $resourcePath in a temp file...")
+
+            loadCliFromResourcesToTemp(resourcePath)?.let {
+                project.logger.info("[sentry] cli Found: $it")
+                return@getSentryCliPath it
+            } ?: project.logger.warn("[sentry] Failed to load sentry-cli from resource folder")
+        }
+
+        project.logger.error("[sentry] Falling back to invoking `sentry-cli` from shell")
+        return "sentry-cli"
+    }
+
+    internal fun getSentryPropertiesPath(project: Project): String? =
+        listOf(
+            project.file("sentry.properties"),
+            project.rootProject.file("sentry.properties")
+        ).firstOrNull(File::exists)?.path
+
+    internal fun searchCliInPropertiesFile(project: Project): String? {
+        return getSentryPropertiesPath(project)?.let { propertiesFile ->
+            runCatching {
+                Properties()
+                    .apply { load(FileInputStream(propertiesFile)) }
+                    .getProperty("cli.executable")
+            }.getOrNull()
+        }
+    }
+
+    internal fun searchCliInResources(resourcePath: String): String? {
+        val resourceURL = javaClass.getResource(resourcePath)
+        val resourceFile = resourceURL?.let { File(it.file) }
+        return if (resourceFile?.exists() == true) {
+            resourceFile.absolutePath
+        } else {
+            null
+        }
+    }
+
+    internal fun loadCliFromResourcesToTemp(resourcePath: String): String? {
+        val resourceStream = javaClass.getResourceAsStream(resourcePath)
+        val tempFile = File.createTempFile(".sentry-cli", ".exe").apply {
+            deleteOnExit()
+            setExecutable(true)
+        }
+
+        return if (resourceStream != null) {
+            FileOutputStream(tempFile).use { output ->
+                resourceStream.use { input ->
+                    input.copyTo(output)
+                }
+            }
+            tempFile.absolutePath
+        } else {
+            null
+        }
+    }
+
+    internal fun getCliSuffix(): String? {
+        val osName = System.getProperty("os.name").toLowerCase()
+        val osArch = System.getProperty("os.arch")
+        return when {
+            "mac" in osName -> "Darwin-x86_64"
+            "linux" in osName -> if (osArch == "amd64") "Linux-x86_64" else "Linux-$osArch"
+            "win" in osName -> "Windows-i686.exe"
+            else -> null
+        }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -1,0 +1,195 @@
+package io.sentry.android.gradle
+
+import io.sentry.android.gradle.SentryCliProvider.getCliSuffix
+import io.sentry.android.gradle.SentryCliProvider.getSentryPropertiesPath
+import io.sentry.android.gradle.SentryCliProvider.loadCliFromResourcesToTemp
+import io.sentry.android.gradle.SentryCliProvider.searchCliInPropertiesFile
+import io.sentry.android.gradle.SentryCliProvider.searchCliInResources
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SentryCliProviderTest {
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    @Test
+    fun `getSentryPropertiesPath returns local properties file`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        testProjectDir.newFile("sentry.properties")
+
+        assertEquals(
+            project.file("sentry.properties").path,
+            getSentryPropertiesPath(project)
+        )
+    }
+
+    @Test
+    fun `getSentryPropertiesPath fallbacks to top level properties file`() {
+        val topLevelProject = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        val project = ProjectBuilder
+            .builder()
+            .withParent(topLevelProject)
+            .build()
+
+        testProjectDir.newFile("sentry.properties")
+
+        assertEquals(
+            topLevelProject.file("sentry.properties").path,
+            getSentryPropertiesPath(project)
+        )
+    }
+
+    @Test
+    fun `getSentryPropertiesPath returns null if no properties file is found`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        assertNull(getSentryPropertiesPath(project))
+    }
+
+    @Test
+    fun `searchCliInPropertiesFile returns cli-executable correctly`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        testProjectDir.newFile("sentry.properties").apply {
+            writeText("cli.executable=vim")
+        }
+
+        assertEquals("vim", searchCliInPropertiesFile(project))
+    }
+
+    @Test
+    fun `searchCliInPropertiesFile ignores other fields`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        testProjectDir.newFile("sentry.properties").apply {
+            writeText("another=field")
+        }
+
+        assertNull(searchCliInPropertiesFile(project))
+    }
+
+    @Test
+    fun `searchCliInPropertiesFile returns null for empty file`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        testProjectDir.newFile("sentry.properties")
+
+        assertNull(searchCliInPropertiesFile(project))
+    }
+
+    @Test
+    fun `searchCliInPropertiesFile returns null for missing file`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        assertNull(searchCliInPropertiesFile(project))
+    }
+
+    @Test
+    fun `searchCliInResources finds the file correctly`() {
+        val resourcePath = "/testFixtures/bin/dummy-sentry-cli"
+
+        val foundPath = searchCliInResources(resourcePath)
+        assertNotNull(foundPath)
+        assertTrue(foundPath.endsWith(resourcePath))
+    }
+
+    @Test
+    fun `searchCliInResources returns null if file does not exist`() {
+        val resourcePath = "/testFixtures/bin/i-dont-exist"
+
+        assertNull(searchCliInResources(resourcePath))
+    }
+
+    @Test
+    fun `loadCliFromResourcesToTemp finds the file correctly`() {
+        val resourcePath = "/testFixtures/bin/dummy-sentry-cli"
+
+        val loadedPath = loadCliFromResourcesToTemp(resourcePath)
+        assertNotNull(loadedPath)
+
+        val binContent = File(loadedPath).readText()
+        assertEquals(
+            """
+            #!/bin/bash
+            echo "This is just a dummy script"
+
+            """.trimIndent(),
+            binContent
+        )
+    }
+
+    @Test
+    fun `loadCliFromResourcesToTemp returns null if file does not exist`() {
+        val resourcePath = "/testFixtures/bin/i-dont-exist"
+
+        assertNull(loadCliFromResourcesToTemp(resourcePath))
+    }
+
+    @Test
+    fun `getCliSuffix on mac returns Darwin`() {
+        System.setProperty("os.name", "mac")
+
+        assertEquals("Darwin-x86_64", getCliSuffix())
+    }
+
+    @Test
+    fun `getCliSuffix on linux amd64 returns Linux-x86_64`() {
+        System.setProperty("os.name", "linux")
+        System.setProperty("os.arch", "amd64")
+
+        assertEquals("Linux-x86_64", getCliSuffix())
+    }
+
+    @Test
+    fun `getCliSuffix on linux armV7 returns Linux-armV7`() {
+        System.setProperty("os.name", "linux")
+        System.setProperty("os.arch", "armV7")
+
+        assertEquals("Linux-armV7", getCliSuffix())
+    }
+
+    @Test
+    fun `getCliSuffix on win returns Windows-i686`() {
+        System.setProperty("os.name", "windows")
+
+        assertEquals("Windows-i686.exe", getCliSuffix())
+    }
+
+    @Test
+    fun `getCliSuffix on an unknown platform returns null`() {
+        System.setProperty("os.name", "¯\\_(ツ)_/¯")
+
+        assertNull(getCliSuffix())
+    }
+}


### PR DESCRIPTION
Taking some of the work from #44, I've moved all the CLI logic to a separate file and rewritten it in Kotlin + I've added some tests.

Differently than #44 I haven't created a separate task for it as I think it would introduce more complexity.