### PR TITLE
Enhancement: Clean up deprecated/removed Dex and Transform tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Enhancement: Clean up deprecated/removed Dex and Transform tasks (#)
+* Enhancement: Clean up deprecated/removed Dex and Transform tasks (#130)
 
 # 2.0.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Enhancement: Clean up deprecated/removed Dex and Transform tasks (#)
+
 # 2.0.0-beta.2
 
 * Enhancement: Use pluginManager instead of project.afterEvaluate (#119)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -5,7 +5,6 @@ import io.sentry.android.gradle.SentryCliProvider.getSentryCliPath
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
 import io.sentry.android.gradle.SentryTasksProvider.getAssembleTaskProvider
 import io.sentry.android.gradle.SentryTasksProvider.getBundleTask
-import io.sentry.android.gradle.SentryTasksProvider.getDexTask
 import io.sentry.android.gradle.SentryTasksProvider.getMappingFileProvider
 import io.sentry.android.gradle.SentryTasksProvider.getMergeAssetsProvider
 import io.sentry.android.gradle.SentryTasksProvider.getPackageBundleTask
@@ -54,7 +53,6 @@ class SentryPlugin : Plugin<Project> {
 
                 val isMinifyEnabled = variant.buildType.isMinifyEnabled
 
-                var dexTask: Task? = null
                 var preBundleTask: Task? = null
                 var transformerTask: Task? = null
                 var packageBundleTask: Task? = null
@@ -62,9 +60,6 @@ class SentryPlugin : Plugin<Project> {
                 val sep = File.separator
 
                 if (isMinifyEnabled) {
-                    dexTask = withLogging(project.logger, "dexTask") {
-                        getDexTask(project, variant.name)
-                    }
                     preBundleTask = withLogging(project.logger, "preBundleTask") {
                         getPreBundleTask(project, variant.name)
                     }
@@ -118,10 +113,7 @@ class SentryPlugin : Plugin<Project> {
                         uuidOutputDirectory
                     )
 
-                    // and run before dex transformation. If we managed to find the dex task
-                    // we set ourselves as dependency, otherwise we just hack ourselves into
-                    // the proguard task's doLast.
-                    dexTask?.dependsOn(uploadSentryProguardMappingsTask)
+                    // we just hack ourselves into the proguard task's doLast.
                     transformerTask?.finalizedBy(uploadSentryProguardMappingsTask)
 
                     // To include proguard uuid file into aab, run before bundle task.

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -20,28 +20,10 @@ internal object SentryTasksProvider {
      */
     @JvmStatic
     fun getTransformerTask(project: Project, variantName: String): Task? =
-        // previously accessed via ApkVariant#getDex, no way to access it anymore directly
         project.findTask(
-            // Android Studio 3.3 includes the R8 shrinker.
-            "transformClassesAndResourcesWithR8For${variantName.capitalized}",
-            "transformClassesAndResourcesWithProguardFor${variantName.capitalized}",
+            // AGP 3.3 includes the R8 shrinker.
             "minify${variantName.capitalized}WithR8",
             "minify${variantName.capitalized}WithProguard"
-        )
-
-    /**
-     * Returns the dex task for the given project and variant.
-     *
-     * @return the task or null otherwise
-     */
-    @JvmStatic
-    fun getDexTask(project: Project, variantName: String): Task? =
-        // previously accessed via ApkVariant#getDex, no way to access it anymore directly
-        project.findTask(
-            // Android Studio 3.3 includes the R8 shrinker.
-            "transformClassesWithDexFor${variantName.capitalized}",
-            "transformClassesWithDexBuilderFor${variantName.capitalized}",
-            "transformClassesAndDexWithShrinkResFor${variantName.capitalized}"
         )
 
     /**

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -3,7 +3,6 @@ package io.sentry.android.gradle
 import com.android.build.gradle.AppExtension
 import io.sentry.android.gradle.SentryTasksProvider.getAssembleTaskProvider
 import io.sentry.android.gradle.SentryTasksProvider.getBundleTask
-import io.sentry.android.gradle.SentryTasksProvider.getDexTask
 import io.sentry.android.gradle.SentryTasksProvider.getMergeAssetsProvider
 import io.sentry.android.gradle.SentryTasksProvider.getPackageBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageProvider
@@ -31,22 +30,6 @@ class SentryTaskProviderTest {
     }
 
     @Test
-    fun `getTransformerTask returns transform for R8`() {
-        val (project, task) = getTestProjectWithTask("transformClassesAndResourcesWithR8ForDebug")
-
-        assertEquals(task, getTransformerTask(project, "debug"))
-    }
-
-    @Test
-    fun `getTransformerTask returns transform for Proguard`() {
-        val (project, task) = getTestProjectWithTask(
-            "transformClassesAndResourcesWithProguardForDebug"
-        )
-
-        assertEquals(task, getTransformerTask(project, "debug"))
-    }
-
-    @Test
     fun `getTransformerTask returns minify for R8`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithR8")
 
@@ -58,34 +41,6 @@ class SentryTaskProviderTest {
         val (project, task) = getTestProjectWithTask("minifyDebugWithProguard")
 
         assertEquals(task, getTransformerTask(project, "debug"))
-    }
-
-    @Test
-    fun `getDexTask returns null for missing task`() {
-        val project = ProjectBuilder.builder().build()
-
-        assertNull(getDexTask(project, "debug"))
-    }
-
-    @Test
-    fun `getDexTask returns transform with Dex`() {
-        val (project, task) = getTestProjectWithTask("transformClassesWithDexForDebug")
-
-        assertEquals(task, getDexTask(project, "debug"))
-    }
-
-    @Test
-    fun `getDexTask returns transform with Dex builder`() {
-        val (project, task) = getTestProjectWithTask("transformClassesWithDexBuilderForDebug")
-
-        assertEquals(task, getDexTask(project, "debug"))
-    }
-
-    @Test
-    fun `getDexTask returns transform with Dex shrinker`() {
-        val (project, task) = getTestProjectWithTask("transformClassesAndDexWithShrinkResForDebug")
-
-        assertEquals(task, getDexTask(project, "debug"))
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Enhancement: Clean up deprecated/removed Dex and Transform tasks.

Tasks dont exist anymore using AGP 4.0.0, See Gradle scan
https://scans.gradle.com/s/qxa77lro2mu52/timeline

## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-android-gradle-plugin/issues/124


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
