### PR TITLE
Export MappingFileProvider

### DIFF
--- a/plugin-build/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/plugin-build/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -28,7 +28,7 @@ class SentryPlugin implements Plugin<Project> {
             project.android.applicationVariants.all { ApplicationVariant variant ->
                 variant.outputs.each { variantOutput ->
 
-                    def mappingFile = getMappingFile(variant, project)
+                    def mappingFile = SentryMappingFileProvider.getMappingFile(project, variant)
                     def transformerTask = SentryTasksProvider.getTransformerTask(project, variant.name)
 
                     def dexTask = SentryTasksProvider.getDexTask(project, variant.name)
@@ -260,27 +260,5 @@ class SentryPlugin implements Plugin<Project> {
         }
 
         return propsFile
-    }
-
-    /**
-     * Returns the mapping file
-     * @param variant the ApplicationVariant
-     * @return the file or null if not found
-     */
-    static File getMappingFile(ApplicationVariant variant, Project project) {
-        try {
-            def files = variant.getMappingFileProvider().get().files
-            if (files.isEmpty()) {
-                project.logger.debug("mappingFileProvider.files is empty for ${variant.name}")
-                return null
-            }
-            project.logger.info("mapping files size: ${files.size()} for ${variant.name}")
-            def file = files.iterator().next()
-            project.logger.info("mapping file: ${file.path} for ${variant.name}")
-            return file
-        } catch (Exception ignored) {
-            project.logger.error("getMappingFile(): ${ignored.getMessage()}")
-            return variant.getMappingFile()
-        }
     }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
@@ -1,0 +1,30 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.api.ApplicationVariant
+import org.gradle.api.Project
+import java.io.File
+
+internal object SentryMappingFileProvider {
+
+    /**
+     * Returns the obfuscation mapping file (might be null if the obfuscation is disabled).
+     *
+     * @return the mapping file or null if not found
+     */
+    @JvmStatic
+    fun getMappingFile(project: Project, variant: ApplicationVariant): File? =
+        try {
+            val mappingFiles = variant.mappingFileProvider.get().files
+            if (mappingFiles.isEmpty()) {
+                project.logger.warn("[sentry] .mappingFileProvider.files is empty for ${variant.name}")
+                null
+            } else {
+                project.logger.info("[sentry] Mapping File ${mappingFiles.first()} for ${variant.name}")
+                mappingFiles.first()
+            }
+        } catch (ignored: Throwable) {
+            project.logger.error("[sentry] .mappingFileProvider failed with: ${ignored.message}")
+            ignored.printStackTrace()
+            variant.mappingFile
+        }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
@@ -24,7 +24,6 @@ internal object SentryMappingFileProvider {
             }
         } catch (ignored: Throwable) {
             project.logger.error("[sentry] .mappingFileProvider failed with: ${ignored.message}")
-            ignored.printStackTrace()
             variant.mappingFile
         }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -44,7 +44,6 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
         computeCommandLineArgs().let {
             commandLine(it)
             logger.info("cli args: $it")
-            System.err.println("cli args: $it")
         }
         setSentryPropertiesEnv()
         super.exec()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -5,6 +5,8 @@ import io.sentry.android.gradle.SentryCliProvider.getSentryPropertiesPath
 import io.sentry.android.gradle.SentryCliProvider.loadCliFromResourcesToTemp
 import io.sentry.android.gradle.SentryCliProvider.searchCliInPropertiesFile
 import io.sentry.android.gradle.SentryCliProvider.searchCliInResources
+import io.sentry.android.gradle.utils.SystemPropertyRule
+import io.sentry.android.gradle.utils.WithSystemProperty
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -19,6 +21,9 @@ class SentryCliProviderTest {
 
     @get:Rule
     val testProjectDir = TemporaryFolder()
+
+    @get:Rule
+    val systemPropertyRule = SystemPropertyRule()
 
     @Test
     fun `getSentryPropertiesPath returns local properties file`() {
@@ -127,7 +132,7 @@ class SentryCliProviderTest {
 
         val foundPath = searchCliInResources(resourcePath)
         assertNotNull(foundPath)
-        assertTrue(foundPath.endsWith("/dummy-bin/dummy-sentry-cli"))
+        assertTrue(foundPath.endsWith("${File.separator}dummy-bin${File.separator}dummy-sentry-cli"))
 
         resourceFile?.delete()
     }
@@ -167,39 +172,32 @@ class SentryCliProviderTest {
     }
 
     @Test
+    @WithSystemProperty(["os.name"], ["mac"])
     fun `getCliSuffix on mac returns Darwin`() {
-        System.setProperty("os.name", "mac")
-
         assertEquals("Darwin-x86_64", getCliSuffix())
     }
 
     @Test
+    @WithSystemProperty(["os.name", "os.arch"], ["linux", "amd64"])
     fun `getCliSuffix on linux amd64 returns Linux-x86_64`() {
-        System.setProperty("os.name", "linux")
-        System.setProperty("os.arch", "amd64")
-
         assertEquals("Linux-x86_64", getCliSuffix())
     }
 
     @Test
+    @WithSystemProperty(["os.name", "os.arch"], ["linux", "armV7"])
     fun `getCliSuffix on linux armV7 returns Linux-armV7`() {
-        System.setProperty("os.name", "linux")
-        System.setProperty("os.arch", "armV7")
-
         assertEquals("Linux-armV7", getCliSuffix())
     }
 
     @Test
+    @WithSystemProperty(["os.name"], ["windows"])
     fun `getCliSuffix on win returns Windows-i686`() {
-        System.setProperty("os.name", "windows")
-
         assertEquals("Windows-i686.exe", getCliSuffix())
     }
 
     @Test
+    @WithSystemProperty(["os.name"], ["¯\\_(ツ)_/¯"])
     fun `getCliSuffix on an unknown platform returns null`() {
-        System.setProperty("os.name", "¯\\_(ツ)_/¯")
-
         assertNull(getCliSuffix())
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryMappingFileProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryMappingFileProviderTest.kt
@@ -4,10 +4,13 @@ import com.android.build.gradle.AppExtension
 import io.sentry.android.gradle.SentryMappingFileProvider.getMappingFile
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
+import java.io.File
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryMappingFileProviderTest {
+
+    private val sep = File.separator
 
     @Test
     fun `getMappingFile works correctly when minify enabled`() {
@@ -26,10 +29,10 @@ class SentryMappingFileProviderTest {
         project.getTasksByName("assembleDebug", false)
 
         val debugVariant = android.applicationVariants.first { it.name == "debug" }
-        assertTrue { getMappingFile(project, debugVariant)!!.endsWith("build/outputs/mapping/debug/mapping.txt") }
+        assertTrue { getMappingFile(project, debugVariant)!!.endsWith("build${sep}outputs${sep}mapping${sep}debug${sep}mapping.txt") }
 
         val releaseVariant = android.applicationVariants.first { it.name == "release" }
-        assertTrue { getMappingFile(project, releaseVariant)!!.endsWith("build/outputs/mapping/release/mapping.txt") }
+        assertTrue { getMappingFile(project, releaseVariant)!!.endsWith("build${sep}outputs${sep}mapping${sep}release${sep}mapping.txt") }
     }
 
     @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryMappingFileProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryMappingFileProviderTest.kt
@@ -1,0 +1,52 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.AppExtension
+import io.sentry.android.gradle.SentryMappingFileProvider.getMappingFile
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SentryMappingFileProviderTest {
+
+    @Test
+    fun `getMappingFile works correctly when minify enabled`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            buildTypes {
+                it.all { buildType ->
+                    buildType.setMinifyEnabled(true)
+                }
+            }
+        }
+
+        // This forces the project to be evaluated
+        project.getTasksByName("assembleDebug", false)
+
+        val debugVariant = android.applicationVariants.first { it.name == "debug" }
+        assertTrue { getMappingFile(project, debugVariant)!!.endsWith("build/outputs/mapping/debug/mapping.txt") }
+
+        val releaseVariant = android.applicationVariants.first { it.name == "release" }
+        assertTrue { getMappingFile(project, releaseVariant)!!.endsWith("build/outputs/mapping/release/mapping.txt") }
+    }
+
+    @Test
+    fun `getMappingFile returns null when minify disabled`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+        }
+
+        // This forces the project to be evaluated
+        project.getTasksByName("assembleDebug", false)
+
+        val debugVariant = android.applicationVariants.first { it.name == "debug" }
+        assertNull(getMappingFile(project, debugVariant))
+
+        val releaseVariant = android.applicationVariants.first { it.name == "release" }
+        assertNull(getMappingFile(project, releaseVariant))
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/utils/SystemPropertyRule.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/utils/SystemPropertyRule.kt
@@ -1,0 +1,39 @@
+package io.sentry.android.gradle.utils
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * A JUnit [TestRule] to override values of [System.getProperties] with the support of the
+ * [WithSystemProperty] annotation.
+ */
+class SystemPropertyRule : TestRule {
+
+    private val retain = mutableMapOf<String, String?>()
+
+    override fun apply(statement: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                val annotation = description
+                    .annotations
+                    .filterIsInstance<WithSystemProperty>()
+                    .firstOrNull()
+
+                annotation?.keys?.forEachIndexed { index, key ->
+                    System.getProperty(key).let { oldProperty ->
+                        retain[key] = oldProperty
+                    }
+                    System.setProperty(key, annotation.values[index])
+                }
+                try {
+                    statement.evaluate()
+                } finally {
+                    retain.forEach { (key, value) ->
+                        System.setProperty(key, value)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/utils/WithSystemProperty.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/utils/WithSystemProperty.kt
@@ -1,0 +1,11 @@
+package io.sentry.android.gradle.utils
+
+/**
+ * Annotation to specify arrays of key-values to override
+ * [System.getProperties] with [SystemPropertyRule]
+ */
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WithSystemProperty(
+    val keys: Array<String>,
+    val values: Array<String>
+)


### PR DESCRIPTION
This PR converts the `getMappingFile` to Kotlin + adds tests for it.

Moreover, I had to introduce the `SystemPropertyRule`. The reason is that changing properties with `System.setProperty` was causing property values to be retained, hence adding flakiness to tests.

Here a green CI run: https://github.com/cortinico/sentry-android-gradle-plugin/runs/2331188077