### PR TITLE
feat(release): Set plugin version on pre-release

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,3 +11,7 @@ echo $OLD_VERSION
 echo $NEW_VERSION
 
 GRADLE_FILEPATH="plugin-build/gradle.properties"
+
+# Replace `version` with the given version
+VERSION_NAME_PATTERN="version"
+sed -i "" -e "s/$VERSION_NAME_PATTERN = .*$/$VERSION_NAME_PATTERN = $NEW_VERSION/g" $GRADLE_FILEPATH

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,9 +7,6 @@ cd $SCRIPT_DIR/..
 OLD_VERSION="${1}"
 NEW_VERSION="${2}"
 
-echo $OLD_VERSION
-echo $NEW_VERSION
-
 GRADLE_FILEPATH="plugin-build/gradle.properties"
 
 # Replace `version` with the given version

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+echo $OLD_VERSION
+echo $NEW_VERSION
+
+GRADLE_FILEPATH="plugin-build/gradle.properties"


### PR DESCRIPTION
At the moment, the version in `plugin-build/gradle.properties` has to be updated manually before doing a release. The `scripts/bump-version.sh` will be run by Craft before doing a release, and it will set the correct version in that properties file.

_#skip-changelog_