### PR TITLE
Use gradle-build-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     name: Build and upload distribution artifact
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout current commit (${{ github.sha }})
         uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,9 @@ jobs:
 
       - name: Checkout current commit (${{ github.sha }})
         uses: actions/checkout@v2
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-${{ matrix.os }}
-          restore-keys: |
-            cache-gradle-
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.1
 
       - name: Set up Java
         uses: actions/setup-java@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Set up Java
         uses: actions/setup-java@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,12 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Set up Java
         uses: actions/setup-java@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
 
       - name: Set up Java
         uses: actions/setup-java@v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -26,7 +26,7 @@ jobs:
           java-version: '11'
 
       - name: Run Gradle tasks
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: preMerge --continue
 
@@ -38,11 +38,11 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: assembleDebug
 
       - name: Build the Release variant
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: assembleRelease

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -26,12 +26,9 @@ jobs:
           java-version: '11'
 
       - name: Run Gradle tasks
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.1
         with:
           arguments: preMerge --continue
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
@@ -41,17 +38,11 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.1
         with:
           arguments: assembleDebug
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
 
       - name: Build the Release variant
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.1
         with:
           arguments: assembleRelease
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,15 +18,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-${{ matrix.os }}
-          restore-keys: |
-            cache-gradle-
 
       - name: Setup Java Version
         uses: actions/setup-java@v2
@@ -35,7 +26,12 @@ jobs:
           java-version: '11'
 
       - name: Run Gradle tasks
-        run: ./gradlew preMerge --continue
+        uses: gradle/gradle-build-action@v1
+        with:
+          arguments: preMerge --continue
+          distributions-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
@@ -45,7 +41,17 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        run: ./gradlew assembleDebug
+        uses: gradle/gradle-build-action@v1
+        with:
+          arguments: assembleDebug
+          distributions-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
 
       - name: Build the Release variant
-        run: ./gradlew assembleRelease
+        uses: gradle/gradle-build-action@v1
+        with:
+          arguments: assembleRelease
+          distributions-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -40,9 +40,19 @@ jobs:
       - name: Build the Debug variant
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           arguments: assembleDebug
 
       - name: Build the Release variant
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           arguments: assembleRelease

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -40,19 +40,9 @@ jobs:
       - name: Build the Debug variant
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           arguments: assembleDebug
 
       - name: Build the Release variant
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           arguments: assembleRelease

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: Build the Release variant
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
           arguments: assembleRelease
 
@@ -63,7 +62,6 @@ jobs:
       - name: Build the Release Bundle variant
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
           arguments: bundleRelease
 

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -33,21 +33,10 @@ jobs:
     name: Publish Dry Run - AGP ${{ matrix.agp }} - Gradle ${{ matrix.gradle }}
     env:
       VERSION_AGP: ${{ matrix.agp }}
-      VERSION_GRADLE: ${{ matrix.gradle }}
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-${{ matrix.gradle }}-${{ matrix.agp }}
-          restore-keys: |
-            cache-gradle-${{ matrix.gradle }}-
-            cache-gradle-
 
       - name: Setup Java Version
         uses: actions/setup-java@v2
@@ -55,11 +44,14 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
 
-      - name: Set Gradle Version
-        run: ./gradlew wrapper --gradle-version $VERSION_GRADLE --distribution-type=all
-
       - name: Build the Release variant
-        run: ./gradlew assembleRelease
+        uses: gradle/gradle-build-action@v1
+        with:
+          gradle-version: ${{ matrix.gradle }}
+          arguments: assembleRelease
+          distributions-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
 
       - name: Check sentry-debug-meta.properties inside APKs
         run: |
@@ -71,7 +63,13 @@ jobs:
           rm -r output
 
       - name: Build the Release Bundle variant
-        run: ./gradlew bundleRelease
+        uses: gradle/gradle-build-action@v1
+        with:
+          gradle-version: ${{ matrix.gradle }}
+          arguments: bundleRelease
+          distributions-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
 
       - name: Check sentry-debug-meta.properties inside App Bundle
         run: |

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Build the Release variant
         uses: gradle/gradle-build-action@v2
         with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
           arguments: assembleRelease
 
@@ -62,6 +63,7 @@ jobs:
       - name: Build the Release Bundle variant
         uses: gradle/gradle-build-action@v2
         with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
           arguments: bundleRelease
 

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -45,7 +45,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build the Release variant
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: assembleRelease
@@ -60,7 +60,7 @@ jobs:
           rm -r output
 
       - name: Build the Release Bundle variant
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: bundleRelease

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -45,13 +45,10 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build the Release variant
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.1
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: assembleRelease
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
 
       - name: Check sentry-debug-meta.properties inside APKs
         run: |
@@ -63,13 +60,10 @@ jobs:
           rm -r output
 
       - name: Build the Release Bundle variant
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2.1
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: bundleRelease
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
 
       - name: Check sentry-debug-meta.properties inside App Bundle
         run: |

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -19,15 +19,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Cache Gradle Files
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/
-            ~/.gradle/wrapper/
-          key: cache-gradle-${{ matrix.os }}
-          restore-keys: |
-            cache-gradle-
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.1
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -21,12 +21,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.1
+        uses: gradle/gradle-build-action@v2
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -21,6 +21,12 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,6 +1,6 @@
 object BuildPluginsVersion {
     val AGP = System.getenv("VERSION_AGP") ?: "7.0.3"
-    const val DOKKA = "1.4.30"
+    const val DOKKA = "1.4.32"
     const val KOTLIN = "1.4.32"
     const val AAR_2_JAR = "0.6"
     const val KTLINT = "10.2.0"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,6 +1,6 @@
 object BuildPluginsVersion {
     val AGP = System.getenv("VERSION_AGP") ?: "7.0.3"
-    const val DOKKA = "1.4.32"
+    const val DOKKA = "1.4.30"
     const val KOTLIN = "1.4.32"
     const val AAR_2_JAR = "0.6"
     const val KTLINT = "10.2.0"


### PR DESCRIPTION
## :scroll: Description
Replace manual `./gradlew` calls with `gradle/gradle-build-action` invocations

## :bulb: Motivation and Context
Fixes #168 

## :green_heart: How did you test it?
Let's let the CI tell us the truth.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
There are currently two "blockers" to this:

1. `test-publish.yaml` is using `| tee gradle.log` that is not supported by this action. This is used to verify that native symbols are effectively uploaded. 
2. `build.yaml` is using a makefile to make Gradle invocations.

Therefore we end up having a mixture of Gradle invocations & caching mechanisms on Github Actions. I'm unsure if we want to go this way or not.

#skip-changelog