### PR TITLE
ci(release): Run CI on release branches

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/test-maven-publish-maven-local.yaml
+++ b/.github/workflows/test-maven-publish-maven-local.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
In order to get the artifacts that may be generated when doing a release, release branches must run CI.

_#skip-changelog_