### PR TITLE
feat(release): Update plugin version and make it snapshot in post-release

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -6,3 +6,6 @@ cd $SCRIPT_DIR/..
 
 OLD_VERSION="${1}"
 NEW_VERSION="${2}"
+
+# Add a new unreleased entry in the changelog
+sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -7,5 +7,24 @@ cd $SCRIPT_DIR/..
 OLD_VERSION="${1}"
 NEW_VERSION="${2}"
 
+GRADLE_FILEPATH="plugin-build/gradle.properties"
+
 # Add a new unreleased entry in the changelog
 sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
+
+# Increment `version` and make it a snapshot
+# Incrementing the version before the release (`bump-version.sh`) sets a
+# fixed version until the next release it's made. For testing purposes, it's
+# interesting to have a different version name that doesn't match the
+# name of the version in production.
+# Note that the version must end with a number: `1.2.3-alpha` is a semantic
+# version but not compatible with this post-release script, and `1.2.3-alpha.0`
+# should be used instead.
+VERSION_NAME_PATTERN="version"
+version="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end
+version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9]+$')"
+((version_digit_to_bump++))
+# Using `*` instead of `+` for compatibility. The result is the same,
+# since the version to be bumped is extracted using `+`.
+new_version="$( echo $version | sed "s/[0-9]*$/$version_digit_to_bump/g" )"
+sed -i "" -e "s/$VERSION_NAME_PATTERN = .*$/$VERSION_NAME_PATTERN = $new_version-SNAPSHOT/g" $GRADLE_FILEPATH

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eux
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -9,6 +9,8 @@ NEW_VERSION="${2}"
 
 GRADLE_FILEPATH="plugin-build/gradle.properties"
 
+git checkout main
+
 # Add a new unreleased entry in the changelog
 sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 
@@ -28,3 +30,7 @@ version_digit_to_bump="$( awk "/$VERSION_PATTERN/" $GRADLE_FILEPATH | egrep -o '
 # since the version to be bumped is extracted using `+`.
 new_version="$( echo $version | sed "s/[0-9]*$/$version_digit_to_bump/g" )"
 sed -i "" -e "s/$VERSION_PATTERN = .*$/$VERSION_PATTERN = $new_version-SNAPSHOT/g" $GRADLE_FILEPATH
+
+git add .
+git commit -m "Prepare $new_version"
+git push

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -20,11 +20,11 @@ sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 # Note that the version must end with a number: `1.2.3-alpha` is a semantic
 # version but not compatible with this post-release script, and `1.2.3-alpha.0`
 # should be used instead.
-VERSION_NAME_PATTERN="version"
-version="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end
-version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9]+$')"
+VERSION_PATTERN="version"
+version="$( awk "/$VERSION_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end
+version_digit_to_bump="$( awk "/$VERSION_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9]+$')"
 ((version_digit_to_bump++))
 # Using `*` instead of `+` for compatibility. The result is the same,
 # since the version to be bumped is extracted using `+`.
 new_version="$( echo $version | sed "s/[0-9]*$/$version_digit_to_bump/g" )"
-sed -i "" -e "s/$VERSION_NAME_PATTERN = .*$/$VERSION_NAME_PATTERN = $new_version-SNAPSHOT/g" $GRADLE_FILEPATH
+sed -i "" -e "s/$VERSION_PATTERN = .*$/$VERSION_PATTERN = $new_version-SNAPSHOT/g" $GRADLE_FILEPATH


### PR DESCRIPTION
Incrementing the version before the release sets a fixed version until the next release it's made. For testing purposes, it's interesting to have a different version name that doesn't match the name of the version in production (ending with `-SNAPSHOT`). Versions are incremented by increasing by one the last numeric value; for example, `1.2.3` will become `1.2.4`, and `1.2.5-beta.1` will become `1.2.5-beta.2`. The first version in these examples is the released version (the argument Craft takes). Note, however, that versions must end with a number: `1.2.3-alpha` is a semantic version but not compatible with this post-release script (doesn't end with a number), and `1.2.3-alpha.0` should be used instead.

_#skip-changelog_