### PR TITLE
ref(changelog): Make versions heading level 2

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 minVersion: 0.23.1
-changelogPolicy: simple
+changelogPolicy: auto
 artifactProvider:
   name: none
 targets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-# Unreleased
+# Changelog
 
-# 2.0.1
+## Unreleased
+
+## 2.0.1
 
 * Fix: Only upload debug symbols for non debuggable App. (#139)
 
-# 2.0.0
+## 2.0.0
 
 This release comes with a full rewrite of the Sentry Gradle Plugin.
 
@@ -36,36 +38,36 @@ Thank you:
 * @ansman for driving the first PoC of the full rewrite.
 * @cerisier for EA and small fixes.
 
-# 2.0.0-beta.3
+## 2.0.0-beta.3
 
 * Enhancement: Clean up deprecated/removed Dex and Transform tasks (#130)
 
-# 2.0.0-beta.2
+## 2.0.0-beta.2
 
 * Enhancement: Use pluginManager instead of project.afterEvaluate (#119)
 * Enhancement: Use assembleTaskProvider lazily (#121)
 * Enhancement: Use packageProvider lazily (#125)
 * Enhancement: Use mappingFileProvider lazily (#128)
 
-# 2.0.0-beta.1
+## 2.0.0-beta.1
 
 * Feat: Support Configuration Avoidance (#112)
 * Fix: Silence the warning for missing mapping file on variants that don't enable minification (#111)
 * Bump: sentry-cli to 1.64.1
 
-# 2.0.0-alpha.3
+## 2.0.0-alpha.3
 
 * Fix: Only wire upload mapping task if minifyEnabled (#86) @cerisier
 
-# 2.0.0-alpha.2
+## 2.0.0-alpha.2
 
 * Fix: Publish Plugin Marker on maven central @marandaneto
 
-# 2.0.0-alpha.1
+## 2.0.0-alpha.1
 
 * Feat: Gradle plugin v2 (#50) @cortinico
 * Enhancement: Allow module level sentry properties file (#33) @MatthewTPage
 
-# 1.x
+## 1.x
 
 * See GH releases https://github.com/getsentry/sentry-android-gradle-plugin/releases


### PR DESCRIPTION
Craft's [Changelog Policies](https://github.com/getsentry/craft#changelog-policies) show valid examples of changelogs. Versions should be in heading level 2 (instead of the current 1). This will allow automating the release process using Craft.

_#skip-changelog_