### PR TITLE
Fix: Use task logger instead of project logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Use task logger instead of project logger (#165)
+
 ## 2.1.2
 
 * Bump: AGP to 4.2.2 (#106)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt
@@ -27,7 +27,7 @@ abstract class SentryGenerateProguardUuidTask : DefaultTask() {
 
     @TaskAction
     fun generateProperties() {
-        project.logger.info(
+        logger.info(
             "[sentry] SentryGenerateProguardUuidTask - outputFile: ${outputFile.get()}"
         )
 


### PR DESCRIPTION

## :scroll: Description

Invocation of Task.project is forbidden at execution time to comply with configuration cache requirements.
This was the last instance of Task.project that was making config cache fail for my project.


## :bulb: Motivation and Context

Fixes Gradle configuration cache compliance.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
