### PR TITLE
Lazy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enhancement: Avoid Eager Task Configuration (#156)
+
 ## 2.1.1-beta.2
 
 - No documented changes.

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -121,17 +121,23 @@ class SentryPlugin : Plugin<Project> {
                     )
 
                     // we just hack ourselves into the proguard task's doLast.
-                    transformerTaskProvider?.configure { it.finalizedBy(uploadSentryProguardMappingsTask) }
+                    transformerTaskProvider?.configure {
+                        it.finalizedBy(uploadSentryProguardMappingsTask)
+                    }
 
                     // To include proguard uuid file into aab, run before bundle task.
-                    preBundleTaskProvider?.configure { it.dependsOn(uploadSentryProguardMappingsTask) }
+                    preBundleTaskProvider?.configure { task ->
+                        task.dependsOn(uploadSentryProguardMappingsTask)
+                    }
 
                     // The package task will only be executed if the uploadSentryProguardMappingsTask has already been executed.
-                    getPackageProvider(variant)?.configure {
-                        it.dependsOn(uploadSentryProguardMappingsTask)
+                    getPackageProvider(variant)?.configure { task ->
+                        task.dependsOn(uploadSentryProguardMappingsTask)
                     }
                     // App bundle has different package task
-                    packageBundleTaskProvider?.configure { it.dependsOn(uploadSentryProguardMappingsTask) }
+                    packageBundleTaskProvider?.configure { task ->
+                        task.dependsOn(uploadSentryProguardMappingsTask)
+                    }
                 }
 
                 // only debug symbols of non debuggable code should be uploaded (aka release builds).

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
@@ -3,15 +3,16 @@ package io.sentry.android.gradle.util
 import java.util.Locale
 import org.gradle.api.Task
 import org.gradle.api.logging.Logger
+import org.gradle.api.tasks.TaskProvider
 
 internal object SentryPluginUtils {
 
     fun withLogging(
         logger: Logger,
         varName: String,
-        initializer: () -> Task?
+        initializer: () -> TaskProvider<Task>?
     ) = initializer().also {
-        logger.info("[sentry] $varName is ${it?.path}")
+        logger.info("[sentry] $varName is ${it?.name}")
     }
 
     fun String.capitalizeUS() = if (isEmpty()) {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle
 
 import java.io.File
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -8,6 +9,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -104,6 +106,30 @@ class SentryPluginTest(
         )
 
         runner.build()
+    }
+
+    @Test
+    @Ignore("Because the Sentry plugin currently eagerly configures some tasks of the Android Gradle Plugin")
+    fun `plugin does not configure tasks`() {
+        val prefix = "task-configured-for-test: "
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+                plugins {
+                  id "com.android.application"
+                  id "io.sentry.android.gradle"
+                }
+
+                project.tasks.configureEach { Task task -> println("$prefix" + task.path) }
+            """.trimIndent()
+        )
+
+        val result = runner.withArguments("help").build()
+        val configuredTasks = result.output.lines()
+            .filter { it.startsWith(prefix) }
+            .map { it.removePrefix(prefix) }
+            .sorted()
+        assertEquals(listOf(), configuredTasks)
     }
 
     @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -9,7 +9,6 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -109,7 +108,6 @@ class SentryPluginTest(
     }
 
     @Test
-    @Ignore("Because the Sentry plugin currently eagerly configures some tasks of the Android Gradle Plugin")
     fun `plugin does not configure tasks`() {
         val prefix = "task-configured-for-test: "
         appBuildFile.writeText(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -26,63 +26,63 @@ class SentryTaskProviderTest {
     fun `getTransformerTask returns null for missing task`() {
         val project = ProjectBuilder.builder().build()
 
-        assertNull(getTransformerTask(project, "debug"))
+        assertNull(getTransformerTask(project, "debug")?.get())
     }
 
     @Test
     fun `getTransformerTask returns minify for R8`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithR8")
 
-        assertEquals(task, getTransformerTask(project, "debug"))
+        assertEquals(task, getTransformerTask(project, "debug")?.get())
     }
 
     @Test
     fun `getTransformerTask returns minify for Proguard`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithProguard")
 
-        assertEquals(task, getTransformerTask(project, "debug"))
+        assertEquals(task, getTransformerTask(project, "debug")?.get())
     }
 
     @Test
     fun `getPreBundleTask returns null for missing task`() {
         val project = ProjectBuilder.builder().build()
 
-        assertNull(getPreBundleTask(project, "debug"))
+        assertNull(getPreBundleTask(project, "debug")?.get())
     }
 
     @Test
     fun `getPreBundleTask returns correct task`() {
         val (project, task) = getTestProjectWithTask("buildDebugPreBundle")
 
-        assertEquals(task, getPreBundleTask(project, "debug"))
+        assertEquals(task, getPreBundleTask(project, "debug")?.get())
     }
 
     @Test
     fun `getBundleTask returns null for missing task`() {
         val project = ProjectBuilder.builder().build()
 
-        assertNull(getBundleTask(project, "debug"))
+        assertNull(getBundleTask(project, "debug")?.get())
     }
 
     @Test
     fun `getBundleTask returns correct task`() {
         val (project, task) = getTestProjectWithTask("bundleDebug")
 
-        assertEquals(task, getBundleTask(project, "debug"))
+        assertEquals(task, getBundleTask(project, "debug")?.get())
     }
 
     @Test
     fun `getPackageBundleTask returns null for missing task`() {
         val project = ProjectBuilder.builder().build()
 
-        assertNull(getPackageBundleTask(project, "debug"))
+        assertNull(getPackageBundleTask(project, "debug")?.get())
     }
 
     @Test
     fun `getPackageBundleTask returns package bundle task`() {
         val (project, task) = getTestProjectWithTask("packageDebugBundle")
 
-        assertEquals(task, getPackageBundleTask(project, "debug"))
+        assertEquals(task, getPackageBundleTask(project, "debug")?.get())
     }
 
     @Test
@@ -91,9 +91,9 @@ class SentryTaskProviderTest {
 
         android.applicationVariants.configureEach {
             if (it.name == "debug") {
-                assertEquals("assembleDebug", getAssembleTaskProvider(it)?.name)
+                assertEquals("assembleDebug", getAssembleTaskProvider(it)?.get()?.name)
             } else {
-                assertEquals("assembleRelease", getAssembleTaskProvider(it)?.name)
+                assertEquals("assembleRelease", getAssembleTaskProvider(it)?.get()?.name)
             }
         }
     }
@@ -104,9 +104,9 @@ class SentryTaskProviderTest {
 
         android.applicationVariants.configureEach {
             if (it.name == "debug") {
-                assertEquals("mergeDebugAssets", getMergeAssetsProvider(it)?.name)
+                assertEquals("mergeDebugAssets", getMergeAssetsProvider(it)?.get()?.name)
             } else {
-                assertEquals("mergeReleaseAssets", getMergeAssetsProvider(it)?.name)
+                assertEquals("mergeReleaseAssets", getMergeAssetsProvider(it)?.get()?.name)
             }
         }
     }


### PR DESCRIPTION
## :scroll: Description
Changes the Plugin to use TaskProviders instead of tasks directly to ensure that tasks from AGP are not configured eagerly.

## :bulb: Motivation and Context
[Lazy Configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) "can avoid resource intensive work during the configuration phase, which can have a large impact on build performance". 

## :green_heart: How did you test it?
The newly added test verifies that no additional tasks are being configured when invoking the `help` task.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes
