### PR TITLE
Fix: missing sentry-cli on embedded resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build distribution artifacts
         run: |
+#          trigger the download of sentry-cli if necessary
+          ./gradlew tasks
           cd plugin-build
           make all
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Build distribution artifacts
         run: |
-#          trigger the download of sentry-cli if necessary
           ./gradlew tasks
           cd plugin-build
           make all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-- Bump: AGP to 4.2.2 (#106)
+* Bump: AGP to 4.2.2 (#106)
+* Fix: missing sentry-cli on embedded resources
 
 ## 2.1.1
 
-- Enhancement: Avoid Eager Task Configuration (#156)
-- Fix: Do not hardcode the build/ folder (#158)
+* Enhancement: Avoid Eager Task Configuration (#156)
+* Fix: Do not hardcode the build/ folder (#158)
 
 ## 2.1.1-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Bump: AGP to 4.2.2 (#106)
-* Fix: missing sentry-cli on embedded resources
+* Fix: missing sentry-cli on embedded resources (#162)
 
 ## 2.1.1
 


### PR DESCRIPTION
## :scroll: Description
Fix: missing sentry-cli on embedded resources


## :bulb: Motivation and Context
`plugin-buikd/make all` does not trigger the `shouldDownloadSentryCli` method from buildSrc, hence the release 2.1.1 didn't have the embedded sentry-cli version


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
