### PR TITLE
create alias for closeAndReleaseRepository from project root

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,3 +42,9 @@ tasks.register("preMerge") {
     dependsOn(":examples:android-gradle-kts:check")
     dependsOn(gradle.includedBuild("plugin-build").task(":check"))
 }
+
+tasks.register("closeAndReleaseRepository") {
+    description = "Runs closeAndReleaseRepository for plugin-build"
+
+    dependsOn(gradle.includedBuild("plugin-build").task(":closeAndReleaseRepository"))
+}


### PR DESCRIPTION
## :scroll: Description
create alias for closeAndReleaseRepository from project root

_#skip-changelog_


## :bulb: Motivation and Context
since we can't do `gradlew plugin-build:closeAndReleaseRepository`, because its a composite build, craft fails due to `closeAndReleaseRepository` not found in the project root, also doing `./plugin-build/gradlew closeAndReleaseRepository` also does not work since it executes the gradlew in the current folder anyway, not sure if the alias is the best way but it should fix the issue right now.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
