### PR TITLE
Setup publishing to Maven Central

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -2,6 +2,7 @@ object BuildPluginsVersion {
     val AGP = System.getenv("VERSION_AGP") ?: "4.1.3"
     const val KOTLIN = "1.4.32"
     const val KTLINT = "10.0.0"
+    const val NEXUS = "1.1.0"
 }
 
 object LibsVersion {

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     kotlin("jvm") version BuildPluginsVersion.KOTLIN
     id("java-gradle-plugin")
     id("maven-publish")
+    id("signing")
+    id("io.github.gradle-nexus.publish-plugin") version BuildPluginsVersion.NEXUS
     id("org.jlleitschuh.gradle.ktlint") version BuildPluginsVersion.KTLINT
 }
 
@@ -58,6 +60,20 @@ ktlint {
     }
 }
 
+nexusPublishing {
+    repositories {
+        // Maven Central (Sonatype) login info go to:
+        // ~/.gradle/gradle.properties
+        //
+        // mavenCentralRepositoryUsername=user name
+        // mavenCentralRepositoryPassword=password
+        sonatype {
+            username.set(findProperty("mavenCentralRepositoryUsername") as? String)
+            password.set(findProperty("mavenCentralRepositoryPassword") as? String)
+        }
+    }
+}
+
 /* ktlint-disable max-line-length */
 publishing {
     publications {
@@ -96,6 +112,21 @@ publishing {
                 }
             }
         }
+    }
+
+    if (!version.toString().endsWith("-SNAPSHOT")) {
+        signing {
+            useGpgCmd()
+            publishing.publications.all {
+                sign(this)
+            }
+        }
+        // signing info and maven central info go to:
+        // ~/.gradle/gradle.properties
+        //
+        // signing.keyId=id
+        // signing.password=password
+        // signing.secretKeyRingFile=file path
     }
 }
 /* ktlint-enable max-line-length */


### PR DESCRIPTION
This sets up the publishing to Sonatype using the `gradle-nexus.publish-plugin` plugin.