### PR TITLE
Add support for hashing the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Bump: sentry-cli to 1.64.1
-* Add support for hashing sentry-cli to trigger a re-download upon bumps
+* Add support for hashing sentry-cli to trigger a re-download upon bumps (#110)
 
 # 2.0.0-alpha.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Bump: sentry-cli to 1.64.1
+* Add support for hashing sentry-cli to trigger a re-download upon bumps
 
 # 2.0.0-alpha.3
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,15 +15,15 @@ if(shouldDownloadSentryCli()) {
 }
 
 /**
- * When bumping the Sentry CLI, you should update the `expected-checksums.md5` file inside `buildSrc`
- * to match the `checksums.md5` file from `./plugin-build/src/main/resources/bin/`
+ * When bumping the Sentry CLI, you should update the `expected-checksums.sha` file inside `buildSrc`
+ * to match the `checksums.sha` file from `./plugin-build/src/main/resources/bin/`
  *
  * That's to retrigger a download of the cli upon a bump.
  */
 fun shouldDownloadSentryCli() : Boolean {
     val cliDir: Array<File> = File("./plugin-build/src/main/resources/bin/").listFiles() ?: emptyArray()
-    val expectedChecksums = File("./buildSrc/expected-checksums.md5")
-    val actualChecksums = File("./plugin-build/src/main/resources/bin/checksums.md5")
+    val expectedChecksums = File("./buildSrc/expected-checksums.sha")
+    val actualChecksums = File("./plugin-build/src/main/resources/bin/checksums.sha")
     return when {
         cliDir.size <= 2 -> {
             logger.lifecycle("Sentry CLI is missing")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,12 +5,38 @@ repositories {
     jcenter()
 }
 
-val cliDir: Array<File> = File("./plugin-build/src/main/resources/bin/").listFiles() ?: emptyArray()
-if(cliDir.size == 1 && cliDir[0].name == ".gitignore") {
-    logger.lifecycle("Sentry CLI is Missing - Downloading it...")
+if(shouldDownloadSentryCli()) {
+    logger.lifecycle("Downloading Sentry CLI...")
     exec {
         executable("sh")
         workingDir("../plugin-build")
         args("-c", "./download-sentry-cli.sh")
+    }
+}
+
+/**
+ * When bumping the Sentry CLI, you should update the `expected-checksums.md5` file inside `buildSrc`
+ * to match the `checksums.md5` file from `./plugin-build/src/main/resources/bin/`
+ *
+ * That's to retrigger a download of the cli upon a bump.
+ */
+fun shouldDownloadSentryCli() : Boolean {
+    val cliDir: Array<File> = File("./plugin-build/src/main/resources/bin/").listFiles() ?: emptyArray()
+    val expectedChecksums = File("./buildSrc/expected-checksums.md5")
+    val actualChecksums = File("./plugin-build/src/main/resources/bin/checksums.md5")
+    return when {
+        cliDir.size <= 2 -> {
+            logger.lifecycle("Sentry CLI is missing")
+            true
+        }
+        !actualChecksums.exists() -> {
+            logger.lifecycle("Sentry CLI Checksums is missing")
+            true
+        }
+        expectedChecksums.readText() != actualChecksums.readText() -> {
+            logger.lifecycle("Sentry CLI Checksums doesn't match")
+            true
+        }
+        else -> false
     }
 }

--- a/buildSrc/expected-checksums.md5
+++ b/buildSrc/expected-checksums.md5
@@ -1,0 +1,4 @@
+961fbbf6986d52eeabace13c04d258ee  src/main/resources/bin/sentry-cli-Darwin-x86_64
+1ad03e10bd6c909479b4d5297ec46fc2  src/main/resources/bin/sentry-cli-Linux-i686
+bdee4670afef094c7624b22a6943c053  src/main/resources/bin/sentry-cli-Linux-x86_64
+913fbb4c1cb5fe91d57b0c4b34218fa1  src/main/resources/bin/sentry-cli-Windows-i686.exe

--- a/buildSrc/expected-checksums.md5
+++ b/buildSrc/expected-checksums.md5
@@ -1,4 +1,0 @@
-961fbbf6986d52eeabace13c04d258ee  src/main/resources/bin/sentry-cli-Darwin-x86_64
-1ad03e10bd6c909479b4d5297ec46fc2  src/main/resources/bin/sentry-cli-Linux-i686
-bdee4670afef094c7624b22a6943c053  src/main/resources/bin/sentry-cli-Linux-x86_64
-913fbb4c1cb5fe91d57b0c4b34218fa1  src/main/resources/bin/sentry-cli-Windows-i686.exe

--- a/buildSrc/expected-checksums.sha
+++ b/buildSrc/expected-checksums.sha
@@ -1,0 +1,4 @@
+e2f725f0181e8a87f653646f1b8749083a28427a  src/main/resources/bin/sentry-cli-Darwin-x86_64
+88ae9c5cbfdfd680ec27f9aa7f9d9ea049c75dba  src/main/resources/bin/sentry-cli-Linux-i686
+6d078fc28be3613c39ecba6e09278150337c2de8  src/main/resources/bin/sentry-cli-Linux-x86_64
+adac360a40cc9643f36ee3759cb05dfa0716170e  src/main/resources/bin/sentry-cli-Windows-i686.exe

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -15,5 +15,5 @@ for plat in $PLATFORMS; do
   fn="src/main/resources/bin/sentry-cli-${plat}${suffix}"
   curl -SL --progress-bar "$download_url" -o "$fn"
   chmod +x "$fn"
-  md5sum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.md5
+  md5sum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.md5 || md5 src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.md5
 done

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -15,4 +15,5 @@ for plat in $PLATFORMS; do
   fn="src/main/resources/bin/sentry-cli-${plat}${suffix}"
   curl -SL --progress-bar "$download_url" -o "$fn"
   chmod +x "$fn"
+  md5sum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.md5
 done

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -15,5 +15,5 @@ for plat in $PLATFORMS; do
   fn="src/main/resources/bin/sentry-cli-${plat}${suffix}"
   curl -SL --progress-bar "$download_url" -o "$fn"
   chmod +x "$fn"
-  md5sum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.md5 || md5 src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.md5
+  shasum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.sha
 done

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -15,5 +15,5 @@ for plat in $PLATFORMS; do
   fn="src/main/resources/bin/sentry-cli-${plat}${suffix}"
   curl -SL --progress-bar "$download_url" -o "$fn"
   chmod +x "$fn"
-  shasum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.sha
+  sha1sum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.sha || shasum src/main/resources/bin/sentry-cli-* > src/main/resources/bin/checksums.sha
 done

--- a/plugin-build/src/main/resources/bin/.gitignore
+++ b/plugin-build/src/main/resources/bin/.gitignore
@@ -1,1 +1,2 @@
 sentry-cli-*
+checksums.md5

--- a/plugin-build/src/main/resources/bin/.gitignore
+++ b/plugin-build/src/main/resources/bin/.gitignore
@@ -1,2 +1,2 @@
 sentry-cli-*
-checksums.md5
+checksums.sha


### PR DESCRIPTION
## :scroll: Description
Fixes #103 

## :bulb: Motivation and Context
I've extended the condition to decide when to download the sentry CLI with a check upon the local MD5 hash. I believe that's simple enough to protect against stale version of the CLI.

## :green_heart: How did you test it?
Tested locally, works fine so far.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps

I've added a comment on the `shouldDownloadSentryCli` function to remind to update the `expected-checksums.md5` file once the CLI gets bumped. Not a major deal but the CLI will be re-downloaded every time otherwise.