### PR TITLE
Support Configuration Avoidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Support Configuration Avoidance (#112)
 * Silence the warning for missing mapping file on variants that don't enable minification (#111)
 * Bump: sentry-cli to 1.64.1
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -36,83 +36,117 @@ class SentryPlugin : Plugin<Project> {
 
             val androidExtension = project.extensions.getByType(AppExtension::class.java)
 
+            fun withLogging(varName: String, initializer: () -> Task?) =
+                initializer().also {
+                    project.logger.info("[sentry] $varName is ${it?.path}")
+                }
+
+            val cliExecutable = getSentryCliPath(project)
+
+            val extraProperties = project.extensions.getByName("ext")
+                as ExtraPropertiesExtension
+
+            val sentryOrgParameter = runCatching {
+                extraProperties.get(SENTRY_ORG_PARAMETER).toString()
+            }.getOrNull()
+            val sentryProjectParameter = runCatching {
+                extraProperties.get(SENTRY_PROJECT_PARAMETER).toString()
+            }.getOrNull()
+
             androidExtension.applicationVariants.all { variant ->
-                variant.outputs.all { variantOutput ->
-                    val taskSuffix = variant.name.capitalize(Locale.ROOT) +
-                        variantOutput.name.capitalize(Locale.ROOT)
 
-                    fun withLogging(varName: String, initializer: () -> Task?) =
-                        initializer().also {
-                            project.logger.info("[sentry] $varName is ${it?.path}")
-                        }
+                val varNameCapitalize = variant.name.capitalize(Locale.ROOT)
 
-                    val dexTask = withLogging("dexTask") { getDexTask(project, variant.name) }
-                    val preBundleTask = withLogging("preBundleTask") {
+                val bundleTask = withLogging("bundleTask") {
+                    getBundleTask(project, variant.name)
+                }
+
+                val assembleTask = withLogging("assembleTask") { getAssembleTask(variant) }
+
+                val sentryProperties = getPropertiesFilePath(project, variant)
+
+                val isMinifyEnabled = variant.buildType.isMinifyEnabled
+
+                var dexTask: Task? = null
+                var preBundleTask: Task? = null
+                var transformerTask: Task? = null
+                var packageTask: Task? = null
+                var mappingFile: File? = null
+                val sep = File.separator
+
+                if (isMinifyEnabled) {
+                    dexTask = withLogging("dexTask") { getDexTask(project, variant.name) }
+                    preBundleTask = withLogging("preBundleTask") {
                         getPreBundleTask(project, variant.name)
                     }
-                    val bundleTask = withLogging("bundleTask") {
-                        getBundleTask(project, variant.name)
-                    }
-                    val transformerTask = withLogging("transformerTask") {
+                    transformerTask = withLogging("transformerTask") {
                         getTransformerTask(project, variant.name)
                     }
-                    val packageTask = withLogging("packageTask") {
+                    packageTask = withLogging("packageTask") {
                         getPackageTask(project, variant.name)
                     }
-                    val assembleTask = withLogging("assembleTask") { getAssembleTask(variant) }
+                    mappingFile = getMappingFile(project, variant)
+                } else {
+                    project.logger.info("[sentry] isMinifyEnabled is disabled.")
+                }
 
-                    val sentryProperties = getPropertiesFilePath(project, variant)
+                variant.outputs.all { variantOutput ->
+                    val taskSuffix = varNameCapitalize + variantOutput.name.capitalize(Locale.ROOT)
 
-                    val extraProperties = project.extensions.getByName("ext")
-                        as ExtraPropertiesExtension
-
-                    val sentryOrgParameter = runCatching {
-                        extraProperties.get(SENTRY_ORG_PARAMETER).toString()
-                    }.getOrNull()
-                    val sentryProjectParameter = runCatching {
-                        extraProperties.get(SENTRY_PROJECT_PARAMETER).toString()
-                    }.getOrNull()
-
-                    val mappingFile = getMappingFile(project, variant)
-                    val cliExecutable = getSentryCliPath(project)
-                    val sep = File.separator
-
-                    // Setup the task to generate a UUID asset file
-                    val generateUuidTask = project.tasks.create(
-                        "generateSentryProguardUuid$taskSuffix",
-                        SentryGenerateProguardUuidTask::class.java
-                    ) {
-                        it.outputDirectory.set(
-                            project.file(
-                                "build${sep}generated${sep}assets${sep}sentry${sep}${variant.name}"
+                    if (isMinifyEnabled) {
+                        // Setup the task to generate a UUID asset file
+                        val generateUuidTask = project.tasks.register(
+                            "generateSentryProguardUuid$taskSuffix",
+                            SentryGenerateProguardUuidTask::class.java
+                        ) {
+                            it.outputDirectory.set(
+                                project.file(
+                                    "build${sep}generated${sep}assets${sep}sentry" +
+                                        "${sep}${variant.name}"
+                                )
                             )
-                        )
-                    }
-                    variant.mergeAssetsProvider.configure { it.dependsOn(generateUuidTask) }
+                        }
+                        variant.mergeAssetsProvider.configure { it.dependsOn(generateUuidTask) }
 
-                    // Setup the task that uploads the proguard mapping and UUIDs
-                    val uploadSentryProguardMappingsTask = project.tasks.create(
-                        "uploadSentryProguardMappings$taskSuffix",
-                        SentryUploadProguardMappingsTask::class.java
-                    ) {
-                        it.dependsOn(generateUuidTask)
-                        it.workingDir(project.rootDir)
-                        it.cliExecutable.set(cliExecutable)
-                        it.sentryProperties.set(
-                            sentryProperties?.let { file -> project.file(file) }
+                        // Setup the task that uploads the proguard mapping and UUIDs
+                        val uploadSentryProguardMappingsTask = project.tasks.register(
+                            "uploadSentryProguardMappings$taskSuffix",
+                            SentryUploadProguardMappingsTask::class.java
+                        ) {
+                            it.dependsOn(generateUuidTask)
+                            it.workingDir(project.rootDir)
+                            it.cliExecutable.set(cliExecutable)
+                            it.sentryProperties.set(
+                                sentryProperties?.let { file -> project.file(file) }
+                            )
+                            it.mappingsUuid.set(generateUuidTask.get().outputUuid)
+                            mappingFile?.let { mapFile ->
+                                it.mappingsFile.set(mapFile)
+                            }
+                            it.autoUpload.set(extension.autoUpload.get())
+                            it.sentryOrganization.set(sentryOrgParameter)
+                            it.sentryProject.set(sentryProjectParameter)
+                        }
+                        variant.register(uploadSentryProguardMappingsTask.get())
+                        androidExtension.sourceSets.getByName(variant.name).assets.srcDir(
+                            generateUuidTask.get().outputDirectory
                         )
-                        it.mappingsUuid.set(generateUuidTask.outputUuid)
-                        it.mappingsFile.set(mappingFile)
-                        it.autoUpload.set(extension.autoUpload.get())
-                        it.sentryOrganization.set(sentryOrgParameter)
-                        it.sentryProject.set(sentryProjectParameter)
+
+                        // and run before dex transformation. If we managed to find the dex task
+                        // we set ourselves as dependency, otherwise we just hack ourselves into
+                        // the proguard task's doLast.
+                        dexTask?.dependsOn(uploadSentryProguardMappingsTask)
+                        transformerTask?.finalizedBy(uploadSentryProguardMappingsTask)
+
+                        // To include proguard uuid file into aab, run before bundle task.
+                        preBundleTask?.dependsOn(uploadSentryProguardMappingsTask)
+
+                        // The package task will only be executed if the uploadSentryProguardMappingsTask has already been executed.
+                        packageTask?.dependsOn(uploadSentryProguardMappingsTask)
                     }
-                    androidExtension.sourceSets.getByName(variant.name).assets.srcDir(
-                        generateUuidTask.outputDirectory
-                    )
 
                     // Setup the task to upload native symbols task after the assembling task
-                    val uploadNativeSymbolsTask = project.tasks.create(
+                    val uploadNativeSymbolsTask = project.tasks.register(
                         "uploadNativeSymbolsFor$taskSuffix",
                         SentryUploadNativeSymbolsTask::class.java
                     ) {
@@ -125,20 +159,6 @@ class SentryPlugin : Plugin<Project> {
                         it.variantName.set(variant.name)
                         it.sentryOrganization.set(sentryOrgParameter)
                         it.sentryProject.set(sentryProjectParameter)
-                    }
-
-                    if (variant.buildType.isMinifyEnabled) {
-                        // and run before dex transformation. If we managed to find the dex task
-                        // we set ourselves as dependency, otherwise we just hack ourselves into
-                        // the proguard task's doLast.
-                        dexTask?.dependsOn(uploadSentryProguardMappingsTask)
-                        transformerTask?.finalizedBy(uploadSentryProguardMappingsTask)
-
-                        // To include proguard uuid file into aab, run before bundle task.
-                        preBundleTask?.dependsOn(uploadSentryProguardMappingsTask)
-
-                        // The package task will only be executed if the uploadSentryProguardMappingsTask has already been executed.
-                        packageTask?.dependsOn(uploadSentryProguardMappingsTask)
                     }
 
                     // uploadNativeSymbolsTask will only be executed after the assemble task

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt
@@ -4,7 +4,6 @@ import java.util.UUID
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -22,9 +21,6 @@ abstract class SentryGenerateProguardUuidTask : DefaultTask() {
     abstract val outputDirectory: DirectoryProperty
 
     @get:Internal
-    abstract val outputUuid: Property<UUID>
-
-    @get:Internal
     val outputFile: Provider<RegularFile> get() = outputDirectory.file(
         "sentry-debug-meta.properties"
     )
@@ -36,7 +32,6 @@ abstract class SentryGenerateProguardUuidTask : DefaultTask() {
         )
 
         UUID.randomUUID().also {
-            outputUuid.set(it)
             outputFile.get().asFile.parentFile.mkdirs()
             outputFile.get().asFile.writeText("io.sentry.ProguardUuids=$it")
         }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
@@ -1,5 +1,7 @@
 package io.sentry.android.gradle.tasks
 
+import java.io.File
+import java.lang.IllegalStateException
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -8,14 +10,22 @@ import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertThrows
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class SentryUploadProguardMappingTaskTest {
 
+    @get:Rule
+    val tempDir = TemporaryFolder()
+
     @Test
     fun `cli-executable is set correctly`() {
-        val project = createProject()
         val randomUuid = UUID.randomUUID()
+        createFakeUuid(randomUuid)
+
+        val project = createProject()
         val mappingFile = project.file("dummy/folder/mapping.txt")
         val task: TaskProvider<SentryUploadProguardMappingsTask> =
             project.tasks.register(
@@ -23,7 +33,7 @@ class SentryUploadProguardMappingTaskTest {
                 SentryUploadProguardMappingsTask::class.java
             ) {
                 it.cliExecutable.set("sentry-cli")
-                it.mappingsUuid.set(randomUuid)
+                it.uuidDirectory.set(tempDir.root)
                 it.mappingsFile.set(mappingFile)
                 it.autoUpload.set(true)
             }
@@ -40,6 +50,7 @@ class SentryUploadProguardMappingTaskTest {
 
     @Test
     fun `--auto-upload is set correctly`() {
+        createFakeUuid()
         val project = createProject()
         val randomUuid = UUID.randomUUID()
         val mappingFile = project.file("dummy/folder/mapping.txt")
@@ -49,7 +60,7 @@ class SentryUploadProguardMappingTaskTest {
                 SentryUploadProguardMappingsTask::class.java
             ) {
                 it.cliExecutable.set("sentry-cli")
-                it.mappingsUuid.set(randomUuid)
+                it.uuidDirectory.set(tempDir.root)
                 it.mappingsFile.set(mappingFile)
                 it.autoUpload.set(false)
             }
@@ -95,6 +106,7 @@ class SentryUploadProguardMappingTaskTest {
 
     @Test
     fun `with sentryOrganization adds --org`() {
+        createFakeUuid()
         val project = createProject()
         val task: TaskProvider<SentryUploadProguardMappingsTask> =
             project.tasks.register(
@@ -102,7 +114,7 @@ class SentryUploadProguardMappingTaskTest {
                 SentryUploadProguardMappingsTask::class.java
             ) {
                 it.cliExecutable.set("sentry-cli")
-                it.mappingsUuid.set(UUID.randomUUID())
+                it.uuidDirectory.set(tempDir.root)
                 it.mappingsFile.set(project.file("dummy/folder/mapping.txt"))
                 it.autoUpload.set(false)
                 it.sentryOrganization.set("dummy-org")
@@ -116,6 +128,7 @@ class SentryUploadProguardMappingTaskTest {
 
     @Test
     fun `with sentryProject adds --project`() {
+        createFakeUuid()
         val project = createProject()
         val task: TaskProvider<SentryUploadProguardMappingsTask> =
             project.tasks.register(
@@ -123,7 +136,7 @@ class SentryUploadProguardMappingTaskTest {
                 SentryUploadProguardMappingsTask::class.java
             ) {
                 it.cliExecutable.set("sentry-cli")
-                it.mappingsUuid.set(UUID.randomUUID())
+                it.uuidDirectory.set(tempDir.root)
                 it.mappingsFile.set(project.file("dummy/folder/mapping.txt"))
                 it.autoUpload.set(false)
                 it.sentryProject.set("dummy-proj")
@@ -135,10 +148,54 @@ class SentryUploadProguardMappingTaskTest {
         assertTrue("dummy-proj" in args)
     }
 
+    @Test
+    fun `readUuidFromFile works correctly`() {
+        val expected = "8c776014-bb25-11eb-8529-0242ac130003"
+        val input = tempDir.newFile().apply { writeText("io.sentry.ProguardUuids=$expected") }
+        val actual = SentryUploadProguardMappingsTask.readUuidFromFile(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `readUuidFromFile works correctly with whitespaces`() {
+        val expected = "8c776014-bb25-11eb-8529-0242ac130003"
+        val input = tempDir.newFile().apply { writeText(" io.sentry.ProguardUuids=$expected\n") }
+        val actual = SentryUploadProguardMappingsTask.readUuidFromFile(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `readUuidFromFile fails with missing file`() {
+        assertThrows(IllegalStateException::class.java) {
+            SentryUploadProguardMappingsTask.readUuidFromFile(File("missing"))
+        }
+    }
+
+    @Test
+    fun `readUuidFromFile fails with empty file`() {
+        assertThrows(IllegalStateException::class.java) {
+            SentryUploadProguardMappingsTask.readUuidFromFile(tempDir.newFile())
+        }
+    }
+
+    @Test
+    fun `readUuidFromFile fails with missing property`() {
+        assertThrows(IllegalStateException::class.java) {
+            val inputFile = tempDir.newFile().apply { writeText("a.property=true") }
+            SentryUploadProguardMappingsTask.readUuidFromFile(inputFile)
+        }
+    }
+
     private fun createProject(): Project {
         with(ProjectBuilder.builder().build()) {
             plugins.apply("io.sentry.android.gradle")
             return this
         }
+    }
+
+    private fun createFakeUuid(uuid: UUID = UUID.randomUUID()) {
+        tempDir.newFile("sentry-debug-meta.properties").writeText(
+            "io.sentry.ProguardUuids=$uuid"
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Description
I've cherry-picked the commits on #85 + I've applied 2943df5 to make sure we can leverage task configuration avoidance.

I had to remove the `Property<UUID>` as that was forcing the `generateUuidTask` task to be created at configuration time. Now the connection point between the two task is the output asset folder.


## :bulb: Motivation and Context
Closes #85
Fixes #84 

## :green_heart: How did you test it?
JUnit tests are attached.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes
