### PR TITLE
Export Task Providers to a separate class

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -1,0 +1,88 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.api.ApplicationVariant
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+internal object SentryTasksProvider {
+
+    /**
+     * Returns the transformer task for the given project and variant.
+     * It could be either ProGuard or R8
+     *
+     * @return the task or null otherwise
+     */
+    @JvmStatic
+    fun getTransformerTask(project: Project, variantName: String): Task? =
+        project.findTask(
+            // Android Studio 3.3 includes the R8 shrinker.
+            "transformClassesAndResourcesWithR8For${variantName.capitalized}",
+            "transformClassesAndResourcesWithProguardFor${variantName.capitalized}",
+            "minify${variantName.capitalized}WithR8",
+            "minify${variantName.capitalized}WithProguard"
+        )
+
+    /**
+     * Returns the dex task for the given project and variant.
+     *
+     * @return the task or null otherwise
+     */
+    @JvmStatic
+    fun getDexTask(project: Project, variantName: String): Task? =
+        project.findTask(
+            // Android Studio 3.3 includes the R8 shrinker.
+            "transformClassesWithDexFor${variantName.capitalized}",
+            "transformClassesWithDexBuilderFor${variantName.capitalized}",
+            "transformClassesAndDexWithShrinkResFor${variantName.capitalized}"
+        )
+
+    /**
+     * Returns the pre bundle task for the given project and variant.
+     *
+     * @return the task or null otherwise
+     */
+    @JvmStatic
+    fun getPreBundleTask(project: Project, variantName: String): Task? =
+        project.findTask("build${variantName.capitalized}PreBundle")
+
+    /**
+     * Returns the pre bundle task for the given project and variant.
+     *
+     * @return the task or null otherwise
+     */
+    @JvmStatic
+    fun getBundleTask(project: Project, variantName: String): Task? =
+        project.findTask("bundle${variantName.capitalized}")
+
+    /**
+     * Returns the package task
+     *
+     * @return the package task or null if not found
+     */
+    @JvmStatic
+    fun getPackageTask(project: Project, variantName: String) =
+        project.findTask(
+            "package${variantName.capitalized}",
+            "package${variantName.capitalized}Bundle"
+        )
+
+    /**
+     * Returns the assemble task
+     *
+     * @return the task if found or null otherwise
+     */
+    @JvmStatic
+    fun getAssembleTask(project: Project, variant: ApplicationVariant): Task {
+        return try {
+            variant.assembleProvider.get()
+        } catch (ignored: Exception) {
+            project.logger.error("[sentry] .assembleProvider failed with: ${ignored.message}")
+            variant.assemble
+        }
+    }
+
+    private fun Project.findTask(vararg taskName: String): Task? =
+        taskName.mapNotNull { project.tasks.findByName(it) }.firstOrNull()
+
+    private val String.capitalized: String get() = this.capitalize()
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -1,0 +1,164 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.AppExtension
+import io.sentry.android.gradle.SentryTasksProvider.getAssembleTask
+import io.sentry.android.gradle.SentryTasksProvider.getBundleTask
+import io.sentry.android.gradle.SentryTasksProvider.getDexTask
+import io.sentry.android.gradle.SentryTasksProvider.getPackageTask
+import io.sentry.android.gradle.SentryTasksProvider.getPreBundleTask
+import io.sentry.android.gradle.SentryTasksProvider.getTransformerTask
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SentryTaskProviderTest {
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    @Test
+    fun `getTransformerTask returns null for missing task`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertNull(getTransformerTask(project, "debug"))
+    }
+
+    @Test
+    fun `getTransformerTask returns transform for R8`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("transformClassesAndResourcesWithR8ForDebug")
+
+        assertEquals(task.get(), getTransformerTask(project, "debug"))
+    }
+
+    @Test
+    fun `getTransformerTask returns transform for Proguard`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("transformClassesAndResourcesWithProguardForDebug")
+
+        assertEquals(task.get(), getTransformerTask(project, "debug"))
+    }
+
+    @Test
+    fun `getTransformerTask returns minify for R8`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("minifyDebugWithR8")
+
+        assertEquals(task.get(), getTransformerTask(project, "debug"))
+    }
+
+    @Test
+    fun `getTransformerTask returns minify for Proguard`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("minifyDebugWithProguard")
+
+        assertEquals(task.get(), getTransformerTask(project, "debug"))
+    }
+
+    @Test
+    fun `getDexTask returns null for missing task`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertNull(getDexTask(project, "debug"))
+    }
+
+    @Test
+    fun `getDexTask returns transform with Dex`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("transformClassesWithDexForDebug")
+
+        assertEquals(task.get(), getDexTask(project, "debug"))
+    }
+
+    @Test
+    fun `getDexTask returns transform with Dex builder`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("transformClassesWithDexBuilderForDebug")
+
+        assertEquals(task.get(), getDexTask(project, "debug"))
+    }
+
+    @Test
+    fun `getDexTask returns transform with Dex shrinker`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("transformClassesAndDexWithShrinkResForDebug")
+
+        assertEquals(task.get(), getDexTask(project, "debug"))
+    }
+
+    @Test
+    fun `getPreBundleTask returns null for missing task`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertNull(getPreBundleTask(project, "debug"))
+    }
+
+    @Test
+    fun `getPreBundleTask returns correct task`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("buildDebugPreBundle")
+
+        assertEquals(task.get(), getPreBundleTask(project, "debug"))
+    }
+
+    @Test
+    fun `getBundleTask returns null for missing task`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertNull(getBundleTask(project, "debug"))
+    }
+
+    @Test
+    fun `getBundleTask returns correct task`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("bundleDebug")
+
+        assertEquals(task.get(), getBundleTask(project, "debug"))
+    }
+
+    @Test
+    fun `getPackageTask returns null for missing task`() {
+        val project = ProjectBuilder.builder().build()
+
+        assertNull(getPackageTask(project, "debug"))
+    }
+
+    @Test
+    fun `getPackageTask returns plain package task`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("packageDebug")
+
+        assertEquals(task.get(), getPackageTask(project, "debug"))
+    }
+
+    @Test
+    fun `getPackageTask returns package bundle task`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("packageDebugBundle")
+
+        assertEquals(task.get(), getPackageTask(project, "debug"))
+    }
+
+    @Test
+    fun `getAssembleTask works correctly for all the variants`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+        }
+
+        // This forces the project to be evaluated
+        project.getTasksByName("assembleDebug", false)
+
+        android.applicationVariants.all {
+            if (it.name == "debug") {
+                assertEquals("assembleDebug", getAssembleTask(project, it).name)
+            } else {
+                assertEquals("assembleRelease", getAssembleTask(project, it).name)
+            }
+        }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -7,6 +7,8 @@ import io.sentry.android.gradle.SentryTasksProvider.getDexTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageTask
 import io.sentry.android.gradle.SentryTasksProvider.getPreBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getTransformerTask
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -28,34 +30,30 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getTransformerTask returns transform for R8`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("transformClassesAndResourcesWithR8ForDebug")
+        val (project, task) = getTestProjectWithTask("transformClassesAndResourcesWithR8ForDebug")
 
-        assertEquals(task.get(), getTransformerTask(project, "debug"))
+        assertEquals(task, getTransformerTask(project, "debug"))
     }
 
     @Test
     fun `getTransformerTask returns transform for Proguard`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("transformClassesAndResourcesWithProguardForDebug")
+        val (project, task) = getTestProjectWithTask("transformClassesAndResourcesWithProguardForDebug")
 
-        assertEquals(task.get(), getTransformerTask(project, "debug"))
+        assertEquals(task, getTransformerTask(project, "debug"))
     }
 
     @Test
     fun `getTransformerTask returns minify for R8`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("minifyDebugWithR8")
+        val (project, task) = getTestProjectWithTask("minifyDebugWithR8")
 
-        assertEquals(task.get(), getTransformerTask(project, "debug"))
+        assertEquals(task, getTransformerTask(project, "debug"))
     }
 
     @Test
     fun `getTransformerTask returns minify for Proguard`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("minifyDebugWithProguard")
+        val (project, task) = getTestProjectWithTask("minifyDebugWithProguard")
 
-        assertEquals(task.get(), getTransformerTask(project, "debug"))
+        assertEquals(task, getTransformerTask(project, "debug"))
     }
 
     @Test
@@ -67,26 +65,23 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getDexTask returns transform with Dex`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("transformClassesWithDexForDebug")
+        val (project, task) = getTestProjectWithTask("transformClassesWithDexForDebug")
 
-        assertEquals(task.get(), getDexTask(project, "debug"))
+        assertEquals(task, getDexTask(project, "debug"))
     }
 
     @Test
     fun `getDexTask returns transform with Dex builder`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("transformClassesWithDexBuilderForDebug")
+        val (project, task) = getTestProjectWithTask("transformClassesWithDexBuilderForDebug")
 
-        assertEquals(task.get(), getDexTask(project, "debug"))
+        assertEquals(task, getDexTask(project, "debug"))
     }
 
     @Test
     fun `getDexTask returns transform with Dex shrinker`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("transformClassesAndDexWithShrinkResForDebug")
+        val (project, task) = getTestProjectWithTask("transformClassesAndDexWithShrinkResForDebug")
 
-        assertEquals(task.get(), getDexTask(project, "debug"))
+        assertEquals(task, getDexTask(project, "debug"))
     }
 
     @Test
@@ -98,10 +93,9 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getPreBundleTask returns correct task`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("buildDebugPreBundle")
+        val (project, task) = getTestProjectWithTask("buildDebugPreBundle")
 
-        assertEquals(task.get(), getPreBundleTask(project, "debug"))
+        assertEquals(task, getPreBundleTask(project, "debug"))
     }
 
     @Test
@@ -113,10 +107,9 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getBundleTask returns correct task`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("bundleDebug")
+        val (project, task) = getTestProjectWithTask("bundleDebug")
 
-        assertEquals(task.get(), getBundleTask(project, "debug"))
+        assertEquals(task, getBundleTask(project, "debug"))
     }
 
     @Test
@@ -128,18 +121,16 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getPackageTask returns plain package task`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("packageDebug")
+        val (project, task) = getTestProjectWithTask("packageDebug")
 
-        assertEquals(task.get(), getPackageTask(project, "debug"))
+        assertEquals(task, getPackageTask(project, "debug"))
     }
 
     @Test
     fun `getPackageTask returns package bundle task`() {
-        val project = ProjectBuilder.builder().build()
-        val task = project.tasks.register("packageDebugBundle")
+        val (project, task) = getTestProjectWithTask("packageDebugBundle")
 
-        assertEquals(task.get(), getPackageTask(project, "debug"))
+        assertEquals(task, getPackageTask(project, "debug"))
     }
 
     @Test
@@ -160,5 +151,10 @@ class SentryTaskProviderTest {
                 assertEquals("assembleRelease", getAssembleTask(project, it).name)
             }
         }
+    }
+
+    private fun getTestProjectWithTask(taskName: String) : Pair<Project, Task> {
+        val project = ProjectBuilder.builder().build()
+        return project to project.tasks.register(taskName).get()
     }
 }


### PR DESCRIPTION
Moved all the task providers to a separate file and added test coverage for them.
Plus I've updated all the parameters from `ApplicationVariant` to `String` so become trivial to test.