### PR TITLE
bump sentry-cli 1.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Bump: AGP to 7.0.1 (#181)
-* Bump sentry-cli 1.69.0 which includes a fix for Dart debug symbols (#191)
+* Bump sentry-cli 1.69.1 which includes a fix for Dart debug symbols (#191)
 
 
 ## 2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Bump: AGP to 7.0.1 (#181)
+* Bump sentry-cli 1.69.0 which includes a fix for Dart debug symbols (#191)
+
 
 ## 2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Bump: AGP to 7.0.1 (#181)
 * Bump sentry-cli 1.69.1 which includes a fix for Dart debug symbols (#191)
 
-
 ## 2.1.4
 
 * Fix: Pass buildDir as task input (#166)

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd $(dirname "$0")
 REPO=getsentry/sentry-cli
-VERSION=1.65.0
+VERSION=1.69.0
 PLATFORMS="Darwin-x86_64 Linux-i686 Linux-x86_64 Windows-i686"
 
 rm -f src/main/resources/bin/sentry-cli-*

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd $(dirname "$0")
 REPO=getsentry/sentry-cli
-VERSION=1.69.0
+VERSION=1.69.1
 PLATFORMS="Darwin-x86_64 Linux-i686 Linux-x86_64 Windows-i686"
 
 rm -f src/main/resources/bin/sentry-cli-*

--- a/plugin-build/expected-checksums.sha
+++ b/plugin-build/expected-checksums.sha
@@ -1,4 +1,4 @@
-245094273dcb05b357c2d3bfca7147bf8350fd8a  src/main/resources/bin/sentry-cli-Darwin-x86_64
-657d92b044dfce2802961a74a3e16042c4983b33  src/main/resources/bin/sentry-cli-Linux-i686
-8ce50141d82f750371ea870a8be29043731f1d1d  src/main/resources/bin/sentry-cli-Linux-x86_64
-d2e48001d3615f345518cb28248f1abf27195ad8  src/main/resources/bin/sentry-cli-Windows-i686.exe
+f6c85afe68e850b91c6acc204cb9a3760f0dcfaf  src/main/resources/bin/sentry-cli-Darwin-x86_64
+5c421f31bbd8a6ee537a6cd0052f41e2ccde669b  src/main/resources/bin/sentry-cli-Linux-i686
+db91e89a31e8957f04be4ffe37911f6acfb81cd8  src/main/resources/bin/sentry-cli-Linux-x86_64
+3a2191aa9350472dff35e0ef81c9413e6fa98ff9  src/main/resources/bin/sentry-cli-Windows-i686.exe

--- a/plugin-build/expected-checksums.sha
+++ b/plugin-build/expected-checksums.sha
@@ -1,4 +1,4 @@
-f6c85afe68e850b91c6acc204cb9a3760f0dcfaf  src/main/resources/bin/sentry-cli-Darwin-x86_64
-5c421f31bbd8a6ee537a6cd0052f41e2ccde669b  src/main/resources/bin/sentry-cli-Linux-i686
-db91e89a31e8957f04be4ffe37911f6acfb81cd8  src/main/resources/bin/sentry-cli-Linux-x86_64
-3a2191aa9350472dff35e0ef81c9413e6fa98ff9  src/main/resources/bin/sentry-cli-Windows-i686.exe
+26d126d8fa8988610fca5f49cf33652d2ba1b2e8  src/main/resources/bin/sentry-cli-Darwin-x86_64
+29dbce36abe71387ca6698e13eec145e136eb848  src/main/resources/bin/sentry-cli-Linux-i686
+41f8384718a5d7ac11ec6578a62ac4fe34d171e9  src/main/resources/bin/sentry-cli-Linux-x86_64
+8027b021e5499b6880e08c1fee2a7497e213886a  src/main/resources/bin/sentry-cli-Windows-i686.exe

--- a/plugin-build/expected-checksums.sha
+++ b/plugin-build/expected-checksums.sha
@@ -1,4 +1,4 @@
-26d126d8fa8988610fca5f49cf33652d2ba1b2e8  src/main/resources/bin/sentry-cli-Darwin-x86_64
-29dbce36abe71387ca6698e13eec145e136eb848  src/main/resources/bin/sentry-cli-Linux-i686
-41f8384718a5d7ac11ec6578a62ac4fe34d171e9  src/main/resources/bin/sentry-cli-Linux-x86_64
-8027b021e5499b6880e08c1fee2a7497e213886a  src/main/resources/bin/sentry-cli-Windows-i686.exe
+92a2180ebf5678929a494434dc5159ef9730f100  src/main/resources/bin/sentry-cli-Darwin-x86_64
+151f5c77fca22d00d651dd22de0eeed733db0094  src/main/resources/bin/sentry-cli-Linux-i686
+b70e1bada7929045265cb675a1c52234b1792748  src/main/resources/bin/sentry-cli-Linux-x86_64
+42e1a23c84b2a8b96992fafa0b500a5a158e7e61  src/main/resources/bin/sentry-cli-Windows-i686.exe


### PR DESCRIPTION
Includes a fix needed by the Dart/Flutter SDK:

https://github.com/getsentry/sentry-dart/issues/591#issuecomment-930388078