### PR TITLE
Export UploadNativeSymbols to its own task

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -1,0 +1,92 @@
+package io.sentry.android.gradle.tasks
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import java.io.File
+
+abstract class SentryUploadNativeSymbolsTask : Exec() {
+
+    init {
+        description = "Uploads native symbols to Sentry"
+    }
+
+    @get:Input
+    abstract val cliExecutable: Property<String>
+
+    @get:InputFile
+    @get:Optional
+    abstract val sentryProperties: RegularFileProperty
+
+    @get:Input
+    @get:Optional
+    abstract val sentryOrganization: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val sentryProject: Property<String>
+
+    @get:Input
+    abstract val includeNativeSources: Property<Boolean>
+
+    @get:Internal
+    abstract val variantName: Property<String>
+
+    override fun exec() {
+        computeCommandLineArgs().let {
+            commandLine(it)
+            logger.info("cli args: $it")
+        }
+        setSentryPropertiesEnv()
+        super.exec()
+    }
+
+    internal fun setSentryPropertiesEnv() {
+        val sentryProperties = sentryProperties.orNull
+        if (sentryProperties != null) {
+            environment("SENTRY_PROPERTIES", sentryProperties)
+        } else {
+            logger.info("[sentry] sentryProperties is null")
+        }
+    }
+
+    internal fun computeCommandLineArgs(): List<String> {
+        val args = mutableListOf(
+            cliExecutable.get(),
+            "upload-dif",
+        )
+
+        sentryOrganization.orNull?.let {
+            args.add("--org")
+            args.add(it)
+        }
+
+        sentryProject.orNull?.let {
+            args.add("--project")
+            args.add(it)
+        }
+
+        val sep = File.separator
+
+        // eg absoluteProjectFolderPath/build/intermediates/merged_native_libs/{variantName}
+        // where {variantName} could be debug/release...
+        args.add("${project.projectDir}${sep}build${sep}intermediates${sep}merged_native_libs${sep}${variantName.get()}")
+
+        // Only include sources if includeNativeSources is enabled, as this is opt-in feature
+        if (includeNativeSources.get()) {
+            args.add("--include-sources")
+        }
+
+        if (Os.isFamily(FAMILY_WINDOWS)) {
+            args.add(0, "cmd")
+            args.add(1, "/c")
+        }
+        return args
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
@@ -1,7 +1,6 @@
 package io.sentry.android.gradle.tasks
 
 import org.gradle.api.Project
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 import java.io.File
@@ -15,14 +14,13 @@ class SentryUploadNativeSymbolsTaskTest {
     @Test
     fun `cli-executable is set correctly`() {
         val project = createProject()
-        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
-            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
-                it.cliExecutable.set("sentry-cli")
-                it.includeNativeSources.set(false)
-                it.variantName.set("debug")
-            }
+        val task = createTestTask(project) {
+            it.cliExecutable.set("sentry-cli")
+            it.includeNativeSources.set(false)
+            it.variantName.set("debug")
+        }
 
-        val args = task.get().computeCommandLineArgs()
+        val args = task.computeCommandLineArgs()
         val sep = File.separator
 
         assertTrue("sentry-cli" in args)
@@ -34,14 +32,13 @@ class SentryUploadNativeSymbolsTaskTest {
     @Test
     fun `--include-sources is set correctly`() {
         val project = createProject()
-        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
-            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
-                it.cliExecutable.set("sentry-cli")
-                it.includeNativeSources.set(true)
-                it.variantName.set("debug")
-            }
+        val task = createTestTask(project) {
+            it.cliExecutable.set("sentry-cli")
+            it.includeNativeSources.set(true)
+            it.variantName.set("debug")
+        }
 
-        val args = task.get().computeCommandLineArgs()
+        val args = task.computeCommandLineArgs()
 
         assertTrue("--include-sources" in args)
     }
@@ -50,39 +47,36 @@ class SentryUploadNativeSymbolsTaskTest {
     fun `with sentryProperties file SENTRY_PROPERTIES is set correctly`() {
         val project = createProject()
         val propertiesFile = project.file("dummy/folder/sentry.properties")
-        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
-            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
-                it.sentryProperties.set(propertiesFile)
-            }
+        val task = createTestTask(project) {
+            it.sentryProperties.set(propertiesFile)
+        }
 
-        task.get().setSentryPropertiesEnv()
+        task.setSentryPropertiesEnv()
 
-        assertEquals(propertiesFile.absolutePath, task.get().environment["SENTRY_PROPERTIES"].toString())
+        assertEquals(propertiesFile.absolutePath, task.environment["SENTRY_PROPERTIES"].toString())
     }
 
     @Test
     fun `without sentryProperties file SENTRY_PROPERTIES is not set`() {
         val project = createProject()
-        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
-            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java)
+        val task = createTestTask(project)
 
-        task.get().setSentryPropertiesEnv()
+        task.setSentryPropertiesEnv()
 
-        assertNull(task.get().environment["SENTRY_PROPERTIES"])
+        assertNull(task.environment["SENTRY_PROPERTIES"])
     }
 
     @Test
     fun `with sentryOrganization adds --org`() {
         val project = createProject()
-        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
-            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
-                it.cliExecutable.set("sentry-cli")
-                it.sentryOrganization.set("dummy-org")
-                it.includeNativeSources.set(true)
-                it.variantName.set("debug")
-            }
+        val task = createTestTask(project) {
+            it.cliExecutable.set("sentry-cli")
+            it.sentryOrganization.set("dummy-org")
+            it.includeNativeSources.set(true)
+            it.variantName.set("debug")
+        }
 
-        val args = task.get().computeCommandLineArgs()
+        val args = task.computeCommandLineArgs()
 
         assertTrue("--org" in args)
         assertTrue("dummy-org" in args)
@@ -91,15 +85,14 @@ class SentryUploadNativeSymbolsTaskTest {
     @Test
     fun `with sentryProject adds --project`() {
         val project = createProject()
-        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
-            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
-                it.cliExecutable.set("sentry-cli")
-                it.sentryProject.set("dummy-proj")
-                it.includeNativeSources.set(true)
-                it.variantName.set("debug")
-            }
+        val task = createTestTask(project) {
+            it.cliExecutable.set("sentry-cli")
+            it.sentryProject.set("dummy-proj")
+            it.includeNativeSources.set(true)
+            it.variantName.set("debug")
+        }
 
-        val args = task.get().computeCommandLineArgs()
+        val args = task.computeCommandLineArgs()
 
         assertTrue("--project" in args)
         assertTrue("dummy-proj" in args)
@@ -111,4 +104,12 @@ class SentryUploadNativeSymbolsTaskTest {
             return this
         }
     }
+
+    private fun createTestTask(
+        project: Project,
+        block: (SentryUploadNativeSymbolsTask) -> Unit = {}
+    ): SentryUploadNativeSymbolsTask =
+        project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
+            block(it)
+        }.get()
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
@@ -1,0 +1,114 @@
+package io.sentry.android.gradle.tasks
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SentryUploadNativeSymbolsTaskTest {
+
+    @Test
+    fun `cli-executable is set correctly`() {
+        val project = createProject()
+        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
+            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
+                it.cliExecutable.set("sentry-cli")
+                it.includeNativeSources.set(false)
+                it.variantName.set("debug")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+        val sep = File.separator
+
+        assertTrue("sentry-cli" in args)
+        assertTrue("upload-dif" in args)
+        assertTrue("${project.projectDir}${sep}build${sep}intermediates${sep}merged_native_libs${sep}debug" in args)
+        assertFalse("--include-sources" in args)
+    }
+
+    @Test
+    fun `--include-sources is set correctly`() {
+        val project = createProject()
+        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
+            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
+                it.cliExecutable.set("sentry-cli")
+                it.includeNativeSources.set(true)
+                it.variantName.set("debug")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+
+        assertTrue("--include-sources" in args)
+    }
+
+    @Test
+    fun `with sentryProperties file SENTRY_PROPERTIES is set correctly`() {
+        val project = createProject()
+        val propertiesFile = project.file("dummy/folder/sentry.properties")
+        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
+            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
+                it.sentryProperties.set(propertiesFile)
+            }
+
+        task.get().setSentryPropertiesEnv()
+
+        assertEquals(propertiesFile.absolutePath, task.get().environment["SENTRY_PROPERTIES"].toString())
+    }
+
+    @Test
+    fun `without sentryProperties file SENTRY_PROPERTIES is not set`() {
+        val project = createProject()
+        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
+            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java)
+
+        task.get().setSentryPropertiesEnv()
+
+        assertNull(task.get().environment["SENTRY_PROPERTIES"])
+    }
+
+    @Test
+    fun `with sentryOrganization adds --org`() {
+        val project = createProject()
+        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
+            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
+                it.cliExecutable.set("sentry-cli")
+                it.sentryOrganization.set("dummy-org")
+                it.includeNativeSources.set(true)
+                it.variantName.set("debug")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+
+        assertTrue("--org" in args)
+        assertTrue("dummy-org" in args)
+    }
+
+    @Test
+    fun `with sentryProject adds --project`() {
+        val project = createProject()
+        val task: TaskProvider<SentryUploadNativeSymbolsTask> =
+            project.tasks.register("testUploadNativeSymbols", SentryUploadNativeSymbolsTask::class.java) {
+                it.cliExecutable.set("sentry-cli")
+                it.sentryProject.set("dummy-proj")
+                it.includeNativeSources.set(true)
+                it.variantName.set("debug")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+
+        assertTrue("--project" in args)
+        assertTrue("dummy-proj" in args)
+    }
+
+    private fun createProject(): Project {
+        with(ProjectBuilder.builder().build()) {
+            plugins.apply("io.sentry.android.gradle")
+            return this
+        }
+    }
+}


### PR DESCRIPTION
The `uploadNativeSymbols` task had his task-action inlined in the plugin apply function. I'm exporting it to a proper Task class and rewriting it in Kotlin here.