### PR TITLE
Make tracingInstrumentation public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Fix: Correctly add the proguard UUID output directory to the source set (#226) 
+* Fix: Correctly add the proguard UUID output directory to the source set (#226)
+* Expose SentryPluginExtension.tracingInstrumentation (#229)
 
 ## 3.0.0-beta.1
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
@@ -59,7 +59,7 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
     val ignoredFlavors: ListProperty<String> = objects.listProperty(String::class.java)
         .convention(emptyList())
 
-    internal val tracingInstrumentation: TracingInstrumentationExtension = objects.newInstance(
+    val tracingInstrumentation: TracingInstrumentationExtension = objects.newInstance(
         TracingInstrumentationExtension::class.java
     )
 


### PR DESCRIPTION
## :scroll: Description
`SentryPluginExtension.tracingInstrumentation` is now public


## :bulb: Motivation and Context
It's customary to both offer an accessor as well as a function that accepts an `Action` to configure an object. This way you can both access it using the `sentry.tracingInstrumentation.enabled = true` syntax as well as `sentry.tracingInstrumentation { enabled = true }` syntax.


## :green_heart: How did you test it?
No testing needed since it's just a visibility change.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
