### PR TITLE
Feat: use Sentry SDK

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     compileOnly(gradleApi())
     compileOnly(Libs.AGP)
+    implementation("io.sentry:sentry:4.3.0")
 
     testImplementation(gradleTestKit())
     testImplementation(kotlin("test"))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryMappingFileProvider.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle
 
 import com.android.build.gradle.api.ApplicationVariant
+import io.sentry.Sentry
 import java.io.File
 import org.gradle.api.Project
 
@@ -29,11 +30,12 @@ internal object SentryMappingFileProvider {
                 project.logger.info(logMessage)
                 mappingFiles.firstOrNull()
             }
-        } catch (ignored: Throwable) {
+        } catch (throwable: Throwable) {
             project.logger.info(
-                "[sentry] .mappingFileProvider is missing for $variant - Error: ${ignored.message}",
-                ignored
+                "[sentry] .mappingFileProvider is missing for $variant - Error: ${throwable.message}",
+                throwable
             )
+            Sentry.captureException(throwable)
             null
         }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle
 
 import com.android.build.gradle.AppExtension
+import io.sentry.Sentry
 import io.sentry.android.gradle.SentryCliProvider.getSentryCliPath
 import io.sentry.android.gradle.SentryMappingFileProvider.getMappingFile
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
@@ -19,9 +20,17 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.util.GradleVersion
 
 class SentryPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        Sentry.init {
+            it.dsn = "https://1053864c67cc410aa1ffc9701bd6f93d@o447951.ingest.sentry.io/5428559"
+            // read release dynamically somehow
+            it.release = "io.sentry.android.gradle@2.0.0-beta.2-SNAPSHOT"
+            it.addInAppInclude("io.sentry.android.gradle")
+        }
+
         val extension = project.extensions.create(
             "sentry",
             SentryPluginExtension::class.java,
@@ -50,6 +59,9 @@ class SentryPlugin : Plugin<Project> {
                 val sentryProperties = getPropertiesFilePath(project, variant)
 
                 val isMinifyEnabled = variant.buildType.isMinifyEnabled
+                Sentry.setTag("isMinifyEnabled", isMinifyEnabled.toString())
+                Sentry.setTag("gradleVersion", GradleVersion.current().version)
+//                Sentry.setTag("agpVersion", how?)
 
                 var dexTask: Task? = null
                 var preBundleTask: Task? = null


### PR DESCRIPTION
## :scroll: Description
Feat: use Sentry SDK in the Plugin
We should offer a way to turn it off though, maybe a boolean flag in the plugin extensions

## :bulb: Motivation and Context
The idea is to have more context when we get issues using the Sentry gradle plugin which heavily depends on some data like AGP, Gradle version, environment etc.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
looks like that the stack traces are always Gradle stuff, need to figure out how to capture our own stack traces, maybe Gradle is always wrapping up but not adding as a cause