### PR TITLE
fix: Cli downloading every Gradle sync

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,9 +21,9 @@ if(shouldDownloadSentryCli()) {
  * That's to retrigger a download of the cli upon a bump.
  */
 fun shouldDownloadSentryCli() : Boolean {
-    val cliDir: Array<File> = File("./plugin-build/src/main/resources/bin/").listFiles() ?: emptyArray()
-    val expectedChecksums = File("./buildSrc/expected-checksums.sha")
-    val actualChecksums = File("./plugin-build/src/main/resources/bin/checksums.sha")
+    val cliDir: Array<File> = File("$rootDir/../plugin-build/src/main/resources/bin/").listFiles() ?: emptyArray()
+    val expectedChecksums = File("$rootDir/expected-checksums.sha")
+    val actualChecksums = File("$rootDir/../plugin-build/src/main/resources/bin/checksums.sha")
     return when {
         cliDir.size <= 2 -> {
             logger.lifecycle("Sentry CLI is missing")


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
When doing a Gradle sync in IntelliJ, the CLIs got downloaded every time for me. My guess is that because it configures **all** projects (buildSrc and root in our case), and since we use relative paths there, when configuring the root project `:` (see the screenshot), it couldn't locate the CLIs properly. So I've just changed it to rely on the `rootDir`

![image](https://user-images.githubusercontent.com/4999776/129927070-82ce9125-f222-4423-981f-c3043ae56279.png)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
