### PR TITLE
build(craft): Disable android on `maven` target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,6 +7,7 @@ targets:
     mavenSettingsPath: scripts/settings.xml
     mavenRepoId: ossrh
     mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2/
+    android: false
   - name: github
   - name: registry
     sdks:


### PR DESCRIPTION
Craft requires, from https://github.com/getsentry/craft/pull/271, to set the Android config in the `maven` target. This PR updates that config.

_#skip-changelog_