### PR TITLE
feat: Add sentry-android sdk version check

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,6 +26,9 @@ object Libs {
     const val SQLITE = "androidx.sqlite:sqlite:${LibsVersion.SQLITE}"
     const val SQLITE_FRAMEWORK = "androidx.sqlite:sqlite-framework:${LibsVersion.SQLITE}"
     const val SENTRY_ANDROID = "io.sentry:sentry-android:${LibsVersion.SENTRY}"
+
+    // test
+    val MOCKITO_KOTLIN = "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
 }
 
 object CI {

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(Libs.AGP)
     testImplementation(Libs.JUNIT)
+    testImplementation(Libs.MOCKITO_KOTLIN)
 
     testImplementation(Libs.ASM)
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -79,6 +79,9 @@ class SentryPlugin : Plugin<Project> {
                         params.debug.setDisallowChanges(
                             extension.tracingInstrumentation.debug.get()
                         )
+                        params.features.setDisallowChanges(
+                            extension.tracingInstrumentation.features.get()
+                        )
                         params.sdkStateFile.set(
                             project.file(
                                 File(project.buildDir, buildSdkStateFilePath(variant.name))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -24,13 +24,13 @@ import io.sentry.android.gradle.util.SentryPluginUtils.capitalizeUS
 import io.sentry.android.gradle.util.SentryPluginUtils.withLogging
 import io.sentry.android.gradle.util.getSentryAndroidSdkState
 import io.sentry.android.gradle.util.info
+import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.tasks.TaskProvider
 import org.slf4j.LoggerFactory
-import java.io.File
 
 @Suppress("UnstableApiUsage")
 class SentryPlugin : Plugin<Project> {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
@@ -3,12 +3,12 @@ package io.sentry.android.gradle
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFactory) {
     /**
      * Enable the tracing instrumentation.
-     * Does bytecode manipulation for 'androidx.sqlite' and 'androidx.room' libraries.
-     * It starts and finishes a Span within any CRUD operation performed by sqlite or room.
+     * Does bytecode manipulation for specified [features].
      * Defaults to true.
      */
     val enabled: Property<Boolean> = objects.property(Boolean::class.java)
@@ -31,4 +31,33 @@ open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFa
      */
     val forceInstrumentDependencies: Property<Boolean> = objects.property(Boolean::class.java)
         .convention(false)
+
+    /**
+     * Specifies a set of [InstrumentationFeature] features that are eligible for bytecode
+     * manipulation.
+     * Defaults to all available features of [InstrumentationFeature].
+     */
+    val features: SetProperty<InstrumentationFeature> =
+        objects.setProperty(InstrumentationFeature::class.java).convention(
+            setOf(
+                InstrumentationFeature.DATABASE,
+                InstrumentationFeature.FILE_IO
+            )
+        )
+}
+
+enum class InstrumentationFeature {
+    /**
+     * When enabled the SDK will create spans for any CRUD operation performed by 'androidx.sqlite'
+     * and 'androidx.room'. This feature uses bytecode manipulation.
+     */
+    DATABASE,
+
+    /**
+     * When enabled the SDK will create spans for [java.io.FileInputStream],
+     * [java.io.FileOutputStream], [java.io.FileReader], [java.io.FileWriter].
+     * This feature uses bytecode manipulation and replaces the above
+     * mentioned classes with Sentry-specific implementations.
+     */
+    FILE_IO
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/Instrumentable.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/Instrumentable.kt
@@ -3,9 +3,9 @@
 package io.sentry.android.gradle.instrumentation
 
 import com.android.build.api.instrumentation.ClassContext
+import java.io.Serializable
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
-import java.io.Serializable
 
 interface Instrumentable<Visitor, InstrumentableContext> : Serializable {
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/Instrumentable.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/Instrumentable.kt
@@ -5,8 +5,9 @@ package io.sentry.android.gradle.instrumentation
 import com.android.build.api.instrumentation.ClassContext
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
+import java.io.Serializable
 
-interface Instrumentable<Visitor, InstrumentableContext> {
+interface Instrumentable<Visitor, InstrumentableContext> : Serializable {
 
     /**
      * Fully-qualified name of the instrumentable. Examples:

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -68,6 +68,11 @@ abstract class SpanAddingClassVisitorFactory :
                 SentryAndroidSdkState::class.java
             )
             SentryPlugin.logger.info { "Read sentry-android sdk state: $sdkState" }
+            /**
+             * When adding a new instrumentable to the list below, do not forget to add a new
+             * version range to [SentryAndroidSdkState.from], if it involves runtime classes
+             * from the sentry-android SDK.
+             */
             val instrumentables = listOfNotNull(
                 AndroidXSQLiteDatabase().takeIf { sdkState.isAtLeast(PERFORMANCE) },
                 AndroidXSQLiteStatement().takeIf { sdkState.isAtLeast(PERFORMANCE) },

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -14,7 +14,6 @@ import io.sentry.android.gradle.instrumentation.wrap.WrappingInstrumentable
 import io.sentry.android.gradle.util.SentryAndroidSdkState
 import io.sentry.android.gradle.util.SentryAndroidSdkState.FILE_IO
 import io.sentry.android.gradle.util.SentryAndroidSdkState.PERFORMANCE
-import io.sentry.android.gradle.util.error
 import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.warn
 import java.io.File

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -60,7 +60,6 @@ abstract class SpanAddingClassVisitorFactory :
         get() {
             val memoized = parameters.get()._instrumentables
             if (memoized != null) {
-                SentryPlugin.logger.info { "Memoized: ${memoized.joinToString()}" }
                 return memoized
             }
 
@@ -77,7 +76,6 @@ abstract class SpanAddingClassVisitorFactory :
                     listOf(WrappingInstrumentable(), RemappingInstrumentable())
                 ).takeIf { sdkState.isAtLeast(FILE_IO) }
             )
-            SentryPlugin.logger.info { "Instrumentables: ${instrumentables.joinToString()}" }
             parameters.get()._instrumentables = ArrayList(instrumentables)
             return instrumentables
         }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -4,18 +4,28 @@ import com.android.build.api.instrumentation.AsmClassVisitorFactory
 import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
+import com.android.build.gradle.internal.cxx.json.readJsonFile
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.database.AndroidXSQLiteDatabase
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.statement.AndroidXSQLiteStatement
 import io.sentry.android.gradle.instrumentation.remap.RemappingInstrumentable
 import io.sentry.android.gradle.instrumentation.wrap.WrappingInstrumentable
+import io.sentry.android.gradle.util.SentryAndroidSdkState
+import io.sentry.android.gradle.util.SentryAndroidSdkState.FILE_IO
+import io.sentry.android.gradle.util.SentryAndroidSdkState.PERFORMANCE
+import io.sentry.android.gradle.util.error
+import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.warn
 import java.io.File
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.objectweb.asm.ClassVisitor
 
 @Suppress("UnstableApiUsage")
@@ -36,20 +46,42 @@ abstract class SpanAddingClassVisitorFactory :
         @get:Input
         val debug: Property<Boolean>
 
+        @get:PathSensitive(value = PathSensitivity.NONE)
+        @get:InputFile
+        val sdkStateFile: RegularFileProperty
+
         @get:Internal
         val tmpDir: Property<File>
+
+        @get:Internal
+        var _instrumentables: List<ClassInstrumentable>?
     }
 
-    companion object {
-        private val instrumentables: List<ClassInstrumentable> = listOf(
-            AndroidXSQLiteDatabase(),
-            AndroidXSQLiteStatement(),
-            AndroidXRoomDao(),
-            ChainedInstrumentable(
-                listOf(WrappingInstrumentable(), RemappingInstrumentable())
+    private val instrumentables: List<ClassInstrumentable>
+        get() {
+            val memoized = parameters.get()._instrumentables
+            if (memoized != null) {
+                SentryPlugin.logger.info { "Memoized: ${memoized.joinToString()}" }
+                return memoized
+            }
+
+            val sdkState = readJsonFile(
+                parameters.get().sdkStateFile.get().asFile,
+                SentryAndroidSdkState::class.java
             )
-        )
-    }
+            SentryPlugin.logger.error { "Read sentry-android sdk state: $sdkState" }
+            val instrumentables = listOfNotNull(
+                AndroidXSQLiteDatabase().takeIf { sdkState.isAtLeast(PERFORMANCE) },
+                AndroidXSQLiteStatement().takeIf { sdkState.isAtLeast(PERFORMANCE) },
+                AndroidXRoomDao().takeIf { sdkState.isAtLeast(PERFORMANCE) },
+                ChainedInstrumentable(
+                    listOf(WrappingInstrumentable(), RemappingInstrumentable())
+                ).takeIf { sdkState.isAtLeast(FILE_IO) }
+            )
+            SentryPlugin.logger.info { "Instrumentables: ${instrumentables.joinToString()}" }
+            parameters.get()._instrumentables = ArrayList(instrumentables)
+            return instrumentables
+        }
 
     override fun createClassVisitor(
         classContext: ClassContext,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -53,7 +53,7 @@ abstract class SpanAddingClassVisitorFactory :
         val tmpDir: Property<File>
 
         @get:Internal
-        var _instrumentables: ArrayList<ClassInstrumentable>?
+        var _instrumentables: List<ClassInstrumentable>?
     }
 
     private val instrumentables: List<ClassInstrumentable>

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -54,7 +54,7 @@ abstract class SpanAddingClassVisitorFactory :
         val tmpDir: Property<File>
 
         @get:Internal
-        var _instrumentables: List<ClassInstrumentable>?
+        var _instrumentables: ArrayList<ClassInstrumentable>?
     }
 
     private val instrumentables: List<ClassInstrumentable>
@@ -69,7 +69,7 @@ abstract class SpanAddingClassVisitorFactory :
                 parameters.get().sdkStateFile.get().asFile,
                 SentryAndroidSdkState::class.java
             )
-            SentryPlugin.logger.error { "Read sentry-android sdk state: $sdkState" }
+            SentryPlugin.logger.info { "Read sentry-android sdk state: $sdkState" }
             val instrumentables = listOfNotNull(
                 AndroidXSQLiteDatabase().takeIf { sdkState.isAtLeast(PERFORMANCE) },
                 AndroidXSQLiteStatement().takeIf { sdkState.isAtLeast(PERFORMANCE) },

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -5,6 +5,7 @@ import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
 import com.android.build.gradle.internal.cxx.json.readJsonFile
+import io.sentry.android.gradle.InstrumentationFeature
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.database.AndroidXSQLiteDatabase
@@ -14,11 +15,13 @@ import io.sentry.android.gradle.instrumentation.wrap.WrappingInstrumentable
 import io.sentry.android.gradle.util.SentryAndroidSdkState
 import io.sentry.android.gradle.util.SentryAndroidSdkState.FILE_IO
 import io.sentry.android.gradle.util.SentryAndroidSdkState.PERFORMANCE
+import io.sentry.android.gradle.util.debug
 import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.warn
 import java.io.File
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -45,6 +48,9 @@ abstract class SpanAddingClassVisitorFactory :
         @get:Input
         val debug: Property<Boolean>
 
+        @get:Input
+        val features: SetProperty<InstrumentationFeature>
+
         @get:PathSensitive(value = PathSensitivity.NONE)
         @get:InputFile
         val sdkStateFile: RegularFileProperty
@@ -60,6 +66,9 @@ abstract class SpanAddingClassVisitorFactory :
         get() {
             val memoized = parameters.get()._instrumentables
             if (memoized != null) {
+                SentryPlugin.logger.debug {
+                    "Memoized: ${memoized.joinToString { it::class.java.simpleName }}"
+                }
                 return memoized
             }
 
@@ -74,16 +83,37 @@ abstract class SpanAddingClassVisitorFactory :
              * from the sentry-android SDK.
              */
             val instrumentables = listOfNotNull(
-                AndroidXSQLiteDatabase().takeIf { sdkState.isAtLeast(PERFORMANCE) },
-                AndroidXSQLiteStatement().takeIf { sdkState.isAtLeast(PERFORMANCE) },
-                AndroidXRoomDao().takeIf { sdkState.isAtLeast(PERFORMANCE) },
+                AndroidXSQLiteDatabase().takeIf {
+                    isDatabaseInstrEnabled(sdkState, parameters.get())
+                },
+                AndroidXSQLiteStatement().takeIf {
+                    isDatabaseInstrEnabled(sdkState, parameters.get())
+                },
+                AndroidXRoomDao().takeIf { isDatabaseInstrEnabled(sdkState, parameters.get()) },
                 ChainedInstrumentable(
                     listOf(WrappingInstrumentable(), RemappingInstrumentable())
-                ).takeIf { sdkState.isAtLeast(FILE_IO) }
+                ).takeIf { isFileIOInstrEnabled(sdkState, parameters.get()) }
             )
+            SentryPlugin.logger.debug {
+                "Instrumentables: ${instrumentables.joinToString { it::class.java.simpleName }}"
+            }
             parameters.get()._instrumentables = ArrayList(instrumentables)
             return instrumentables
         }
+
+    private fun isDatabaseInstrEnabled(
+        sdkState: SentryAndroidSdkState,
+        parameters: SpanAddingParameters
+    ): Boolean =
+        sdkState.isAtLeast(PERFORMANCE) &&
+            parameters.features.get().contains(InstrumentationFeature.DATABASE)
+
+    private fun isFileIOInstrEnabled(
+        sdkState: SentryAndroidSdkState,
+        parameters: SpanAddingParameters
+    ): Boolean =
+        sdkState.isAtLeast(FILE_IO) &&
+            parameters.features.get().contains(InstrumentationFeature.FILE_IO)
 
     override fun createClassVisitor(
         classContext: ClassContext,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
@@ -48,7 +48,7 @@ private fun Set<ResolvedDependency>.findSentryAndroidSdk(): String? {
     val queue = LinkedList(this)
     while (queue.isNotEmpty()) {
         val dep = queue.remove()
-        if (dep.moduleGroup == "io.sentry" && dep.moduleName == "sentry-android") {
+        if (dep.moduleGroup == "io.sentry" && dep.moduleName == "sentry-android-core") {
             return dep.moduleVersion
         }
         queue.addAll(dep.children)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
@@ -1,0 +1,56 @@
+package io.sentry.android.gradle.util
+
+import java.util.LinkedList
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolvedDependency
+
+fun Project.getSentryAndroidSdkState(
+    configurationName: String,
+    variantName: String
+): SentryAndroidSdkState {
+    val configuration = configurations.findByName(configurationName)
+
+    if (configuration == null) {
+        logger.warn {
+            "Unable to find configuration $configurationName for variant $variantName."
+        }
+        return SentryAndroidSdkState.MISSING
+    }
+
+    val resolvedConfiguration = configuration.resolvedConfiguration
+    if (resolvedConfiguration.hasError()) {
+        resolvedConfiguration.rethrowFailure()
+        logger.warn { "Unable to resolve configuration $configurationName." }
+        return SentryAndroidSdkState.MISSING
+    }
+
+    val deps = resolvedConfiguration.firstLevelModuleDependencies
+    val version = deps.findSentryAndroidSdk()
+    if (version != null) {
+        val sdkState = try {
+            SentryAndroidSdkState.from(version)
+        } catch (e: IllegalStateException) {
+            logger.warn { e.localizedMessage }
+            SentryAndroidSdkState.MISSING
+        }
+        logger.error {
+            "Detected sentry-android $sdkState for version: $version, " +
+                "variant: $variantName, config: $configurationName"
+        }
+        return sdkState
+    }
+    logger.warn { "Unable to detect sentry-android dependency" }
+    return SentryAndroidSdkState.MISSING
+}
+
+private fun Set<ResolvedDependency>.findSentryAndroidSdk(): String? {
+    val queue = LinkedList(this)
+    while (queue.isNotEmpty()) {
+        val dep = queue.remove()
+        if (dep.moduleGroup == "io.sentry" && dep.moduleName == "sentry-android") {
+            return dep.moduleVersion
+        }
+        queue.addAll(dep.children)
+    }
+    return null
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
@@ -26,21 +26,22 @@ fun Project.getSentryAndroidSdkState(
 
     val deps = resolvedConfiguration.firstLevelModuleDependencies
     val version = deps.findSentryAndroidSdk()
-    if (version != null) {
-        return try {
-            val sdkState = SentryAndroidSdkState.from(version)
-            logger.info {
-                "Detected sentry-android $sdkState for version: $version, " +
-                    "variant: $variantName, config: $configurationName"
-            }
-            sdkState
-        } catch (e: IllegalStateException) {
-            logger.warn { e.localizedMessage }
-            SentryAndroidSdkState.MISSING
-        }
+    if (version == null) {
+        logger.warn { "sentry-android dependency was not found." }
+        return SentryAndroidSdkState.MISSING
     }
-    logger.warn { "Unable to detect sentry-android dependency" }
-    return SentryAndroidSdkState.MISSING
+
+    return try {
+        val sdkState = SentryAndroidSdkState.from(version)
+        logger.info {
+            "Detected sentry-android $sdkState for version: $version, " +
+                "variant: $variantName, config: $configurationName"
+        }
+        sdkState
+    } catch (e: IllegalStateException) {
+        logger.warn { e.localizedMessage }
+        SentryAndroidSdkState.MISSING
+    }
 }
 
 private fun Set<ResolvedDependency>.findSentryAndroidSdk(): String? {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.gradle.util
 
-import java.util.LinkedList
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedDependency
+import java.util.LinkedList
 
 fun Project.getSentryAndroidSdkState(
     configurationName: String,
@@ -27,17 +27,17 @@ fun Project.getSentryAndroidSdkState(
     val deps = resolvedConfiguration.firstLevelModuleDependencies
     val version = deps.findSentryAndroidSdk()
     if (version != null) {
-        val sdkState = try {
-            SentryAndroidSdkState.from(version)
+        return try {
+            val sdkState = SentryAndroidSdkState.from(version)
+            logger.info {
+                "Detected sentry-android $sdkState for version: $version, " +
+                    "variant: $variantName, config: $configurationName"
+            }
+            sdkState
         } catch (e: IllegalStateException) {
             logger.warn { e.localizedMessage }
             SentryAndroidSdkState.MISSING
         }
-        logger.error {
-            "Detected sentry-android $sdkState for version: $version, " +
-                "variant: $variantName, config: $configurationName"
-        }
-        return sdkState
     }
     logger.warn { "Unable to detect sentry-android dependency" }
     return SentryAndroidSdkState.MISSING

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.gradle.util
 
+import java.util.LinkedList
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedDependency
-import java.util.LinkedList
 
 fun Project.getSentryAndroidSdkState(
     configurationName: String,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkState.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkState.kt
@@ -1,0 +1,23 @@
+package io.sentry.android.gradle.util
+
+import java.io.Serializable
+
+enum class SentryAndroidSdkState(val minVersion: String) : Serializable {
+    MISSING(""),
+
+    PERFORMANCE("4.0.0"),
+
+    FILE_IO("5.5.0");
+
+    fun isAtLeast(state: SentryAndroidSdkState): Boolean = this.ordinal >= state.ordinal
+
+    companion object {
+        fun from(semVer: String): SentryAndroidSdkState =
+            when {
+                semVer < PERFORMANCE.minVersion -> MISSING
+                semVer >= PERFORMANCE.minVersion && semVer < FILE_IO.minVersion -> PERFORMANCE
+                semVer >= FILE_IO.minVersion -> FILE_IO
+                else -> error("Unknown version $semVer of sentry-android")
+            }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkState.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkState.kt
@@ -12,8 +12,13 @@ enum class SentryAndroidSdkState(val minVersion: String) : Serializable {
     fun isAtLeast(state: SentryAndroidSdkState): Boolean = this.ordinal >= state.ordinal
 
     companion object {
+        val semverRegex =
+            Regex("((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)")
+
         fun from(semVer: String): SentryAndroidSdkState =
             when {
+                semVer == "unspecified" -> MISSING
+                !semverRegex.matches(semVer) -> error("Unknown version $semVer of sentry-android")
                 semVer < PERFORMANCE.minVersion -> MISSING
                 semVer >= PERFORMANCE.minVersion && semVer < FILE_IO.minVersion -> PERFORMANCE
                 semVer >= FILE_IO.minVersion -> FILE_IO

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkState.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkState.kt
@@ -12,8 +12,12 @@ enum class SentryAndroidSdkState(val minVersion: String) : Serializable {
     fun isAtLeast(state: SentryAndroidSdkState): Boolean = this.ordinal >= state.ordinal
 
     companion object {
+        /* ktlint-disable max-line-length */
         val semverRegex =
-            Regex("((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)")
+            Regex(
+                "((([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)"
+            )
+        /* ktlint-enable max-line-length */
 
         fun from(semVer: String): SentryAndroidSdkState =
             when {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryPluginTest.kt
@@ -1,0 +1,111 @@
+package io.sentry.android.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.junit.runners.Parameterized
+import java.io.File
+
+@Suppress("FunctionName")
+abstract class BaseSentryPluginTest(
+    private val androidGradlePluginVersion: String,
+    private val gradleVersion: String
+) {
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    private val projectTemplateFolder = File("src/test/resources/testFixtures/appTestProject")
+
+    private lateinit var rootBuildFile: File
+    protected lateinit var appBuildFile: File
+    protected lateinit var runner: GradleRunner
+
+    abstract val additionalRootProjectConfig: String
+
+    @Before
+    fun setup() {
+        projectTemplateFolder.copyRecursively(testProjectDir.root)
+
+        val pluginClasspath = PluginUnderTestMetadataReading.readImplementationClasspath()
+            .joinToString(separator = ", ") { "\"$it\"" }
+            .replace(File.separator, "/")
+
+        appBuildFile = File(testProjectDir.root, "app/build.gradle")
+        rootBuildFile = testProjectDir.writeFile("build.gradle") {
+            // language=Groovy
+            """
+            buildscript {
+              repositories {
+                google()
+                gradlePluginPortal()
+              }
+              dependencies {
+                classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
+                // This is needed to populate the plugin classpath instead of using
+                // withPluginClasspath on the Gradle Runner.
+                classpath files($pluginClasspath)
+              }
+            }
+
+            allprojects {
+              repositories {
+                google()
+                mavenCentral()
+              }
+            }
+            subprojects {
+              pluginManager.withPlugin('com.android.application') {
+                android {
+                  compileSdkVersion 30
+                  defaultConfig {
+                    applicationId "com.example"
+                    minSdkVersion 21
+                  }
+                  buildTypes {
+                    release {
+                      minifyEnabled true
+                      proguardFiles("src/release/proguard-rules.pro")
+                    }
+                  }
+                  $additionalRootProjectConfig
+                }
+              }
+            }
+            """.trimIndent()
+        }
+
+        runner = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments("--stacktrace")
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+    }
+
+    companion object {
+
+        @Parameterized.Parameters(name = "AGP {0}, Gradle {1}")
+        @JvmStatic
+        fun parameters() = listOf(
+            // The supported Gradle version can be found here:
+            // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+            // The pair is [AGP Version, Gradle Version]
+            arrayOf("7.0.3", "7.0.2"),
+            arrayOf("7.0.3", "7.1.1"),
+            arrayOf("7.0.3", "7.2"),
+            arrayOf("7.1.0-beta01", "7.2"),
+            arrayOf("7.2.0-alpha01", "7.2")
+        )
+
+        internal fun GradleRunner.appendArguments(vararg arguments: String) =
+            withArguments(this.arguments + arguments)
+
+        private fun TemporaryFolder.writeFile(fileName: String, text: () -> String): File {
+            val file = File(root, fileName)
+            file.parentFile.mkdirs()
+            file.writeText(text())
+            return file
+        }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryPluginTest.kt
@@ -1,12 +1,12 @@
 package io.sentry.android.gradle
 
+import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runners.Parameterized
-import java.io.File
 
 @Suppress("FunctionName")
 abstract class BaseSentryPluginTest(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
@@ -2,11 +2,11 @@ package io.sentry.android.gradle
 
 import com.android.build.gradle.internal.cxx.json.readJsonFile
 import io.sentry.android.gradle.util.SentryAndroidSdkState
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @Suppress("FunctionName")
 @RunWith(Parameterized::class)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
@@ -1,0 +1,122 @@
+package io.sentry.android.gradle
+
+import com.android.build.gradle.internal.cxx.json.readJsonFile
+import io.sentry.android.gradle.util.SentryAndroidSdkState
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Suppress("FunctionName")
+@RunWith(Parameterized::class)
+class SentryPluginCheckAndroidSdkTest(
+    androidGradlePluginVersion: String,
+    gradleVersion: String
+) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
+
+    override val additionalRootProjectConfig: String = ""
+
+    @Test
+    fun `when tracingInstrumentation is disabled does not check sentry-android sdk state`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            sentry.tracingInstrumentation.enabled = false
+            """.trimIndent()
+        )
+
+        runner
+            .appendArguments("app:tasks")
+            .build()
+        val sdkStateFile = testProjectDir.root
+            .resolve("app/build/${SentryPlugin.buildSdkStateFilePath("debug")}")
+        assertFalse { sdkStateFile.exists() }
+    }
+
+    @Test
+    fun `when tracingInstrumentation is enabled checks sentry-android sdk state`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            sentry.tracingInstrumentation.enabled = true
+            sentry.includeProguardMapping = false
+            """.trimIndent()
+        )
+
+        runner
+            .appendArguments("app:tasks")
+            .build()
+        val sdkStateFile = testProjectDir.root
+            .resolve("app/build/${SentryPlugin.buildSdkStateFilePath("debug")}")
+        assertTrue {
+            sdkStateFile.exists() &&
+                readJsonFile(
+                    sdkStateFile,
+                    SentryAndroidSdkState::class.java
+                ) == SentryAndroidSdkState.MISSING
+        }
+    }
+
+    @Test
+    fun `respects variant configuration`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            sentry {
+              tracingInstrumentation.enabled = true
+              includeProguardMapping = false
+            }
+
+            configurations {
+              debugImplementation
+              releaseImplementation
+            }
+
+            dependencies {
+              debugImplementation 'io.sentry:sentry-android:5.4.0'
+              releaseImplementation 'io.sentry:sentry-android:5.5.0'
+            }
+            """.trimIndent()
+        )
+
+        runner
+            .appendArguments("app:tasks")
+            .build()
+
+        val sdkStateFileDebug = testProjectDir.root
+            .resolve("app/build/${SentryPlugin.buildSdkStateFilePath("debug")}")
+        val sdkStateFileRelease = testProjectDir.root
+            .resolve("app/build/${SentryPlugin.buildSdkStateFilePath("release")}")
+
+        assertTrue {
+            sdkStateFileDebug.exists() &&
+                readJsonFile(
+                    sdkStateFileDebug,
+                    SentryAndroidSdkState::class.java
+                ) == SentryAndroidSdkState.PERFORMANCE
+        }
+        assertTrue {
+            sdkStateFileRelease.exists() &&
+                readJsonFile(
+                    sdkStateFileRelease,
+                    SentryAndroidSdkState::class.java
+                ) == SentryAndroidSdkState.FILE_IO
+        }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -1,92 +1,20 @@
 package io.sentry.android.gradle
 
-import java.io.File
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-import org.junit.Assert.assertThrows
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
 @Suppress("FunctionName")
 @RunWith(Parameterized::class)
 class SentryPluginTest(
-    private val androidGradlePluginVersion: String,
-    private val gradleVersion: String
-) {
-    @get:Rule
-    val testProjectDir = TemporaryFolder()
-
-    private val projectTemplateFolder = File("src/test/resources/testFixtures/appTestProject")
-
-    private lateinit var rootBuildFile: File
-    private lateinit var appBuildFile: File
-    private lateinit var runner: GradleRunner
-
-    @Before
-    fun setup() {
-        projectTemplateFolder.copyRecursively(testProjectDir.root)
-
-        val pluginClasspath = PluginUnderTestMetadataReading.readImplementationClasspath()
-            .joinToString(separator = ", ") { "\"$it\"" }
-            .replace(File.separator, "/")
-
-        appBuildFile = File(testProjectDir.root, "app/build.gradle")
-        rootBuildFile = testProjectDir.writeFile("build.gradle") {
-            // language=Groovy
-            """
-            buildscript {
-              repositories {
-                google()
-                gradlePluginPortal()
-              }
-              dependencies {
-                classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
-                // This is needed to populate the plugin classpath instead of using
-                // withPluginClasspath on the Gradle Runner.
-                classpath files($pluginClasspath)
-              }
-            }
-
-            allprojects {
-              repositories {
-                google()
-                mavenCentral()
-              }
-            }
-            subprojects {
-              pluginManager.withPlugin('com.android.application') {
-                android {
-                  compileSdkVersion 30
-                  defaultConfig {
-                    applicationId "com.example"
-                    minSdkVersion 21
-                  }
-                  buildTypes {
-                    release {
-                      minifyEnabled true
-                      proguardFiles("src/release/proguard-rules.pro")
-                    }
-                  }
-                }
-              }
-            }
-            """.trimIndent()
-        }
-
-        runner = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments("--stacktrace")
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-    }
+    androidGradlePluginVersion: String,
+    gradleVersion: String
+): BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
 
     @Test
     fun `plugin can be applied`() {
@@ -316,29 +244,5 @@ class SentryPluginTest(
         )
     }
 
-    companion object {
-
-        @Parameterized.Parameters(name = "AGP {0}, Gradle {1}")
-        @JvmStatic
-        fun parameters() = listOf(
-            // The supported Gradle version can be found here:
-            // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
-            // The pair is [AGP Version, Gradle Version]
-            arrayOf("7.0.3", "7.0.2"),
-            arrayOf("7.0.3", "7.1.1"),
-            arrayOf("7.0.3", "7.2"),
-            arrayOf("7.1.0-beta01", "7.2"),
-            arrayOf("7.2.0-alpha01", "7.2")
-        )
-
-        private fun GradleRunner.appendArguments(vararg arguments: String) =
-            withArguments(this.arguments + arguments)
-
-        private fun TemporaryFolder.writeFile(fileName: String, text: () -> String): File {
-            val file = File(root, fileName)
-            file.parentFile.mkdirs()
-            file.writeText(text())
-            return file
-        }
-    }
+    override val additionalRootProjectConfig: String = ""
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -1,20 +1,20 @@
 package io.sentry.android.gradle
 
-import org.junit.Assert.assertThrows
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 @Suppress("FunctionName")
 @RunWith(Parameterized::class)
 class SentryPluginTest(
     androidGradlePluginVersion: String,
     gradleVersion: String
-): BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
+) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
 
     @Test
     fun `plugin can be applied`() {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -186,6 +186,49 @@ class SentryPluginTest(
         assertTrue(":app:transformReleaseClassesWithAsm" in build.output)
     }
 
+    @Test
+    fun `applies only DB instrumentables when only DATABASE feature enabled`() {
+        applyTracingInstrumentation(features = setOf(InstrumentationFeature.DATABASE))
+
+        val build = runner
+            .appendArguments(":app:assembleDebug", "--debug")
+            .build()
+
+        assertTrue {
+            "[sentry] Instrumentables: AndroidXSQLiteDatabase, AndroidXSQLiteStatement," +
+                " AndroidXRoomDao" in build.output
+        }
+    }
+
+    @Test
+    fun `applies only FILE_IO instrumentables when only FILE_IO feature enabled`() {
+        applyTracingInstrumentation(features = setOf(InstrumentationFeature.FILE_IO))
+
+        val build = runner
+            .appendArguments(":app:assembleDebug", "--debug")
+            .build()
+
+        assertTrue {
+            "[sentry] Instrumentables: ChainedInstrumentable" in build.output
+        }
+    }
+
+    @Test
+    fun `applies all instrumentables when all features enabled`() {
+        applyTracingInstrumentation(
+            features = setOf(InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO)
+        )
+
+        val build = runner
+            .appendArguments(":app:assembleDebug", "--debug")
+            .build()
+
+        assertTrue {
+            "[sentry] Instrumentables: AndroidXSQLiteDatabase, AndroidXSQLiteStatement," +
+                " AndroidXRoomDao, ChainedInstrumentable" in build.output
+        }
+    }
+
     private fun applyUploadNativeSymbols() {
         appBuildFile.writeText(
             // language=Groovy
@@ -225,7 +268,10 @@ class SentryPluginTest(
         )
     }
 
-    private fun applyTracingInstrumentation(tracingInstrumentation: Boolean = true) {
+    private fun applyTracingInstrumentation(
+        tracingInstrumentation: Boolean = true,
+        features: Set<InstrumentationFeature> = setOf()
+    ) {
         appBuildFile.writeText(
             // language=Groovy
             """
@@ -234,10 +280,20 @@ class SentryPluginTest(
                   id "io.sentry.android.gradle"
                 }
 
+                dependencies {
+                  implementation 'io.sentry:sentry-android:5.5.0'
+                }
+
                 sentry {
                   autoUploadProguardMapping = false
                   tracingInstrumentation {
                     enabled = $tracingInstrumentation
+                    features = ${
+            features.joinToString(
+                prefix = "[",
+                postfix = "]"
+            ) { "${it::class.java.canonicalName}.${it.name}" }
+            }
                   }
                 }
             """.trimIndent()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle
 
+import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -7,7 +8,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import java.io.File
 
 @Suppress("FunctionName")
 @RunWith(Parameterized::class)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginVariantTest.kt
@@ -1,98 +1,34 @@
 package io.sentry.android.gradle
 
-import java.io.File
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import java.io.File
 
 @Suppress("FunctionName")
 @RunWith(Parameterized::class)
 class SentryPluginVariantTest(
-    private val androidGradlePluginVersion: String,
-    private val gradleVersion: String
-) {
-    @get:Rule
-    val testProjectDir = TemporaryFolder()
+    androidGradlePluginVersion: String,
+    gradleVersion: String
+) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
 
-    private val projectTemplateFolder = File("src/test/resources/testFixtures/appTestProject")
-
-    private lateinit var rootBuildFile: File
-    private lateinit var appBuildFile: File
-    private lateinit var runner: GradleRunner
-
-    @Before
-    fun setup() {
-        projectTemplateFolder.copyRecursively(testProjectDir.root)
-
-        val pluginClasspath = PluginUnderTestMetadataReading.readImplementationClasspath()
-            .joinToString(separator = ", ") { "\"$it\"" }
-            .replace(File.separator, "/")
-
-        appBuildFile = File(testProjectDir.root, "app/build.gradle")
-        rootBuildFile = testProjectDir.writeFile("build.gradle") {
-            // language=Groovy
-            """
-            buildscript {
-              repositories {
-                google()
-                gradlePluginPortal()
-              }
-              dependencies {
-                classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
-                // This is needed to populate the plugin classpath instead of using
-                // withPluginClasspath on the Gradle Runner.
-                classpath files($pluginClasspath)
-              }
+    override val additionalRootProjectConfig: String =
+        // language=Groovy
+        """
+          flavorDimensions "version"
+          productFlavors {
+            create("demo") {
+                applicationIdSuffix = ".demo"
             }
-
-            allprojects {
-              repositories {
-                google()
-                mavenCentral()
-              }
+            create("full") {
+                applicationIdSuffix = ".full"
             }
-            subprojects {
-              pluginManager.withPlugin('com.android.application') {
-                android {
-                  compileSdkVersion 30
-                  defaultConfig {
-                    applicationId "com.example"
-                    minSdkVersion 21
-                  }
-                  buildTypes {
-                    release {
-                      minifyEnabled true
-                      proguardFiles("src/release/proguard-rules.pro")
-                    }
-                  }
-                  flavorDimensions "version"
-                  productFlavors {
-                    create("demo") {
-                        applicationIdSuffix = ".demo"
-                    }
-                    create("full") {
-                        applicationIdSuffix = ".full"
-                    }
-                  }
-                }
-              }
-            }
-            """.trimIndent()
-        }
-
-        runner = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments("--stacktrace")
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-    }
+          }
+        """.trimIndent()
 
     @Test
     fun `skips variant if set with ignoredVariants`() {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/BaseTestLogger.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/BaseTestLogger.kt
@@ -4,7 +4,6 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.slf4j.Marker
 
-
 abstract class BaseTestLogger : Logger {
 
     override fun isTraceEnabled(): Boolean = true

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/BaseTestLogger.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/BaseTestLogger.kt
@@ -1,7 +1,9 @@
 package io.sentry.android.gradle.instrumentation.fakes
 
-import org.slf4j.Logger
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
 import org.slf4j.Marker
+
 
 abstract class BaseTestLogger : Logger {
 
@@ -124,4 +126,28 @@ abstract class BaseTestLogger : Logger {
     override fun error(marker: Marker, msg: String, vararg args: Any) = Unit
 
     override fun error(marker: Marker, msg: String, throwable: Throwable?) = Unit
+
+    override fun isLifecycleEnabled(): Boolean = true
+
+    override fun lifecycle(message: String?) = Unit
+
+    override fun lifecycle(message: String?, vararg objects: Any?) = Unit
+
+    override fun lifecycle(message: String?, throwable: Throwable?) = Unit
+
+    override fun isQuietEnabled(): Boolean = true
+
+    override fun quiet(message: String?) = Unit
+
+    override fun quiet(message: String?, vararg objects: Any?) = Unit
+
+    override fun quiet(message: String?, throwable: Throwable?) = Unit
+
+    override fun isEnabled(level: LogLevel?): Boolean = true
+
+    override fun log(level: LogLevel?, message: String?) = Unit
+
+    override fun log(level: LogLevel?, message: String?, vararg objects: Any?) = Unit
+
+    override fun log(level: LogLevel?, message: String?, throwable: Throwable?) = Unit
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -1,15 +1,31 @@
 package io.sentry.android.gradle.instrumentation.fakes
 
+import io.sentry.android.gradle.instrumentation.ClassInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
-import java.io.File
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.file.DefaultFileCollectionFactory
+import org.gradle.api.internal.file.DefaultFileLookup
+import org.gradle.api.internal.file.DefaultFilePropertyFactory
+import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.PropertyHost
+import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.util.internal.PatternSets
+import org.gradle.internal.nativeintegration.services.FileSystems
+import org.gradle.internal.nativeintegration.services.NativeServices
+import java.io.File
 
 class TestSpanAddingParameters(
     private val debugOutput: Boolean = true,
-    private val inMemoryDir: File
+    private val inMemoryDir: File,
+    private val _sdkStateFile: File = File(inMemoryDir, "sdk-state.json")
 ) : SpanAddingClassVisitorFactory.SpanAddingParameters {
+
+    init {
+        NativeServices.initializeOnDaemon(inMemoryDir)
+    }
 
     override val invalidate: Property<Long>
         get() = DefaultProperty(PropertyHost.NO_OP, Long::class.java).convention(0L)
@@ -18,6 +34,30 @@ class TestSpanAddingParameters(
         get() = DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType)
             .convention(debugOutput)
 
+    override val sdkStateFile: RegularFileProperty
+        get() = filePropertyFactory.newFileProperty().value(filePropertyFactory.file(_sdkStateFile))
+
     override val tmpDir: Property<File>
         get() = DefaultProperty<File>(PropertyHost.NO_OP, File::class.java).convention(inMemoryDir)
+
+    override var _instrumentables: ArrayList<ClassInstrumentable>? = ArrayList()
+
+    private val fileLookup: DefaultFileLookup = DefaultFileLookup()
+
+    private val fileCollectionFactory: FileCollectionFactory =
+        DefaultFileCollectionFactory(
+            fileLookup.pathToFileResolver,
+            DefaultTaskDependencyFactory.withNoAssociatedProject(),
+            DefaultDirectoryFileTreeFactory(),
+            PatternSets.getNonCachingPatternSetFactory(),
+            PropertyHost.NO_OP,
+            FileSystems.getDefault()
+        )
+
+    private val filePropertyFactory: DefaultFilePropertyFactory =
+        DefaultFilePropertyFactory(
+            PropertyHost.NO_OP,
+            fileLookup.fileResolver,
+            fileCollectionFactory
+        )
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -40,7 +40,7 @@ class TestSpanAddingParameters(
     override val tmpDir: Property<File>
         get() = DefaultProperty<File>(PropertyHost.NO_OP, File::class.java).convention(inMemoryDir)
 
-    override var _instrumentables: ArrayList<ClassInstrumentable>? = ArrayList()
+    override var _instrumentables: List<ClassInstrumentable>? = listOf()
 
     private val fileLookup: DefaultFileLookup = DefaultFileLookup()
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -2,6 +2,7 @@ package io.sentry.android.gradle.instrumentation.fakes
 
 import io.sentry.android.gradle.instrumentation.ClassInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
+import java.io.File
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.file.DefaultFileCollectionFactory
 import org.gradle.api.internal.file.DefaultFileLookup
@@ -15,7 +16,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.internal.nativeintegration.services.FileSystems
 import org.gradle.internal.nativeintegration.services.NativeServices
-import java.io.File
 
 class TestSpanAddingParameters(
     private val debugOutput: Boolean = true,

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.instrumentation.fakes
 
+import io.sentry.android.gradle.InstrumentationFeature
 import io.sentry.android.gradle.instrumentation.ClassInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import java.io.File
@@ -10,9 +11,11 @@ import org.gradle.api.internal.file.DefaultFilePropertyFactory
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.DefaultSetProperty
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.internal.nativeintegration.services.FileSystems
 import org.gradle.internal.nativeintegration.services.NativeServices
@@ -33,6 +36,10 @@ class TestSpanAddingParameters(
     override val debug: Property<Boolean>
         get() = DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType)
             .convention(debugOutput)
+
+    override val features: SetProperty<InstrumentationFeature>
+        get() = DefaultSetProperty(PropertyHost.NO_OP, InstrumentationFeature::class.java)
+            .convention(setOf(InstrumentationFeature.FILE_IO, InstrumentationFeature.DATABASE))
 
     override val sdkStateFile: RegularFileProperty
         get() = filePropertyFactory.newFileProperty().value(filePropertyFactory.file(_sdkStateFile))

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -92,7 +92,7 @@ class SentryAndroidSdkCheckerTest {
         assertTrue { state == SentryAndroidSdkState.MISSING }
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] Unable to detect sentry-android dependency"
+                "[sentry] sentry-android dependency was not found."
         }
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -100,7 +100,7 @@ class SentryAndroidSdkCheckerTest {
     fun `sentry-android as a local dependency - logs a info and returns MISSING state`() {
         val sentryAndroidDep = mock<ResolvedDependency>()
         whenever(sentryAndroidDep.moduleGroup).doReturn("io.sentry")
-        whenever(sentryAndroidDep.moduleName).doReturn("sentry-android")
+        whenever(sentryAndroidDep.moduleName).doReturn("sentry-android-core")
         // this is the case when sentry-android is a local dependency
         whenever(sentryAndroidDep.moduleVersion).doReturn("unspecified")
 
@@ -119,7 +119,7 @@ class SentryAndroidSdkCheckerTest {
     fun `sentry-android performance version - logs a info and returns PERFORMANCE state`() {
         val sentryAndroidDep = mock<ResolvedDependency>()
         whenever(sentryAndroidDep.moduleGroup).doReturn("io.sentry")
-        whenever(sentryAndroidDep.moduleName).doReturn("sentry-android")
+        whenever(sentryAndroidDep.moduleName).doReturn("sentry-android-core")
         whenever(sentryAndroidDep.moduleVersion).doReturn("4.1.0")
 
         val state = fixture.getSut(testProjectDir.root, dependencies = setOf(sentryAndroidDep))
@@ -136,12 +136,12 @@ class SentryAndroidSdkCheckerTest {
     @Test
     fun `sentry-android transitive - logs a info and returns FILE_IO state`() {
         val firstLevelDep = mock<ResolvedDependency>()
-        whenever(firstLevelDep.moduleGroup).doReturn("dev.random")
-        whenever(firstLevelDep.moduleName).doReturn("random-module")
+        whenever(firstLevelDep.moduleGroup).doReturn("io.sentry")
+        whenever(firstLevelDep.moduleName).doReturn("sentry-android")
 
         val transitiveSentryDep = mock<ResolvedDependency>()
         whenever(transitiveSentryDep.moduleGroup).doReturn("io.sentry")
-        whenever(transitiveSentryDep.moduleName).doReturn("sentry-android")
+        whenever(transitiveSentryDep.moduleName).doReturn("sentry-android-core")
         whenever(transitiveSentryDep.moduleVersion).doReturn("5.5.0")
         whenever(firstLevelDep.children).thenReturn(setOf(transitiveSentryDep))
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -5,6 +5,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
+import java.io.File
+import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedConfiguration
@@ -13,8 +15,6 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
-import kotlin.test.assertTrue
 
 class SentryAndroidSdkCheckerTest {
 
@@ -81,7 +81,7 @@ class SentryAndroidSdkCheckerTest {
     }
 
     @Test
-    fun `sentry-android is not in the dependencies list - logs a warning and returns MISSING state`() {
+    fun `sentry-android is not in the dependencies - logs a warning and returns MISSING state`() {
         val sqliteDep = mock<ResolvedDependency>()
         whenever(sqliteDep.moduleGroup).doReturn("androidx.sqlite")
         whenever(sqliteDep.moduleName).doReturn("sqlite")
@@ -101,7 +101,8 @@ class SentryAndroidSdkCheckerTest {
         val sentryAndroidDep = mock<ResolvedDependency>()
         whenever(sentryAndroidDep.moduleGroup).doReturn("io.sentry")
         whenever(sentryAndroidDep.moduleName).doReturn("sentry-android")
-        whenever(sentryAndroidDep.moduleVersion).doReturn("unspecified") // this is the case when sentry-android is a local dependency
+        // this is the case when sentry-android is a local dependency
+        whenever(sentryAndroidDep.moduleVersion).doReturn("unspecified")
 
         val state = fixture.getSut(testProjectDir.root, dependencies = setOf(sentryAndroidDep))
             .getSentryAndroidSdkState(fixture.configurationName, fixture.variantName)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -1,0 +1,157 @@
+package io.sentry.android.gradle.util
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertTrue
+
+class SentryAndroidSdkCheckerTest {
+
+    class Fixture {
+
+        private val configuration: Configuration = mock()
+        private val resolvedConfiguration: ResolvedConfiguration = mock()
+
+        val configurationName: String = "debugRuntimeClasspath"
+        val variantName: String = "debug"
+
+        val logger = CapturingTestLogger()
+
+        fun getSut(
+            tmpDir: File,
+            resolveConfigurationError: Boolean = false,
+            dependencies: Set<ResolvedDependency> = emptySet()
+        ): Project {
+            whenever(configuration.name).thenReturn(configurationName)
+            whenever(configuration.resolvedConfiguration).thenReturn(resolvedConfiguration)
+            whenever(resolvedConfiguration.firstLevelModuleDependencies).thenReturn(dependencies)
+            whenever(resolvedConfiguration.hasError()).thenReturn(resolveConfigurationError)
+
+            val fakeProject = ProjectBuilder
+                .builder()
+                .withProjectDir(tmpDir)
+                .build()
+
+            val project = spy(fakeProject)
+            whenever(project.logger).thenReturn(logger)
+            project.configurations.add(configuration)
+
+            return project
+        }
+    }
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `configuration cannot be found - logs a warning and returns MISSING state`() {
+        val state = fixture.getSut(testProjectDir.root)
+            .getSentryAndroidSdkState("releaseRuntimeClasspath", "release")
+
+        assertTrue { state == SentryAndroidSdkState.MISSING }
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "[sentry] Unable to find configuration releaseRuntimeClasspath for variant release."
+        }
+    }
+
+    @Test
+    fun `resolvedConfiguration has error - logs a warning and returns MISSING state`() {
+        val state = fixture.getSut(testProjectDir.root, true)
+            .getSentryAndroidSdkState(fixture.configurationName, fixture.variantName)
+
+        assertTrue { state == SentryAndroidSdkState.MISSING }
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "[sentry] Unable to resolve configuration debugRuntimeClasspath."
+        }
+    }
+
+    @Test
+    fun `sentry-android is not in the dependencies list - logs a warning and returns MISSING state`() {
+        val sqliteDep = mock<ResolvedDependency>()
+        whenever(sqliteDep.moduleGroup).doReturn("androidx.sqlite")
+        whenever(sqliteDep.moduleName).doReturn("sqlite")
+
+        val state = fixture.getSut(testProjectDir.root, dependencies = setOf(sqliteDep))
+            .getSentryAndroidSdkState(fixture.configurationName, fixture.variantName)
+
+        assertTrue { state == SentryAndroidSdkState.MISSING }
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "[sentry] Unable to detect sentry-android dependency"
+        }
+    }
+
+    @Test
+    fun `sentry-android as a local dependency - logs a info and returns MISSING state`() {
+        val sentryAndroidDep = mock<ResolvedDependency>()
+        whenever(sentryAndroidDep.moduleGroup).doReturn("io.sentry")
+        whenever(sentryAndroidDep.moduleName).doReturn("sentry-android")
+        whenever(sentryAndroidDep.moduleVersion).doReturn("unspecified") // this is the case when sentry-android is a local dependency
+
+        val state = fixture.getSut(testProjectDir.root, dependencies = setOf(sentryAndroidDep))
+            .getSentryAndroidSdkState(fixture.configurationName, fixture.variantName)
+
+        assertTrue { state == SentryAndroidSdkState.MISSING }
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "[sentry] Detected sentry-android MISSING for version: unspecified, " +
+                "variant: debug, config: debugRuntimeClasspath"
+        }
+    }
+
+    @Test
+    fun `sentry-android performance version - logs a info and returns PERFORMANCE state`() {
+        val sentryAndroidDep = mock<ResolvedDependency>()
+        whenever(sentryAndroidDep.moduleGroup).doReturn("io.sentry")
+        whenever(sentryAndroidDep.moduleName).doReturn("sentry-android")
+        whenever(sentryAndroidDep.moduleVersion).doReturn("4.1.0")
+
+        val state = fixture.getSut(testProjectDir.root, dependencies = setOf(sentryAndroidDep))
+            .getSentryAndroidSdkState(fixture.configurationName, fixture.variantName)
+
+        assertTrue { state == SentryAndroidSdkState.PERFORMANCE }
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "[sentry] Detected sentry-android PERFORMANCE for version: 4.1.0, " +
+                "variant: debug, config: debugRuntimeClasspath"
+        }
+    }
+
+    @Test
+    fun `sentry-android transitive - logs a info and returns FILE_IO state`() {
+        val firstLevelDep = mock<ResolvedDependency>()
+        whenever(firstLevelDep.moduleGroup).doReturn("dev.random")
+        whenever(firstLevelDep.moduleName).doReturn("random-module")
+
+        val transitiveSentryDep = mock<ResolvedDependency>()
+        whenever(transitiveSentryDep.moduleGroup).doReturn("io.sentry")
+        whenever(transitiveSentryDep.moduleName).doReturn("sentry-android")
+        whenever(transitiveSentryDep.moduleVersion).doReturn("5.5.0")
+        whenever(firstLevelDep.children).thenReturn(setOf(transitiveSentryDep))
+
+        val state = fixture.getSut(testProjectDir.root, dependencies = setOf(firstLevelDep))
+            .getSentryAndroidSdkState(fixture.configurationName, fixture.variantName)
+
+        assertTrue { state == SentryAndroidSdkState.FILE_IO }
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "[sentry] Detected sentry-android FILE_IO for version: 5.5.0, " +
+                "variant: debug, config: debugRuntimeClasspath"
+        }
+    }
+}

--- a/plugin-build/src/test/resources/testFixtures/appTestProject/gradle.properties
+++ b/plugin-build/src/test/resources/testFixtures/appTestProject/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx512m -XX\:MaxMetaspaceSize\=512m
+
+android.useAndroidX=true


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
Add a sentry-android SDK version check in the projects.afterevaluate step

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is necessary to avoid breaking customers' code at runtime, for instance, if they are using an older version of `sentry-android` which does not contain file I/O runtime classes. So we just disable the auto-instrumentation features based on the main SDK version

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
