### PR TITLE
Run publish also on merges

### DIFF
--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    if: ${{ github.repository == 'getsentry/sentry-android-gradle-plugin'}}
+    if: ${{ github.repository == 'getsentry/sentry-android-gradle-plugin' || github.event.pull_request.head.repo.full_name == 'getsentry/sentry-android-gradle-plugin'}}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.repository == 'getsentry/sentry-android-gradle-plugin'}}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   publish:
-    if: ${{ github.repository == 'getsentry/sentry-android-gradle-plugin' || github.event.pull_request.head.repo.full_name == 'getsentry/sentry-android-gradle-plugin'}}
     runs-on: ubuntu-latest
 
     env:
@@ -33,6 +32,8 @@ jobs:
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log
+        if: env.SENTRY_AUTH_TOKEN != null
 
       - name: Verify that Native Symbols were uploaded
         run: grep "Uploaded 4 missing debug information files" gradle.log
+        if: env.SENTRY_AUTH_TOKEN != null

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -20,8 +20,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        if: env.SENTRY_AUTH_TOKEN != null
+        
       - name: Cache Gradle Files
         uses: actions/cache@v2
+        if: env.SENTRY_AUTH_TOKEN != null
         with:
           path: |
             ~/.gradle/caches/


### PR DESCRIPTION
## :scroll: Description
This relaxes the `test-publish` condition to run if the owner is `getsentry` (either from a local PR or a merge).

## :bulb: Motivation and Context
Fixes #169 

## :green_heart: How did you test it?
Will check if the PR is green just after merging this

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] No breaking changes

#skip-changelog