### PR TITLE
Zip artifacts per distribution

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -65,9 +65,12 @@ val sep = File.separator
 distributions {
     main {
         contents {
-            duplicatesStrategy = DuplicatesStrategy.INCLUDE
             from("build${sep}libs")
             from("build${sep}publications${sep}maven")
+        }
+    }
+    create("sentryPluginMarker") {
+        contents {
             from("build${sep}publications${sep}sentryPluginPluginMarkerMaven")
         }
     }


### PR DESCRIPTION
## :scroll: Description
Zip artifacts per distribution

_#skip-changelog_


## :bulb: Motivation and Context
zipping with the default task was a problem since there were multiple files with the same name and this would fail during Craft execution, now it creates 2 zip files.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
