### PR TITLE
Make the ignoreXXX properties in SentryPluginExtension SetProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Fix: Correctly add the proguard UUID output directory to the source set (#226) 
+* Fix: Correctly add the proguard UUID output directory to the source set (#226)
+* Feature: Make the ignoreXXX properties in SentryPluginExtension sets (#225)
 
 ## 3.0.0-beta.1
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 abstract class SentryPluginExtension @Inject constructor(project: Project) {
 
@@ -48,16 +49,16 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
     )
 
     /** List of Android build variants that should be ignored by the Sentry plugin. */
-    val ignoredVariants: ListProperty<String> = objects.listProperty(String::class.java)
-        .convention(emptyList())
+    val ignoredVariants: SetProperty<String> = objects.setProperty(String::class.java)
+        .convention(emptySet())
 
     /** List of Android build types that should be ignored by the Sentry plugin. */
-    val ignoredBuildTypes: ListProperty<String> = objects.listProperty(String::class.java)
-        .convention(emptyList())
+    val ignoredBuildTypes: SetProperty<String> = objects.setProperty(String::class.java)
+        .convention(emptySet())
 
     /** List of Android build flavors that should be ignored by the Sentry plugin. */
-    val ignoredFlavors: ListProperty<String> = objects.listProperty(String::class.java)
-        .convention(emptyList())
+    val ignoredFlavors: SetProperty<String> = objects.setProperty(String::class.java)
+        .convention(emptySet())
 
     internal val tracingInstrumentation: TracingInstrumentationExtension = objects.newInstance(
         TracingInstrumentationExtension::class.java

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
@@ -3,7 +3,6 @@ package io.sentry.android.gradle
 import javax.inject.Inject
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
@@ -96,7 +96,7 @@ class SentryPluginVariantTest(
 
     @Test
     fun `skips variant if set with ignoredVariants`() {
-        applyIgnores(ignoredVariants = listOf("fullRelease"))
+        applyIgnores(ignoredVariants = setOf("fullRelease"))
 
         val build = runner
             .appendArguments(":app:assembleFullRelease", "--dry-run")
@@ -107,7 +107,7 @@ class SentryPluginVariantTest(
 
     @Test
     fun `does not skip variant if not included in ignoredVariants`() {
-        applyIgnores(ignoredVariants = listOf("demoRelease", "fullDebug", "demoDebug"))
+        applyIgnores(ignoredVariants = setOf("demoRelease", "fullDebug", "demoDebug"))
 
         val build = runner
             .appendArguments(":app:assembleFullRelease", "--dry-run")
@@ -118,7 +118,7 @@ class SentryPluginVariantTest(
 
     @Test
     fun `skips buildType if set with ignoredBuildTypes`() {
-        applyIgnores(ignoredBuildTypes = listOf("debug"))
+        applyIgnores(ignoredBuildTypes = setOf("debug"))
 
         val build = runner
             .appendArguments(":app:assembleFullDebug", "--dry-run")
@@ -130,7 +130,7 @@ class SentryPluginVariantTest(
 
     @Test
     fun `does not skip buildType if not included in ignoredBuildTypes`() {
-        applyIgnores(ignoredBuildTypes = listOf("debug"))
+        applyIgnores(ignoredBuildTypes = setOf("debug"))
 
         val build = runner
             .appendArguments(":app:assembleFullRelease", "--dry-run")
@@ -141,7 +141,7 @@ class SentryPluginVariantTest(
 
     @Test
     fun `skips flavor if set with ignoredFlavors`() {
-        applyIgnores(ignoredFlavors = listOf("full"))
+        applyIgnores(ignoredFlavors = setOf("full"))
 
         var build = runner
             .appendArguments(":app:assembleFullDebug", "--dry-run")
@@ -158,7 +158,7 @@ class SentryPluginVariantTest(
 
     @Test
     fun `does not skip flavor if not included in ignoredFlavors`() {
-        applyIgnores(ignoredFlavors = listOf("full"))
+        applyIgnores(ignoredFlavors = setOf("full"))
 
         val build = runner
             .appendArguments(":app:assembleDemoRelease", "--dry-run")
@@ -168,9 +168,9 @@ class SentryPluginVariantTest(
     }
 
     private fun applyIgnores(
-        ignoredVariants: List<String> = listOf(),
-        ignoredBuildTypes: List<String> = listOf(),
-        ignoredFlavors: List<String> = listOf()
+        ignoredVariants: Set<String> = setOf(),
+        ignoredBuildTypes: Set<String> = setOf(),
+        ignoredFlavors: Set<String> = setOf()
     ) {
         val variants = ignoredVariants.joinToString(",") { "\"$it\"" }
         val buildTypes = ignoredBuildTypes.joinToString(",") { "\"$it\"" }


### PR DESCRIPTION
## :scroll: Description
The changed properties are better suited as sets values should be unique.

This is technically a breaking change but a major release is coming up and I doubt it will cause any issues since it's mostly source compatible.

## :bulb: Motivation and Context
Set properties are more semantically correct since the properties are used to filter objects.


## :green_heart: How did you test it?
I ran the tests, no changes.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
