### PR TITLE
Remove Explicit KtLint version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,6 @@ subprojects {
 
     ktlint {
         debug.set(false)
-        version.set(Versions.KTLINT)
         verbose.set(true)
         android.set(true)
         outputToConsole.set(true)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,3 @@ object BuildPluginsVersion {
     const val KOTLIN = "1.4.21"
     const val KTLINT = "10.0.0"
 }
-
-object Versions {
-    const val KTLINT = "0.40.0"
-}

--- a/plugin-build/build.gradle
+++ b/plugin-build/build.gradle
@@ -64,7 +64,6 @@ subprojects {
 
     ktlint {
         debug = false
-        version = "0.40.0"
         verbose = true
         android = true
         outputToConsole = true

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -153,7 +153,7 @@ class SentryTaskProviderTest {
         }
     }
 
-    private fun getTestProjectWithTask(taskName: String) : Pair<Project, Task> {
+    private fun getTestProjectWithTask(taskName: String): Pair<Project, Task> {
         val project = ProjectBuilder.builder().build()
         return project to project.tasks.register(taskName).get()
     }


### PR DESCRIPTION
I'm removing the explicit KtLint version declaration so that `ktlint-gradle` will pick the preferred one. Also there was a failure on the branch on `SentryTaskProviderTest.kt`, this PR is addressing it.