### PR TITLE
Make capitalizeUS internal

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -12,8 +12,8 @@ import io.sentry.android.gradle.SentryTasksProvider.getTransformerTask
 import io.sentry.android.gradle.tasks.SentryGenerateProguardUuidTask
 import io.sentry.android.gradle.tasks.SentryUploadNativeSymbolsTask
 import io.sentry.android.gradle.tasks.SentryUploadProguardMappingsTask
+import io.sentry.android.gradle.util.SentryPluginUtils.capitalizeUS
 import io.sentry.android.gradle.util.SentryPluginUtils.withLogging
-import io.sentry.android.gradle.util.capitalizeUS
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -2,7 +2,7 @@ package io.sentry.android.gradle
 
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.tasks.MergeSourceSetFolders
-import io.sentry.android.gradle.util.capitalizeUS
+import io.sentry.android.gradle.util.SentryPluginUtils.capitalizeUS
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
@@ -13,10 +13,10 @@ internal object SentryPluginUtils {
     ) = initializer().also {
         logger.info("[sentry] $varName is ${it?.path}")
     }
-}
 
-fun String.capitalizeUS() = if (isEmpty()) {
-    ""
-} else {
-    substring(0, 1).toUpperCase(Locale.US) + substring(1)
+    fun String.capitalizeUS() = if (isEmpty()) {
+        ""
+    } else {
+        substring(0, 1).toUpperCase(Locale.US) + substring(1)
+    }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryPluginUtilsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryPluginUtilsTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.util
 
+import io.sentry.android.gradle.util.SentryPluginUtils.capitalizeUS
 import kotlin.test.assertEquals
 import org.junit.Test
 
@@ -8,5 +9,15 @@ class SentryPluginUtilsTest {
     @Test
     fun `capitalizes string first letter uppercase`() {
         assertEquals("Kotlin", "kotlin".capitalizeUS())
+    }
+
+    @Test
+    fun `capitalizes string does nothing on already capitalized string`() {
+        assertEquals("Kotlin", "Kotlin".capitalizeUS())
+    }
+
+    @Test
+    fun `capitalizes string returns empty on empty string`() {
+        assertEquals("", "".capitalizeUS())
     }
 }


### PR DESCRIPTION
## :scroll: Description
Moving `capitalizeUS` inside `SentryPluginUtils` so it will become `internal` and won't bleed into the consumer build logic.

## :green_heart: How did you test it?
I've added a couple of tests more.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes

#skip-changelog