### PR TITLE
Do not hardcode the build/ folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Enhancement: Avoid Eager Task Configuration (#156)
+- Fix: Do not hardcode the build/ folder (#158)
 
 ## 2.1.1-beta.2
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -87,7 +87,10 @@ class SentryPlugin : Plugin<Project> {
                 if (isMinifyEnabled) {
                     // Setup the task to generate a UUID asset file
                     val uuidOutputDirectory = project.file(
-                        "build${sep}generated${sep}assets${sep}sentry${sep}${variant.name}"
+                        File(
+                            project.buildDir,
+                            "generated${sep}assets${sep}sentry${sep}${variant.name}"
+                        )
                     )
                     val generateUuidTask = project.tasks.register(
                         "generateSentryProguardUuid$taskSuffix",

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -77,8 +77,10 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
         // eg absoluteProjectFolderPath/build/intermediates/merged_native_libs/{variantName}
         // where {variantName} could be debug/release...
         args.add(
-            "${project.projectDir}${sep}build${sep}intermediates" +
-                "${sep}merged_native_libs${sep}${variantName.get()}"
+            File(
+                project.buildDir,
+                "intermediates${sep}merged_native_libs${sep}${variantName.get()}"
+            ).absolutePath
         )
 
         // Only include sources if includeNativeSources is enabled, as this is opt-in feature


### PR DESCRIPTION
## :scroll: Description
This PR changes the paths hardcoded to `build/` into `project.buildDir`.

## :bulb: Motivation and Context
Fixes #157	

## :green_heart: How did you test it?
Will rely on JUnit tests to verify that everything works as usual.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] No breaking changes