### PR TITLE
Fix: Only upload debug symbols for non debuggable App

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,6 +16,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Only upload debug symbols for non debuggable App.
+
 # 2.0.0
 
 This release comes with a full rewrite of the Sentry Gradle Plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: Only upload debug symbols for non debuggable App.
+* Fix: Only upload debug symbols for non debuggable App. (#139)
 
 # 2.0.0
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -130,12 +130,12 @@ class SentryPlugin : Plugin<Project> {
                 }
 
                 // only debug symbols of non debuggable code should be uploaded (aka release builds).
-                // uploadNativeSymbolsTask will only be executed after the assemble task
+                // uploadSentryNativeSymbols task will only be executed after the assemble task
                 // and also only if `uploadNativeSymbols` is enabled, as this is an opt-in feature.
                 if (!isDebuggable && extension.uploadNativeSymbols.get()) {
                     // Setup the task to upload native symbols task after the assembling task
-                    val uploadNativeSymbolsTask = project.tasks.register(
-                        "uploadNativeSymbolsFor$taskSuffix",
+                    val uploadSentryNativeSymbolsTask = project.tasks.register(
+                        "uploadSentryNativeSymbolsFor$taskSuffix",
                         SentryUploadNativeSymbolsTask::class.java
                     ) {
                         it.workingDir(project.rootDir)
@@ -151,13 +151,13 @@ class SentryPlugin : Plugin<Project> {
 
                     getAssembleTaskProvider(variant)?.configure {
                         it.finalizedBy(
-                            uploadNativeSymbolsTask
+                            uploadSentryNativeSymbolsTask
                         )
                     }
                     // if its a bundle aab, assemble might not be executed, so we hook into bundle task
-                    bundleTask?.finalizedBy(uploadNativeSymbolsTask)
+                    bundleTask?.finalizedBy(uploadSentryNativeSymbolsTask)
                 } else {
-                    project.logger.info("[sentry] uploadNativeSymbolsTask won't be executed")
+                    project.logger.info("[sentry] uploadSentryNativeSymbols won't be executed")
                 }
             }
         }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -2,8 +2,8 @@ package io.sentry.android.gradle
 
 import java.io.File
 import kotlin.test.assertNotEquals
-// import kotlin.test.assertNotNull
-// import kotlin.test.assertNull
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Before
@@ -127,64 +127,53 @@ class SentryPluginTest(
         verifyProguardUuid(testProjectDir.root)
     }
 
-//    @Test
-//    fun `does not include a UUID in the APK`() {
-//        // isMinifyEnabled is disabled by default in debug builds
-//        runner
-//            .appendArguments(":app:assembleDebug")
-//            .build()
-//
-//        verifyNoProguardUuid(testProjectDir.root)
-//    }
+    @Test
+    fun `does not include a UUID in the APK`() {
+        // isMinifyEnabled is disabled by default in debug builds
+        runner
+            .appendArguments(":app:assembleDebug")
+            .build()
 
-//    @Test
-//    fun `creates uploadNativeSymbolsForRelease task if uploadNativeSymbols is enabled and non debuggable app`() {
-//        applyUploadNativeSymbols()
-//
-//        val build = runner
-//            .appendArguments(":app:assembleRelease")
-//            .build()
-//
-//        assertNotNull(build.task("uploadNativeSymbolsForRelease"))
-//    }
+        verifyNoProguardUuid(testProjectDir.root)
+    }
 
-//    @Test
-//    fun `does not create uploadNativeSymbolsForRelease task if non debuggable app`() {
-//        applyUploadNativeSymbols()
-//
-//        val build = runner
-//            .appendArguments(":app:assembleDebug")
-//            .build()
-//
-//        assertNull(build.task("uploadNativeSymbolsForDebug"))
-//    }
+    @Test
+    fun `creates uploadNativeSymbolsForRelease task if uploadNativeSymbols is enabled`() {
+        applyUploadNativeSymbols()
 
-//    @Test
-//    fun `does not create uploadNativeSymbolsForRelease task if uploadNativeSymbols is disabled`() {
-//        applyUploadNativeSymbols(false)
-//
-//        val build = runner
-//            .appendArguments(":app:assembleRelease")
-//            .build()
-//
-//        assertNull(build.task("uploadNativeSymbolsForRelease"))
-//    }
+        val build = runner
+            .appendArguments(":app:assembleRelease")
+            .build()
 
-//    private fun applyUploadNativeSymbols(uploadNativeSymbols: Boolean = true) {
-//        appBuildFile.writeText(
-//            // language=Groovy
-//            """
-//                plugins {
-//                  id "com.android.application"
-//                  id "io.sentry.android.gradle"
-//                }
-//
-//                sentry {
-//                  uploadNativeSymbols = $uploadNativeSymbols
-//                }
-//            """.trimIndent()
-//        )
-//    }
+        assertNotNull(build.task("uploadNativeSymbolsForRelease"))
+    }
+
+    @Test
+    fun `does not create uploadNativeSymbolsForRelease task if non debuggable app`() {
+        applyUploadNativeSymbols()
+
+        val build = runner
+            .appendArguments(":app:assembleDebug")
+            .build()
+
+        assertNull(build.task("uploadNativeSymbolsForDebug"))
+    }
+
+    private fun applyUploadNativeSymbols() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+                plugins {
+                  id "com.android.application"
+                  id "io.sentry.android.gradle"
+                }
+
+                sentry {
+                  uploadNativeSymbols = true
+                }
+            """.trimIndent()
+        )
+    }
 
     companion object {
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -125,6 +126,18 @@ class SentryPluginTest(
             .build()
 
         verifyProguardUuid(testProjectDir.root)
+    }
+
+    @Test
+    fun `does not include a UUID in the APK`() {
+        // isMinifyEnabled is disabled by default in debug builds
+        runner
+            .appendArguments(":app:assembleDebug")
+            .build()
+
+        Assert.assertThrows(AssertionError::class.java) {
+            verifyProguardUuid(testProjectDir.root, variant = "debug", signed = false)
+        }
     }
 
     @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -128,16 +128,6 @@ class SentryPluginTest(
     }
 
     @Test
-    fun `does not include a UUID in the APK`() {
-        // isMinifyEnabled is disabled by default in debug builds
-        runner
-            .appendArguments(":app:assembleDebug")
-            .build()
-
-        verifyNoProguardUuid(testProjectDir.root)
-    }
-
-    @Test
     fun `creates uploadNativeSymbolsForRelease task if uploadNativeSymbols is enabled`() {
         applyUploadNativeSymbols()
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -159,6 +159,7 @@ class SentryPluginTest(
                 }
 
                 sentry {
+                  autoUpload = false
                   uploadNativeSymbols = true
                 }
             """.trimIndent()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -2,8 +2,8 @@ package io.sentry.android.gradle
 
 import java.io.File
 import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+// import kotlin.test.assertNotNull
+// import kotlin.test.assertNull
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Before
@@ -127,53 +127,64 @@ class SentryPluginTest(
         verifyProguardUuid(testProjectDir.root)
     }
 
-    @Test
-    fun `does not include a UUID in the APK`() {
-        // isMinifyEnabled is disabled by default in debug builds
-        runner
-            .appendArguments(":app:assembleDebug")
-            .build()
+//    @Test
+//    fun `does not include a UUID in the APK`() {
+//        // isMinifyEnabled is disabled by default in debug builds
+//        runner
+//            .appendArguments(":app:assembleDebug")
+//            .build()
+//
+//        verifyNoProguardUuid(testProjectDir.root)
+//    }
 
-        verifyNoProguardUuid(testProjectDir.root)
-    }
+//    @Test
+//    fun `creates uploadNativeSymbolsForRelease task if uploadNativeSymbols is enabled and non debuggable app`() {
+//        applyUploadNativeSymbols()
+//
+//        val build = runner
+//            .appendArguments(":app:assembleRelease")
+//            .build()
+//
+//        assertNotNull(build.task("uploadNativeSymbolsForRelease"))
+//    }
 
-    @Test
-    fun `creates uploadNativeSymbolsForRelease task if uploadNativeSymbols is enabled`() {
-        applyUploadNativeSymbols()
+//    @Test
+//    fun `does not create uploadNativeSymbolsForRelease task if non debuggable app`() {
+//        applyUploadNativeSymbols()
+//
+//        val build = runner
+//            .appendArguments(":app:assembleDebug")
+//            .build()
+//
+//        assertNull(build.task("uploadNativeSymbolsForDebug"))
+//    }
 
-        val build = runner
-            .appendArguments(":app:assembleRelease")
-            .build()
+//    @Test
+//    fun `does not create uploadNativeSymbolsForRelease task if uploadNativeSymbols is disabled`() {
+//        applyUploadNativeSymbols(false)
+//
+//        val build = runner
+//            .appendArguments(":app:assembleRelease")
+//            .build()
+//
+//        assertNull(build.task("uploadNativeSymbolsForRelease"))
+//    }
 
-        assertNotNull(build.task("uploadNativeSymbolsForRelease"))
-    }
-
-    @Test
-    fun `does not create uploadNativeSymbolsForRelease task if non debuggable app`() {
-        applyUploadNativeSymbols()
-
-        val build = runner
-            .appendArguments(":app:assembleDebug")
-            .build()
-
-        assertNull(build.task("uploadNativeSymbolsForDebug"))
-    }
-
-    private fun applyUploadNativeSymbols() {
-        appBuildFile.writeText(
-            // language=Groovy
-            """
-                plugins {
-                  id "com.android.application"
-                  id "io.sentry.android.gradle"
-                }
-
-                sentry {
-                  uploadNativeSymbols = true
-                }
-            """.trimIndent()
-        )
-    }
+//    private fun applyUploadNativeSymbols(uploadNativeSymbols: Boolean = true) {
+//        appBuildFile.writeText(
+//            // language=Groovy
+//            """
+//                plugins {
+//                  id "com.android.application"
+//                  id "io.sentry.android.gradle"
+//                }
+//
+//                sentry {
+//                  uploadNativeSymbols = $uploadNativeSymbols
+//                }
+//            """.trimIndent()
+//        )
+//    }
 
     companion object {
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -128,25 +128,25 @@ class SentryPluginTest(
     }
 
     @Test
-    fun `creates uploadNativeSymbolsForRelease task if uploadNativeSymbols is enabled`() {
+    fun `creates uploadSentryNativeSymbols task if uploadNativeSymbols is enabled`() {
         applyUploadNativeSymbols()
 
         val build = runner
             .appendArguments(":app:assembleRelease")
             .build()
 
-        assertNotNull(build.task("uploadNativeSymbolsForRelease"))
+        assertNotNull(build.task(":app:uploadSentryNativeSymbolsForRelease"))
     }
 
     @Test
-    fun `does not create uploadNativeSymbolsForRelease task if non debuggable app`() {
+    fun `does not create uploadSentryNativeSymbols task if non debuggable app`() {
         applyUploadNativeSymbols()
 
         val build = runner
             .appendArguments(":app:assembleDebug")
             .build()
 
-        assertNull(build.task("uploadNativeSymbolsForDebug"))
+        assertNull(build.task(":app:uploadSentryNativeSymbolsForDebug"))
     }
 
     private fun applyUploadNativeSymbols() {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
@@ -17,7 +17,9 @@ private val ASSET_PATTERN =
     )
 /* ktlint-enable max-line-length */
 
-internal fun verifyProguardUuid(rootFile: File, variant: String = "release", signed: Boolean = true): UUID {
+internal fun verifyProguardUuid(rootFile: File,
+                                variant: String = "release",
+                                signed: Boolean = true): UUID {
     val signedStr = if (signed) "-unsigned" else ""
     val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant$signedStr.apk")
     val sentryProperties = extractZip(apk, "assets/sentry-debug-meta.properties")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
@@ -17,8 +17,9 @@ private val ASSET_PATTERN =
     )
 /* ktlint-enable max-line-length */
 
-internal fun verifyProguardUuid(rootFile: File, variant: String = "release"): UUID {
-    val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant-unsigned.apk")
+internal fun verifyProguardUuid(rootFile: File, variant: String = "release", signed: Boolean = true): UUID {
+    val signedStr = if (signed) "-unsigned" else ""
+    val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant$signedStr.apk")
     val sentryProperties = extractZip(apk, "assets/sentry-debug-meta.properties")
     val matcher = ASSET_PATTERN.matchEntire(sentryProperties)
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
@@ -7,6 +7,7 @@ import java.nio.charset.Charset
 import java.util.UUID
 import java.util.zip.ZipInputStream
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /* ktlint-disable max-line-length */
@@ -18,9 +19,8 @@ private val ASSET_PATTERN =
 /* ktlint-enable max-line-length */
 
 internal fun verifyProguardUuid(rootFile: File, variant: String = "release"): UUID {
-    val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant-unsigned.apk")
-    val sentryProperties = extractZip(apk, "assets/sentry-debug-meta.properties")
-    val matcher = ASSET_PATTERN.matchEntire(sentryProperties)
+    val sentryProperties = getSentryProperties(rootFile, variant)
+    val matcher = ASSET_PATTERN.matchEntire(sentryProperties!!)
 
     assertTrue("Properties file is missing from the APK") { sentryProperties.isNotBlank() }
     assertNotNull(matcher, "$sentryProperties does not match pattern $ASSET_PATTERN")
@@ -28,7 +28,18 @@ internal fun verifyProguardUuid(rootFile: File, variant: String = "release"): UU
     return UUID.fromString(matcher.groupValues[1])
 }
 
-private fun extractZip(zipFile: File, fileToExtract: String): String {
+internal fun verifyNoProguardUuid(rootFile: File, variant: String = "debug") {
+    val sentryProperties = getSentryProperties(rootFile, variant)
+
+    assertNull(sentryProperties)
+}
+
+internal fun getSentryProperties(rootFile: File, variant: String): String? {
+    val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant-unsigned.apk")
+    return extractZip(apk, "assets/sentry-debug-meta.properties")
+}
+
+private fun extractZip(zipFile: File, fileToExtract: String): String? {
     ZipInputStream(FileInputStream(zipFile)).use { zis ->
         var entry = zis.nextEntry
         while (entry != null) {
@@ -39,7 +50,7 @@ private fun extractZip(zipFile: File, fileToExtract: String): String {
             entry = zis.nextEntry
         }
     }
-    return ""
+    return null
 }
 
 private fun readZippedContent(zipInputStream: ZipInputStream): String {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/TestUtils.kt
@@ -17,9 +17,11 @@ private val ASSET_PATTERN =
     )
 /* ktlint-enable max-line-length */
 
-internal fun verifyProguardUuid(rootFile: File,
-                                variant: String = "release",
-                                signed: Boolean = true): UUID {
+internal fun verifyProguardUuid(
+    rootFile: File,
+    variant: String = "release",
+    signed: Boolean = true
+): UUID {
     val signedStr = if (signed) "-unsigned" else ""
     val apk = rootFile.resolve("app/build/outputs/apk/$variant/app-$variant$signedStr.apk")
     val sentryProperties = extractZip(apk, "assets/sentry-debug-meta.properties")

--- a/plugin-build/src/test/resources/testFixtures/appTestProject/sentry.properties
+++ b/plugin-build/src/test/resources/testFixtures/appTestProject/sentry.properties
@@ -1,3 +1,2 @@
-defaults.org=example
-defaults.project=example
-auth.token=example
+defaults.project=sentry-android
+defaults.org=sentry-sdks


### PR DESCRIPTION
## :scroll: Description
Fix: Only upload debug symbols for non debuggable App


## :bulb: Motivation and Context
#138


## :green_heart: How did you test it?
running locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
