### PR TITLE
Add AGP 7.x to the CI Matrix

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -29,6 +29,12 @@ jobs:
           restore-keys: |
             cache-gradle-
 
+      - name: Setup Java Version
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
       - name: Run Gradle tasks
         run: ./gradlew preMerge --continue
 

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -16,32 +16,28 @@ jobs:
       matrix:
         agp: ["4.1.0"]
         gradle: ["6.8.3"]
-        experimental: [false]
-        name: ["stable"]
+        java: ["8"]
         include:
           - agp: "4.0.0"
             gradle: "6.1.1"
-            experimental: false
-            name: AGP-4.0.0
+            java: "8"
           - agp: "4.1.3"
             gradle: "6.5"
-            experimental: false
-            name: AGP-4.1.3
+            java: "8"
           - agp: "4.1.3"
             gradle: "6.8.3"
-            experimental: false
-            name: AGP-4.1.3-Gradle-6.8.3
+            java: "8"
           - agp: "4.1.3"
             gradle: "7.0"
-            experimental: false
-            name: AGP-4.1.3-Gradle-7.0
+            java: "8"
           - agp: "4.2.0-rc01"
             gradle: "6.8.3"
-            experimental: false
-            name: AGP-4.2.x-Gradle-6.8.3
+            java: "8"
+          - agp: "7.0.0-alpha15"
+            gradle: "7.0"
+            java: "11"
 
-    continue-on-error: ${{ matrix.experimental }}
-    name: Publish Dry Run - ${{ matrix.name }} - Experimental ${{ matrix.experimental }}
+    name: Publish Dry Run - AGP ${{ matrix.agp }} - Gradle ${{ matrix.gradle }}
     env:
       VERSION_AGP: ${{ matrix.agp }}
       VERSION_GRADLE: ${{ matrix.gradle }}
@@ -59,6 +55,12 @@ jobs:
           restore-keys: |
             cache-gradle-${{ matrix.gradle }}-
             cache-gradle-
+
+      - name: Setup Java Version
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
 
       - name: Set Gradle Version
         run: ./gradlew wrapper --gradle-version $VERSION_GRADLE --distribution-type=all

--- a/examples/android-gradle-kts/build.gradle.kts
+++ b/examples/android-gradle-kts/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         getByName("release") {
-            setMinifyEnabled(true)
+            minifyEnabled(true)
             proguardFiles.add(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }

--- a/examples/android-gradle-kts/build.gradle.kts
+++ b/examples/android-gradle-kts/build.gradle.kts
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         getByName("release") {
-            minifyEnabled(true)
+            isMinifyEnabled = true
             proguardFiles.add(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
     }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -139,6 +139,7 @@ class SentryPluginTest(
             arrayOf("4.1.3", "6.8.1"),
             arrayOf("4.1.3", "7.0"),
             arrayOf("4.2.0-rc01", "6.8.1"),
+            arrayOf("7.0.0-alpha15", "7.0"),
         )
 
         private fun GradleRunner.appendArguments(vararg arguments: String) =


### PR DESCRIPTION
## :scroll: Description
Adding an entry for AGP `7.x` to both the CI and the test matrix.
I've also cleaned up the matrix a bit, removing `experimental` (I was planning to use it for AGP 7.x but turns out is green already) and the `name` parameter. I've added the `java` parameter to properly configure the Java version.

## :bulb: Motivation and Context
Fixes #89 

## :green_heart: How did you test it?
Tests are green locally (as long as you run them on Java 11+).

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes