### PR TITLE
Skip publish workflow on PRs from forks

### DIFF
--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish:
-    if: ${{ github.repository == 'getsentry/sentry-android-gradle-plugin'}}
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## :scroll: Description
The `test-publish` workflow should run only on PRs from local branches or on merges. It should not run on PRs from external forks as the secrets are not exposed hence it will fail.

## :bulb: Motivation and Context
It will fix the CI failure of PR #93 