### PR TITLE
Fix: Only wire upload mapping task if minifyEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # 2.0.0-alpha.1
 
 * Feat: Gradle plugin v2 (#50) @cortinico
-* Allow module level sentry properties file (#33) @MatthewTPage
+* Enhancement: Allow module level sentry properties file (#33) @MatthewTPage
+* Fix: Only wire upload mapping task if minifyEnabled (#86) @cerisier
 
 # 1.x
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -127,7 +127,6 @@ class SentryPlugin : Plugin<Project> {
                         it.sentryProject.set(sentryProjectParameter)
                     }
 
-
                     if (variant.buildType.isMinifyEnabled) {
                         // and run before dex transformation. If we managed to find the dex task
                         // we set ourselves as dependency, otherwise we just hack ourselves into


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes #82.

We only wire the upload mapping task if variant buildType has
minifyEnabled to true, which basically hints that proguard
rules will run.

Note that I got rid of `variant.register` since I believe we do not need it as we already wire the task manually. Happy to leave it there if needed.
Note that we still create the task eagerly for now, which is to be tackled in another PR.

## :bulb: Motivation and Context
This follows a discussion with @marandaneto about #82

## :green_heart: How did you test it?
Published locally and ensured green build in debug variant where minifyEnabled is false.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
