### PR TITLE
feat: Auto-Instrumentation features configuration

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -79,6 +79,9 @@ class SentryPlugin : Plugin<Project> {
                         params.debug.setDisallowChanges(
                             extension.tracingInstrumentation.debug.get()
                         )
+                        params.features.setDisallowChanges(
+                            extension.tracingInstrumentation.features.get()
+                        )
                         params.sdkStateFile.set(
                             project.file(
                                 File(project.buildDir, buildSdkStateFilePath(variant.name))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
@@ -54,10 +54,10 @@ enum class InstrumentationFeature {
     DATABASE,
 
     /**
-     * When enabled the SDK will replace [java.io.FileInputStream], [java.io.FileOutputStream],
-     * [java.io.FileReader], [java.io.FileWriter] with Sentry-specific implementations of those.
-     * It starts and finishes a Span within a File I/O operation performed in a target app.
-     * This feature uses bytecode manipulation.
+     * When enabled the SDK will create spans for [java.io.FileInputStream],
+     * [java.io.FileOutputStream], [java.io.FileReader], [java.io.FileWriter].
+     * This feature uses bytecode manipulation and replaces the above
+     * mentioned classes with Sentry-specific implementations.
      */
     FILE_IO
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
@@ -3,12 +3,12 @@ package io.sentry.android.gradle
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFactory) {
     /**
      * Enable the tracing instrumentation.
-     * Does bytecode manipulation for 'androidx.sqlite' and 'androidx.room' libraries.
-     * It starts and finishes a Span within any CRUD operation performed by sqlite or room.
+     * Does bytecode manipulation for specified [features].
      * Defaults to true.
      */
     val enabled: Property<Boolean> = objects.property(Boolean::class.java)
@@ -31,4 +31,32 @@ open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFa
      */
     val forceInstrumentDependencies: Property<Boolean> = objects.property(Boolean::class.java)
         .convention(false)
+
+    /**
+     * Specifies a set of [InstrumentationFeature] features that are eligible for bytecode
+     * manipulation.
+     * Defaults to all available features of [InstrumentationFeature].
+     */
+    val features: SetProperty<InstrumentationFeature> =
+        objects.setProperty(InstrumentationFeature::class.java).convention(
+            setOf(
+                InstrumentationFeature.DATABASE,
+                InstrumentationFeature.FILE_IO
+            )
+        )
+}
+
+enum class InstrumentationFeature {
+    /**
+     * Does bytecode manipulation for 'androidx.sqlite' and 'androidx.room' libraries.
+     * It starts and finishes a Span within any CRUD operation performed by sqlite or room.
+     */
+    DATABASE,
+
+    /**
+     * Does bytecode manipulation, replacing [java.io.FileInputStream], [java.io.FileOutputStream],
+     * [java.io.FileReader], [java.io.FileWriter] with Sentry-specific implementations of those.
+     * It starts and finishes a Span within a File I/O operation performed in a target app.
+     */
+    FILE_IO
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/TracingInstrumentationExtension.kt
@@ -48,15 +48,16 @@ open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFa
 
 enum class InstrumentationFeature {
     /**
-     * Does bytecode manipulation for 'androidx.sqlite' and 'androidx.room' libraries.
-     * It starts and finishes a Span within any CRUD operation performed by sqlite or room.
+     * When enabled the SDK will create spans for any CRUD operation performed by 'androidx.sqlite'
+     * and 'androidx.room'. This feature uses bytecode manipulation.
      */
     DATABASE,
 
     /**
-     * Does bytecode manipulation, replacing [java.io.FileInputStream], [java.io.FileOutputStream],
+     * When enabled the SDK will replace [java.io.FileInputStream], [java.io.FileOutputStream],
      * [java.io.FileReader], [java.io.FileWriter] with Sentry-specific implementations of those.
      * It starts and finishes a Span within a File I/O operation performed in a target app.
+     * This feature uses bytecode manipulation.
      */
     FILE_IO
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -5,6 +5,7 @@ import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
 import com.android.build.gradle.internal.cxx.json.readJsonFile
+import io.sentry.android.gradle.InstrumentationFeature
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.database.AndroidXSQLiteDatabase
@@ -14,11 +15,13 @@ import io.sentry.android.gradle.instrumentation.wrap.WrappingInstrumentable
 import io.sentry.android.gradle.util.SentryAndroidSdkState
 import io.sentry.android.gradle.util.SentryAndroidSdkState.FILE_IO
 import io.sentry.android.gradle.util.SentryAndroidSdkState.PERFORMANCE
+import io.sentry.android.gradle.util.debug
 import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.warn
 import java.io.File
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -45,6 +48,9 @@ abstract class SpanAddingClassVisitorFactory :
         @get:Input
         val debug: Property<Boolean>
 
+        @get:Input
+        val features: SetProperty<InstrumentationFeature>
+
         @get:PathSensitive(value = PathSensitivity.NONE)
         @get:InputFile
         val sdkStateFile: RegularFileProperty
@@ -60,6 +66,9 @@ abstract class SpanAddingClassVisitorFactory :
         get() {
             val memoized = parameters.get()._instrumentables
             if (memoized != null) {
+                SentryPlugin.logger.debug {
+                    "Memoized: ${memoized.joinToString { it::class.java.simpleName }}"
+                }
                 return memoized
             }
 
@@ -69,16 +78,37 @@ abstract class SpanAddingClassVisitorFactory :
             )
             SentryPlugin.logger.info { "Read sentry-android sdk state: $sdkState" }
             val instrumentables = listOfNotNull(
-                AndroidXSQLiteDatabase().takeIf { sdkState.isAtLeast(PERFORMANCE) },
-                AndroidXSQLiteStatement().takeIf { sdkState.isAtLeast(PERFORMANCE) },
-                AndroidXRoomDao().takeIf { sdkState.isAtLeast(PERFORMANCE) },
+                AndroidXSQLiteDatabase().takeIf {
+                    isDatabaseInstrEnabled(sdkState, parameters.get())
+                },
+                AndroidXSQLiteStatement().takeIf {
+                    isDatabaseInstrEnabled(sdkState, parameters.get())
+                },
+                AndroidXRoomDao().takeIf { isDatabaseInstrEnabled(sdkState, parameters.get()) },
                 ChainedInstrumentable(
                     listOf(WrappingInstrumentable(), RemappingInstrumentable())
-                ).takeIf { sdkState.isAtLeast(FILE_IO) }
+                ).takeIf { isFileIOInstrEnabled(sdkState, parameters.get()) }
             )
+            SentryPlugin.logger.debug {
+                "Instrumentables: ${instrumentables.joinToString { it::class.java.simpleName }}"
+            }
             parameters.get()._instrumentables = ArrayList(instrumentables)
             return instrumentables
         }
+
+    private fun isDatabaseInstrEnabled(
+        sdkState: SentryAndroidSdkState,
+        parameters: SpanAddingParameters
+    ): Boolean =
+        sdkState.isAtLeast(PERFORMANCE) &&
+            parameters.features.get().contains(InstrumentationFeature.DATABASE)
+
+    private fun isFileIOInstrEnabled(
+        sdkState: SentryAndroidSdkState,
+        parameters: SpanAddingParameters
+    ): Boolean =
+        sdkState.isAtLeast(FILE_IO) &&
+            parameters.features.get().contains(InstrumentationFeature.FILE_IO)
 
     override fun createClassVisitor(
         classContext: ClassContext,

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -276,11 +276,11 @@ class SentryPluginTest(
                   tracingInstrumentation {
                     enabled = $tracingInstrumentation
                     features = ${
-                        features.joinToString(
-                            prefix = "[",
-                            postfix = "]"
-                        ) { "${it::class.java.canonicalName}.${it.name}" }
-                    }
+                features.joinToString(
+                    prefix = "[",
+                    postfix = "]"
+                ) { "${it::class.java.canonicalName}.${it.name}" }
+            }
                   }
                 }
             """.trimIndent()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -276,10 +276,10 @@ class SentryPluginTest(
                   tracingInstrumentation {
                     enabled = $tracingInstrumentation
                     features = ${
-                features.joinToString(
-                    prefix = "[",
-                    postfix = "]"
-                ) { "${it::class.java.canonicalName}.${it.name}" }
+            features.joinToString(
+                prefix = "[",
+                postfix = "]"
+            ) { "${it::class.java.canonicalName}.${it.name}" }
             }
                   }
                 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -201,6 +201,19 @@ class SentryPluginTest(
     }
 
     @Test
+    fun `applies only FILE_IO instrumentables when only FILE_IO feature enabled`() {
+        applyTracingInstrumentation(features = setOf(InstrumentationFeature.FILE_IO))
+
+        val build = runner
+            .appendArguments(":app:assembleDebug", "--debug")
+            .build()
+
+        assertTrue {
+            "[sentry] Instrumentables: ChainedInstrumentable" in build.output
+        }
+    }
+
+    @Test
     fun `applies all instrumentables when all features enabled`() {
         applyTracingInstrumentation(
             features = setOf(InstrumentationFeature.DATABASE, InstrumentationFeature.FILE_IO)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -276,11 +276,11 @@ class SentryPluginTest(
                   tracingInstrumentation {
                     enabled = $tracingInstrumentation
                     features = ${
-            features.joinToString(
-                prefix = "[",
-                postfix = "]"
-            ) { "${it::class.java.canonicalName}.${it.name}" }
-            }
+                        features.joinToString(
+                            prefix = "[",
+                            postfix = "]"
+                        ) { "${it::class.java.canonicalName}.${it.name}" }
+                    }
                   }
                 }
             """.trimIndent()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.instrumentation.fakes
 
+import io.sentry.android.gradle.InstrumentationFeature
 import io.sentry.android.gradle.instrumentation.ClassInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import java.io.File
@@ -10,9 +11,11 @@ import org.gradle.api.internal.file.DefaultFilePropertyFactory
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.DefaultSetProperty
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.util.internal.PatternSets
 import org.gradle.internal.nativeintegration.services.FileSystems
 import org.gradle.internal.nativeintegration.services.NativeServices
@@ -33,6 +36,10 @@ class TestSpanAddingParameters(
     override val debug: Property<Boolean>
         get() = DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType)
             .convention(debugOutput)
+
+    override val features: SetProperty<InstrumentationFeature>
+        get() = DefaultSetProperty(PropertyHost.NO_OP, InstrumentationFeature::class.java)
+            .convention(setOf(InstrumentationFeature.FILE_IO, InstrumentationFeature.DATABASE))
 
     override val sdkStateFile: RegularFileProperty
         get() = filePropertyFactory.newFileProperty().value(filePropertyFactory.file(_sdkStateFile))


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Adds new `features` configuration option under the `tracingInstrumentation` sub-extension. This allows specifying a set of features enabled for bytecode manipulation, currently only contains `FILE_IO` and `DATABASE` respectively.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
