### PR TITLE
Drop support for AGP 3.x

### DIFF
--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -20,18 +20,6 @@ jobs:
         experimental: [false]
         name: ["stable"]
         include:
-          - agp: "3.4.3"
-            gradle: "6.1.1"
-            experimental: false
-            name: AGP-3.4.3
-          - agp: "3.5.4"
-            gradle: "6.1.1"
-            experimental: false
-            name: AGP-3.5.4
-          - agp: "3.6.4"
-            gradle: "6.1.1"
-            experimental: false
-            name: AGP-3.6.4
           - agp: "4.0.0"
             gradle: "6.1.1"
             experimental: false

--- a/plugin-build/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/plugin-build/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -190,7 +190,7 @@ class SentryPlugin implements Plugin<Project> {
                     }
 
                     // find the assemble task
-                    def assembleTask = SentryTasksProvider.getAssembleTask(project, variant)
+                    def assembleTask = SentryTasksProvider.getAssembleTask(variant)
                     if (assembleTask != null) {
                         project.logger.info("assembleTask ${assembleTask.path}")
                     } else {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
@@ -23,7 +23,7 @@ internal object SentryMappingFileProvider {
                 mappingFiles.first()
             }
         } catch (ignored: Throwable) {
-            project.logger.error("[sentry] .mappingFileProvider failed with: ${ignored.message}")
-            variant.mappingFile
+            project.logger.error("[sentry] .mappingFileProvider is missing for $variant - Error: ${ignored.message}")
+            null
         }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -72,14 +72,8 @@ internal object SentryTasksProvider {
      * @return the task if found or null otherwise
      */
     @JvmStatic
-    fun getAssembleTask(project: Project, variant: ApplicationVariant): Task {
-        return try {
-            variant.assembleProvider.get()
-        } catch (ignored: Exception) {
-            project.logger.error("[sentry] .assembleProvider failed with: ${ignored.message}")
-            variant.assemble
-        }
-    }
+    fun getAssembleTask(variant: ApplicationVariant): Task =
+        variant.assembleProvider.get()
 
     private fun Project.findTask(vararg taskName: String): Task? =
         taskName.mapNotNull { project.tasks.findByName(it) }.firstOrNull()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -135,9 +135,6 @@ class SentryPluginTest(
             // The supported Gradle version can be found here:
             // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
             // The pair is [AGP Version, Gradle Version]
-            arrayOf("3.4.3", "6.1.1"),
-            arrayOf("3.5.4", "6.1.1"),
-            arrayOf("3.6.4", "6.1.1"),
             arrayOf("4.0.0", "6.1.1"),
             arrayOf("4.1.2", "6.5"),
             arrayOf("4.1.2", "6.8.1"),

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -146,9 +146,9 @@ class SentryTaskProviderTest {
 
         android.applicationVariants.all {
             if (it.name == "debug") {
-                assertEquals("assembleDebug", getAssembleTask(project, it).name)
+                assertEquals("assembleDebug", getAssembleTask(it).name)
             } else {
-                assertEquals("assembleRelease", getAssembleTask(project, it).name)
+                assertEquals("assembleRelease", getAssembleTask(it).name)
             }
         }
     }


### PR DESCRIPTION
This PR removes all the code that is needed to support AGP 3.x
There is a bit more to cleanup inside the Plugin code, but those will be addressed once the plugin class is converted to Kotlin