### PR TITLE
Bump sentry-cli to 1.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Bump sentry-cli 1.72.0 which prevent daemonize mode from crashing upload process (#262)
+
 ## 3.0.0-beta.3
 
 * Introduce the `includeProguardMapping` option to exclude the proguard logic, and deprecate `autoUpload` in favor of `autoUploadProguardMapping` (#240)

--- a/plugin-build/download-sentry-cli.sh
+++ b/plugin-build/download-sentry-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd $(dirname "$0")
 REPO=getsentry/sentry-cli
-VERSION=1.70.0
+VERSION=1.72.0
 PLATFORMS="Darwin-universal Linux-i686 Linux-x86_64 Windows-i686"
 
 rm -f src/main/resources/bin/sentry-cli-*

--- a/plugin-build/expected-checksums.sha
+++ b/plugin-build/expected-checksums.sha
@@ -1,4 +1,4 @@
-3b98ef865243b39d72168b6119979d3aac9c3880  src/main/resources/bin/sentry-cli-Darwin-universal
-6546a1e3ffd57ac95aff4be85450e994d2e76cfc  src/main/resources/bin/sentry-cli-Linux-i686
-157caee85d1ecf106e42f00038e0351f832db23d  src/main/resources/bin/sentry-cli-Linux-x86_64
-796447a1b682c078fa79720f0501488680918a13  src/main/resources/bin/sentry-cli-Windows-i686.exe
+3c71bab6aaf69c3f212d2c326ce50b539141e7ba  src/main/resources/bin/sentry-cli-Darwin-universal
+0cb60f0d0ba097a6477ebc940a7663954aa56b1b  src/main/resources/bin/sentry-cli-Linux-i686
+1a460287bf66df38dbcdacf75b8e428c9976644b  src/main/resources/bin/sentry-cli-Linux-x86_64
+22e07c62656b5fae564805e80f67b4d6862ef2c4  src/main/resources/bin/sentry-cli-Windows-i686.exe


### PR DESCRIPTION
## :scroll: Description
As the title says, this bumps the CLI to 1.72.0

## :bulb: Motivation and Context
Fixes #260 

## :green_heart: How did you test it?
Will wait for a green CI,

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] No breaking changes