### PR TITLE
Silence the missing mapping file warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Silence the warning for missing mapping file on variants that don't enable minification 
 * Bump: sentry-cli to 1.64.1
 
 # 2.0.0-alpha.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Silence the warning for missing mapping file on variants that don't enable minification 
+* Silence the warning for missing mapping file on variants that don't enable minification (#111)
 * Bump: sentry-cli to 1.64.1
 
 # 2.0.0-alpha.3

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
@@ -14,21 +14,25 @@ internal object SentryMappingFileProvider {
     @JvmStatic
     fun getMappingFile(project: Project, variant: ApplicationVariant): File? =
         try {
-            val mappingFiles = variant.mappingFileProvider.get().files
-            if (mappingFiles.isEmpty()) {
-                project.logger.warn(
-                    "[sentry] .mappingFileProvider.files is empty for ${variant.name}"
+            if (!variant.mappingFileProvider.isPresent) {
+                project.logger.info(
+                    "[sentry] .mappingFileProvider is missing for $variant"
                 )
                 null
             } else {
-                project.logger.info(
+                val mappingFiles = variant.mappingFileProvider.get().files
+                val logMessage = if (mappingFiles.isEmpty()) {
+                    "[sentry] .mappingFileProvider.files is empty for ${variant.name}"
+                } else {
                     "[sentry] Mapping File ${mappingFiles.first()} for ${variant.name}"
-                )
-                mappingFiles.first()
+                }
+                project.logger.info(logMessage)
+                mappingFiles.firstOrNull()
             }
         } catch (ignored: Throwable) {
-            project.logger.error(
-                "[sentry] .mappingFileProvider is missing for $variant - Error: ${ignored.message}"
+            project.logger.info(
+                "[sentry] .mappingFileProvider is missing for $variant - Error: ${ignored.message}",
+                ignored
             )
             null
         }


### PR DESCRIPTION
## :scroll: Description
Fixes #29

## :bulb: Motivation and Context
Change the Mapping File Provider to use `isPresent` from the Provider API.
I've also lowered the logging to `info` from `warning`.  

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes