### PR TITLE
Fix a task dependency issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Correctly add the proguard UUID output directory to the source set (#226) 
+
 ## 3.0.0-beta.1
 
 * Fix: Associate spans and events when it throws (#219)


### PR DESCRIPTION
## :scroll: Description
Use `SentryGenerateProguardUuidTask.outputDirectory` rather than sharing a property created outside.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When writing Gradle tasks it's important to correctly hook up your task dependencies. If a task uses the output directory of another task the first task should ideally use the output property of the second task (an explicit dependency is also OK).

Secondly, when adding a directory to a sourceset and that directory is the output directory of a task then the property of the task should be added, not just the directory. This will correctly hook up the dependencies for tasks that use that source set. This will prevent warnings such as this (which the Sentry plugin currently produces):
```
> Task :app:lintVitalAnalyzeRelease
Execution optimizations have been disabled for task ':app:lintVitalAnalyzeRelease' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/path/to/repo/app/build/generated/assets/sentry/release'. Reason: Task ':app:lintVitalAnalyzeRelease' uses this output of task ':app:generateSentryProguardUuidRelease' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

This fixes #92 which is still happening

## :green_heart: How did you test it?
Ran the existing tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
