### PR TITLE
Add support for variant filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feature: Add support for variant filtering. (#140)
+
 # 2.0.1
 
 * Fix: Only upload debug symbols for non debuggable App. (#139)

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -33,6 +33,10 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
+tasks.withType<Test>().configureEach {
+    maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+}
+
 gradlePlugin {
     plugins {
         register("sentryPlugin") {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -46,7 +46,11 @@ class SentryPlugin : Plugin<Project> {
                 extraProperties.get(SENTRY_PROJECT_PARAMETER).toString()
             }.getOrNull()
 
-            androidExtension.applicationVariants.configureEach { variant ->
+            androidExtension.applicationVariants.matching {
+                it.name !in extension.ignoredVariants.get() &&
+                    it.flavorName !in extension.ignoredFlavors.get() &&
+                    it.buildType.name !in extension.ignoredBuildTypes.get()
+            }.configureEach { variant ->
 
                 val bundleTask = withLogging(project.logger, "bundleTask") {
                     getBundleTask(project, variant.name)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
@@ -2,6 +2,7 @@ package io.sentry.android.gradle
 
 import javax.inject.Inject
 import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 abstract class SentryPluginExtension @Inject constructor(project: Project) {
@@ -34,4 +35,16 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
     val includeNativeSources: Property<Boolean> = objects.property(Boolean::class.java).convention(
         false
     )
+
+    /** List of Android build variants that should be ignored by the Sentry plugin. */
+    val ignoredVariants: ListProperty<String> = objects.listProperty(String::class.java)
+        .convention(emptyList())
+
+    /** List of Android build types that should be ignored by the Sentry plugin. */
+    val ignoredBuildTypes: ListProperty<String> = objects.listProperty(String::class.java)
+        .convention(emptyList())
+
+    /** List of Android build flavors that should be ignored by the Sentry plugin. */
+    val ignoredFlavors: ListProperty<String> = objects.listProperty(String::class.java)
+        .convention(emptyList())
 }


### PR DESCRIPTION
## :scroll: Description
This PR adds 3 fields to the extension to offer filtering capabilities for variant/buildtypes/flavors:

```
                sentry {
                  ignoredVariants = ["..."]
                  ignoredBuildTypes = ["..."]
                  ignoredFlavors = ["..."]
                }
```

I refactored a bit the tests and created a new `VariantTest` integration test to test only this (otherwise adding flavors to the original test would have complicated task names unnecessarily).

## :bulb: Motivation and Context
Fixes #18 

## :green_heart: How did you test it?
Integration tests are included

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes
