### PR TITLE
Export PropertiesFileProvider

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPropertiesFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPropertiesFileProvider.kt
@@ -1,0 +1,53 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.api.ApplicationVariant
+import org.gradle.api.Project
+import java.io.File
+
+internal object SentryPropertiesFileProvider {
+
+    private const val FILENAME = "sentry.properties"
+
+    /**
+     * Find sentry.properties and returns the path to the file.
+     * @param project the given project
+     * @param variant the given variant
+     * @return A [String] for the path if sentry.properties is found or null otherwise
+     */
+    @JvmStatic
+    fun getPropertiesFilePath(project: Project, variant: ApplicationVariant): String? {
+        val flavorName = variant.flavorName
+        val buildTypeName = variant.buildType.name
+
+        val projDir = project.projectDir
+        val rootDir = project.rootDir
+
+        // Local Project dirs
+        val possibleFiles = mutableListOf(
+            "$projDir/src/$buildTypeName/$FILENAME"
+        )
+        if (flavorName.isNotBlank()) {
+            possibleFiles.add("$projDir/src/$buildTypeName/$flavorName/$FILENAME")
+            possibleFiles.add("$projDir/src/$flavorName/$buildTypeName/$FILENAME")
+            possibleFiles.add("$projDir/src/$flavorName/$FILENAME")
+        }
+        possibleFiles.add("$projDir/$FILENAME")
+
+        // Other flavors dirs
+        possibleFiles.addAll(variant.productFlavors.map { "$projDir/src/${it.name}/$FILENAME" })
+
+        // Root project dirs
+        possibleFiles.add("$rootDir/src/$buildTypeName/$FILENAME")
+        if (flavorName.isNotBlank()) {
+            possibleFiles.add("$rootDir/src/$flavorName/$FILENAME")
+            possibleFiles.add("$rootDir/src/$buildTypeName/$flavorName/$FILENAME")
+            possibleFiles.add("$rootDir/src/$flavorName/$buildTypeName/$FILENAME")
+        }
+        possibleFiles.add("$rootDir/$FILENAME")
+
+        return possibleFiles.distinct().asSequence()
+            .onEach { project.logger.info("[sentry] Looking for $FILENAME at: $it") }
+            .firstOrNull { File(it).exists() }
+            ?.also { project.logger.info("[sentry] Found $FILENAME at: $it") }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPropertiesFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPropertiesFileProvider.kt
@@ -22,28 +22,30 @@ internal object SentryPropertiesFileProvider {
         val projDir = project.projectDir
         val rootDir = project.rootDir
 
+        val sep = File.separator
+
         // Local Project dirs
         val possibleFiles = mutableListOf(
-            "$projDir/src/$buildTypeName/$FILENAME"
+            "${projDir}${sep}src${sep}${buildTypeName}${sep}$FILENAME"
         )
         if (flavorName.isNotBlank()) {
-            possibleFiles.add("$projDir/src/$buildTypeName/$flavorName/$FILENAME")
-            possibleFiles.add("$projDir/src/$flavorName/$buildTypeName/$FILENAME")
-            possibleFiles.add("$projDir/src/$flavorName/$FILENAME")
+            possibleFiles.add("${projDir}${sep}src${sep}${buildTypeName}${sep}$flavorName${sep}$FILENAME")
+            possibleFiles.add("${projDir}${sep}src${sep}${flavorName}${sep}${buildTypeName}${sep}$FILENAME")
+            possibleFiles.add("${projDir}${sep}src${sep}${flavorName}${sep}$FILENAME")
         }
-        possibleFiles.add("$projDir/$FILENAME")
+        possibleFiles.add("${projDir}${sep}$FILENAME")
 
         // Other flavors dirs
-        possibleFiles.addAll(variant.productFlavors.map { "$projDir/src/${it.name}/$FILENAME" })
+        possibleFiles.addAll(variant.productFlavors.map { "${projDir}${sep}src${sep}${it.name}${sep}$FILENAME" })
 
         // Root project dirs
-        possibleFiles.add("$rootDir/src/$buildTypeName/$FILENAME")
+        possibleFiles.add("${rootDir}${sep}src${sep}${buildTypeName}${sep}$FILENAME")
         if (flavorName.isNotBlank()) {
-            possibleFiles.add("$rootDir/src/$flavorName/$FILENAME")
-            possibleFiles.add("$rootDir/src/$buildTypeName/$flavorName/$FILENAME")
-            possibleFiles.add("$rootDir/src/$flavorName/$buildTypeName/$FILENAME")
+            possibleFiles.add("${rootDir}${sep}src${sep}${flavorName}${sep}$FILENAME")
+            possibleFiles.add("${rootDir}${sep}src${sep}${buildTypeName}${sep}${flavorName}${sep}$FILENAME")
+            possibleFiles.add("${rootDir}${sep}src${sep}${flavorName}${sep}${buildTypeName}${sep}$FILENAME")
         }
-        possibleFiles.add("$rootDir/$FILENAME")
+        possibleFiles.add("${rootDir}${sep}$FILENAME")
 
         return possibleFiles.distinct().asSequence()
             .onEach { project.logger.info("[sentry] Looking for $FILENAME at: $it") }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPropertiesFileProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPropertiesFileProviderTest.kt
@@ -1,0 +1,239 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.AppExtension
+import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+class SentryPropertiesFileProviderTest {
+
+    private val sep = File.separator
+
+    @Test
+    fun `getPropertiesFilePath finds file inside debug folder`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "src/debug/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "debug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside project folder`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "sentry.properties")
+
+        val variant = android.applicationVariants.first()
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside flavorName folder`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version")
+            productFlavors.create("lite")
+            productFlavors.create("full")
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "src/lite/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteDebug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside flavorName-buildType folder`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version")
+            productFlavors.create("lite")
+            productFlavors.create("full")
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "src/lite/debug/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteDebug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside buildType-flavorName folder`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version")
+            productFlavors.create("lite")
+            productFlavors.create("full")
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "src/debug/lite/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteDebug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath with multiple flavorDimensions finds file inside flavor folder`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version", "api")
+            productFlavors.create("lite") {
+                it.dimension("version")
+            }
+            productFlavors.create("api30") {
+                it.dimension("api")
+            }
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "src/liteApi30/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteApi30Debug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside other productFlavor folders`() {
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version", "api")
+            productFlavors.create("lite") {
+                it.dimension("version")
+            }
+            productFlavors.create("api30") {
+                it.dimension("api")
+            }
+        }
+        project.evaluate()
+        createTestFile(project.projectDir, "src/api30/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteApi30Debug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside root project folder`() {
+        val rootProject = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(rootProject).build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+        }
+        project.evaluate()
+        createTestFile(rootProject.projectDir, "sentry.properties")
+
+        val variant = android.applicationVariants.first()
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside root buildType folder`() {
+        val rootProject = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(rootProject).build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+        }
+        project.evaluate()
+        createTestFile(rootProject.projectDir, "src/debug/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "debug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside root flavor folder`() {
+        val rootProject = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(rootProject).build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version")
+            productFlavors.create("lite")
+        }
+        project.evaluate()
+        createTestFile(rootProject.projectDir, "src/lite/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteDebug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside root flavor buildType folder`() {
+        val rootProject = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(rootProject).build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version")
+            productFlavors.create("lite")
+        }
+        project.evaluate()
+        createTestFile(rootProject.projectDir, "src/lite/debug/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteDebug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    @Test
+    fun `getPropertiesFilePath finds file inside root buildType flavor folder`() {
+        val rootProject = ProjectBuilder.builder().build()
+        val project = ProjectBuilder.builder().withParent(rootProject).build()
+        project.plugins.apply("com.android.application")
+        val android = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            flavorDimensions("version")
+            productFlavors.create("lite")
+        }
+        project.evaluate()
+        createTestFile(rootProject.projectDir, "src/debug/lite/sentry.properties")
+
+        val variant = android.applicationVariants.first { it.name == "liteDebug" }
+
+        assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
+    }
+
+    private fun Project.evaluate() {
+        project.getTasksByName("assembleDebug", false)
+    }
+
+    private fun createTestFile(parent: File, path: String) =
+        File(parent, path).apply {
+            parentFile.mkdirs()
+            createNewFile()
+            writeText("42")
+        }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPropertiesFileProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPropertiesFileProviderTest.kt
@@ -14,13 +14,8 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath finds file inside debug folder`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
-        }
-        project.evaluate()
-        createTestFile(project.projectDir, "src/debug/sentry.properties")
+        val (project, android) = createTestAndroidProject()
+        createTestFile(project.projectDir, "src${sep}debug${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "debug" }
 
@@ -29,12 +24,7 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath finds file inside project folder`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
-        }
-        project.evaluate()
+        val (project, android) = createTestAndroidProject()
         createTestFile(project.projectDir, "sentry.properties")
 
         val variant = android.applicationVariants.first()
@@ -44,16 +34,12 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath finds file inside flavorName folder`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject {
             flavorDimensions("version")
             productFlavors.create("lite")
             productFlavors.create("full")
         }
-        project.evaluate()
-        createTestFile(project.projectDir, "src/lite/sentry.properties")
+        createTestFile(project.projectDir, "src${sep}lite${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteDebug" }
 
@@ -62,16 +48,12 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath finds file inside flavorName-buildType folder`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject {
             flavorDimensions("version")
             productFlavors.create("lite")
             productFlavors.create("full")
         }
-        project.evaluate()
-        createTestFile(project.projectDir, "src/lite/debug/sentry.properties")
+        createTestFile(project.projectDir, "src${sep}lite${sep}debug${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteDebug" }
 
@@ -80,16 +62,12 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath finds file inside buildType-flavorName folder`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject {
             flavorDimensions("version")
             productFlavors.create("lite")
             productFlavors.create("full")
         }
-        project.evaluate()
-        createTestFile(project.projectDir, "src/debug/lite/sentry.properties")
+        createTestFile(project.projectDir, "src${sep}debug${sep}lite${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteDebug" }
 
@@ -98,10 +76,7 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath with multiple flavorDimensions finds file inside flavor folder`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject {
             flavorDimensions("version", "api")
             productFlavors.create("lite") {
                 it.dimension("version")
@@ -110,8 +85,7 @@ class SentryPropertiesFileProviderTest {
                 it.dimension("api")
             }
         }
-        project.evaluate()
-        createTestFile(project.projectDir, "src/liteApi30/sentry.properties")
+        createTestFile(project.projectDir, "src${sep}liteApi30${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteApi30Debug" }
 
@@ -120,10 +94,7 @@ class SentryPropertiesFileProviderTest {
 
     @Test
     fun `getPropertiesFilePath finds file inside other productFlavor folders`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject {
             flavorDimensions("version", "api")
             productFlavors.create("lite") {
                 it.dimension("version")
@@ -132,8 +103,7 @@ class SentryPropertiesFileProviderTest {
                 it.dimension("api")
             }
         }
-        project.evaluate()
-        createTestFile(project.projectDir, "src/api30/sentry.properties")
+        createTestFile(project.projectDir, "src${sep}api30${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteApi30Debug" }
 
@@ -143,12 +113,7 @@ class SentryPropertiesFileProviderTest {
     @Test
     fun `getPropertiesFilePath finds file inside root project folder`() {
         val rootProject = ProjectBuilder.builder().build()
-        val project = ProjectBuilder.builder().withParent(rootProject).build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
-        }
-        project.evaluate()
+        val (project, android) = createTestAndroidProject(parent = rootProject)
         createTestFile(rootProject.projectDir, "sentry.properties")
 
         val variant = android.applicationVariants.first()
@@ -159,13 +124,8 @@ class SentryPropertiesFileProviderTest {
     @Test
     fun `getPropertiesFilePath finds file inside root buildType folder`() {
         val rootProject = ProjectBuilder.builder().build()
-        val project = ProjectBuilder.builder().withParent(rootProject).build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
-        }
-        project.evaluate()
-        createTestFile(rootProject.projectDir, "src/debug/sentry.properties")
+        val (project, android) = createTestAndroidProject(parent = rootProject)
+        createTestFile(rootProject.projectDir, "src${sep}debug${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "debug" }
 
@@ -175,15 +135,11 @@ class SentryPropertiesFileProviderTest {
     @Test
     fun `getPropertiesFilePath finds file inside root flavor folder`() {
         val rootProject = ProjectBuilder.builder().build()
-        val project = ProjectBuilder.builder().withParent(rootProject).build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject(parent = rootProject) {
             flavorDimensions("version")
             productFlavors.create("lite")
         }
-        project.evaluate()
-        createTestFile(rootProject.projectDir, "src/lite/sentry.properties")
+        createTestFile(rootProject.projectDir, "src${sep}lite${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteDebug" }
 
@@ -193,15 +149,11 @@ class SentryPropertiesFileProviderTest {
     @Test
     fun `getPropertiesFilePath finds file inside root flavor buildType folder`() {
         val rootProject = ProjectBuilder.builder().build()
-        val project = ProjectBuilder.builder().withParent(rootProject).build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject(parent = rootProject) {
             flavorDimensions("version")
             productFlavors.create("lite")
         }
-        project.evaluate()
-        createTestFile(rootProject.projectDir, "src/lite/debug/sentry.properties")
+        createTestFile(rootProject.projectDir, "src${sep}lite${sep}debug${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteDebug" }
 
@@ -211,23 +163,33 @@ class SentryPropertiesFileProviderTest {
     @Test
     fun `getPropertiesFilePath finds file inside root buildType flavor folder`() {
         val rootProject = ProjectBuilder.builder().build()
-        val project = ProjectBuilder.builder().withParent(rootProject).build()
-        project.plugins.apply("com.android.application")
-        val android = project.extensions.getByType(AppExtension::class.java).apply {
-            compileSdkVersion(30)
+        val (project, android) = createTestAndroidProject(parent = rootProject) {
             flavorDimensions("version")
             productFlavors.create("lite")
         }
-        project.evaluate()
-        createTestFile(rootProject.projectDir, "src/debug/lite/sentry.properties")
+        createTestFile(rootProject.projectDir, "src${sep}debug${sep}lite${sep}sentry.properties")
 
         val variant = android.applicationVariants.first { it.name == "liteDebug" }
 
         assertEquals("42", File(getPropertiesFilePath(project, variant)!!).readText())
     }
 
-    private fun Project.evaluate() {
+    private fun createTestAndroidProject(
+        parent: Project? = null,
+        block: AppExtension.() -> Unit = {}
+    ): Pair<Project, AppExtension> {
+        val project = ProjectBuilder
+            .builder()
+            .apply { parent?.let { withParent(parent) } }
+            .build()
+        project.plugins.apply("com.android.application")
+        val appExtension = project.extensions.getByType(AppExtension::class.java).apply {
+            compileSdkVersion(30)
+            this.block()
+        }
+        // This will force the project to be evaluated
         project.getTasksByName("assembleDebug", false)
+        return project to appExtension
     }
 
     private fun createTestFile(parent: File, path: String) =


### PR DESCRIPTION
Converting another section of the plugin to Kotlin 🎉 
Some of the paths used for search of the properties file are debatable (specifically those on the root projects). I can't seem to figure out why someone would place the property there. @marandaneto do you have some context?

The rest of the PR is mostly tests.