### PR TITLE
Introduce the includeProguardMapping option and deprecate autoUpload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Introduce the `includeProguardMapping` option to exclude the proguard logic, and deprecate `autoUpload` in favor of `autoUploadProguardMapping` (#240)
+
 ## 3.0.0-beta.2
 
 * Fix: Correctly add the proguard UUID output directory to the source set (#226)

--- a/examples/android-gradle-kts/build.gradle.kts
+++ b/examples/android-gradle-kts/build.gradle.kts
@@ -20,7 +20,7 @@ android {
 }
 
 sentry {
-    autoUpload.set(CI.canAutoUpload())
+    autoUploadProguardMapping.set(CI.canAutoUpload())
 
     tracingInstrumentation {
         enabled.set(false)

--- a/examples/android-gradle/build.gradle
+++ b/examples/android-gradle/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 sentry {
-    autoUpload = CI.INSTANCE.canAutoUpload()
+    autoUploadProguardMapping = CI.INSTANCE.canAutoUpload()
 
     tracingInstrumentation {
         enabled = false

--- a/examples/android-ndk/build.gradle
+++ b/examples/android-ndk/build.gradle
@@ -35,7 +35,8 @@ android {
 if (System.getenv("AUTO_UPLOAD")) {
     apply plugin: 'io.sentry.android.gradle'
     sentry {
-        autoUpload = false
+        includeProguardMapping = true
+        autoUploadProguardMapping = false
         uploadNativeSymbols = true
         includeNativeSources = true
         autoUploadNativeSymbols = CI.INSTANCE.canAutoUpload()

--- a/examples/android-ndk/build.gradle
+++ b/examples/android-ndk/build.gradle
@@ -35,7 +35,6 @@ android {
 if (System.getenv("AUTO_UPLOAD")) {
     apply plugin: 'io.sentry.android.gradle'
     sentry {
-        includeProguardMapping = true
         autoUploadProguardMapping = false
         uploadNativeSymbols = true
         includeNativeSources = true

--- a/examples/android-room/build.gradle.kts
+++ b/examples/android-room/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
 }
 
 sentry {
-    autoUpload.set(false)
+    autoUploadProguardMapping.set(false)
 
     tracingInstrumentation {
         forceInstrumentDependencies.set(true)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -120,7 +120,7 @@ class SentryPlugin : Plugin<Project> {
 
                 val taskSuffix = variant.name.capitalizeUS()
 
-                if (isMinifyEnabled) {
+                if (isMinifyEnabled && extension.includeProguardMapping.get()) {
                     // Setup the task to generate a UUID asset file
                     val generateUuidTask = project.tasks.register(
                         "generateSentryProguardUuid$taskSuffix",
@@ -152,7 +152,7 @@ class SentryPlugin : Plugin<Project> {
                         )
                         task.uuidDirectory.set(generateUuidTask.flatMap { it.outputDirectory })
                         task.mappingsFiles = getMappingFileProvider(variant)
-                        task.autoUpload.set(extension.autoUpload)
+                        task.autoUploadProguardMapping.set(extension.autoUploadProguardMapping)
                         task.sentryOrganization.set(sentryOrgParameter)
                         task.sentryProject.set(sentryProjectParameter)
                     }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
@@ -11,11 +11,36 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
     private val objects = project.objects
 
     /**
+     * Disables or enables the handling of Proguard mapping for Sentry.
+     * If enabled the plugin will generate a UUID and will take care of
+     * uploading the mapping to Sentry. If disabled, all the logic
+     * related to proguard mapping will be excluded.
+     * Default is enabled.
+     *
+     * @see [autoUpload]
+     * @see [autoUploadProguardMapping]
+     */
+    val includeProguardMapping: Property<Boolean> = objects
+        .property(Boolean::class.java).convention(true)
+
+    /**
      * Whether the plugin should attempt to auto-upload the mapping file to Sentry or not.
      * If disabled the plugin will run a dry-run.
      * Default is enabled.
      */
-    val autoUpload: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+    val autoUploadProguardMapping: Property<Boolean> = objects
+        .property(Boolean::class.java).convention(true)
+
+    /**
+     * Whether the plugin should attempt to auto-upload the mapping file to Sentry or not.
+     * If disabled the plugin will run a dry-run.
+     * Default is enabled.
+     */
+    @Deprecated(
+        "Use autoUploadProguardMapping instead",
+        replaceWith = ReplaceWith("autoUploadProguardMapping")
+    )
+    val autoUpload: Property<Boolean> = autoUploadProguardMapping
 
     /**
      * Disables or enables the automatic configuration of Native Symbols

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -48,7 +48,7 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
     abstract val sentryProject: Property<String>
 
     @get:Input
-    abstract val autoUpload: Property<Boolean>
+    abstract val autoUploadProguardMapping: Property<Boolean>
 
     override fun exec() {
         if (!mappingsFiles.isPresent || mappingsFiles.get().isEmpty) {
@@ -81,7 +81,7 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
             mappingsFiles.get().files.first().toString()
         )
 
-        if (!autoUpload.get()) {
+        if (!autoUploadProguardMapping.get()) {
             args.add("--no-upload")
         }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -99,7 +99,7 @@ class SentryPluginTest(
                 }
 
                 sentry {
-                  autoUpload = false
+                  autoUploadProguardMapping = false
                   tracingInstrumentation {
                     enabled = false
                   }
@@ -164,6 +164,31 @@ class SentryPluginTest(
 
         assertThrows(AssertionError::class.java) {
             verifyProguardUuid(testProjectDir.root, variant = "debug", signed = false)
+        }
+    }
+
+    @Test
+    fun `does not include a UUID in the APK if includeProguardMapping is off`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+                plugins {
+                  id "com.android.application"
+                  id "io.sentry.android.gradle"
+                }
+
+                sentry {
+                  includeProguardMapping = false
+                }
+            """.trimIndent()
+        )
+
+        runner
+            .appendArguments(":app:assembleRelease")
+            .build()
+
+        assertThrows(AssertionError::class.java) {
+            verifyProguardUuid(testProjectDir.root)
         }
     }
 
@@ -243,7 +268,7 @@ class SentryPluginTest(
                 }
 
                 sentry {
-                  autoUpload = false
+                  autoUploadProguardMapping = false
                   uploadNativeSymbols = true
                   tracingInstrumentation {
                     enabled = false
@@ -262,7 +287,7 @@ class SentryPluginTest(
                   id "io.sentry.android.gradle"
                 }
                 sentry {
-                  autoUpload = true
+                  autoUploadProguardMapping = true
                   ignoredVariants = ["$ignoredVariant"]
                   tracingInstrumentation {
                     enabled = false
@@ -282,7 +307,7 @@ class SentryPluginTest(
                 }
 
                 sentry {
-                  autoUpload = false
+                  autoUploadProguardMapping = false
                   tracingInstrumentation {
                     enabled = $tracingInstrumentation
                   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
@@ -184,7 +184,7 @@ class SentryPluginVariantTest(
                 }
 
                 sentry {
-                  autoUpload = false
+                  autoUploadProguardMapping = false
                   ignoredVariants = [$variants]
                   ignoredBuildTypes = [$buildTypes]
                   ignoredFlavors = [$flavors]

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
@@ -37,7 +37,7 @@ class SentryUploadProguardMappingTaskTest {
                 it.cliExecutable.set("sentry-cli")
                 it.uuidDirectory.set(tempDir.root)
                 it.mappingsFiles = mappingFile
-                it.autoUpload.set(true)
+                it.autoUploadProguardMapping.set(true)
             }
 
         val args = task.get().computeCommandLineArgs()
@@ -63,7 +63,7 @@ class SentryUploadProguardMappingTaskTest {
                 it.cliExecutable.set("sentry-cli")
                 it.uuidDirectory.set(tempDir.root)
                 it.mappingsFiles = mappingFile
-                it.autoUpload.set(false)
+                it.autoUploadProguardMapping.set(false)
             }
 
         val args = task.get().computeCommandLineArgs()
@@ -118,7 +118,7 @@ class SentryUploadProguardMappingTaskTest {
                 it.cliExecutable.set("sentry-cli")
                 it.uuidDirectory.set(tempDir.root)
                 it.mappingsFiles = mappingFile
-                it.autoUpload.set(false)
+                it.autoUploadProguardMapping.set(false)
                 it.sentryOrganization.set("dummy-org")
             }
 
@@ -141,7 +141,7 @@ class SentryUploadProguardMappingTaskTest {
                 it.cliExecutable.set("sentry-cli")
                 it.uuidDirectory.set(tempDir.root)
                 it.mappingsFiles = mappingFile
-                it.autoUpload.set(false)
+                it.autoUploadProguardMapping.set(false)
                 it.sentryProject.set("dummy-proj")
             }
 

--- a/plugin-build/src/test/resources/testFixtures/appTestProject/app/build.gradle
+++ b/plugin-build/src/test/resources/testFixtures/appTestProject/app/build.gradle
@@ -4,5 +4,5 @@ plugins {
 }
 
 sentry {
-    autoUpload = false
+    autoUploadProguardMapping = false
 }


### PR DESCRIPTION
## :scroll: Description
This PR essentially includes two changes:
1. Add the `includeProguardMapping` to exclude all the Proguard related code (defaulted to true).
2. Deprecate `autoUpload` in favor of `autoUploadProguardMapping`.

If this lands the documentation should be updated as well.

## :bulb: Motivation and Context
* Fixes #238 

## :green_heart: How did you test it?
Unit tests are attached.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

To be precise there is a breaking change in the Task API but IIRC that's not a major deal as we don't expect users to use the task directly.