### PR TITLE
Add Support for Dexguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Fix: Strip out unsupported java classes from META-INF/ (so AGP does not fail before our code is reached) (#264)
 * Bump sentry-cli 1.72.0 which prevent daemonize mode from crashing upload process (#262)
 * Fix: Incompatibilities with other Gradle plugins using the same API from AGP for bytecode instrumentation (#270)
+* Feature: Add support for GuardSquare's Proguard (#263)
+* Feature: Add support for GuardSquare's Dexguard (#267)
 
 ## 3.0.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,13 @@
 ## Unreleased
 
 * Feature: Add support for GuardSquare's Proguard (#263)
+* Feature: Add support for GuardSquare's Dexguard (#267)
 
 ## 3.0.0-beta.4
 
 * Fix: Strip out unsupported java classes from META-INF/ (so AGP does not fail before our code is reached) (#264)
 * Bump sentry-cli 1.72.0 which prevent daemonize mode from crashing upload process (#262)
 * Fix: Incompatibilities with other Gradle plugins using the same API from AGP for bytecode instrumentation (#270)
-* Feature: Add support for GuardSquare's Proguard (#263)
-* Feature: Add support for GuardSquare's Dexguard (#267)
 
 ## 3.0.0-beta.3
 

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version BuildPluginsVersion.KOTLIN
     id("distribution")
+    id("groovy")
     id("org.jetbrains.dokka") version BuildPluginsVersion.DOKKA
     id("java-gradle-plugin")
     id("com.vanniktech.maven.publish") version BuildPluginsVersion.MAVEN_PUBLISH apply false
@@ -65,9 +66,18 @@ configure<JavaPluginExtension> {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+// We need to compile Groovy first and let Kotlin depend on it.
+// See https://docs.gradle.org/6.1-rc-1/release-notes.html#compilation-order
+tasks.withType<GroovyCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    classpath = sourceSets["main"].compileClasspath
+}
+
 tasks.withType<KotlinCompile>().configureEach {
     sourceCompatibility = JavaVersion.VERSION_1_8.toString()
     targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    classpath += files(sourceSets["main"].groovy.classesDirectory)
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()

--- a/plugin-build/src/main/groovy/io/sentry/android/gradle/util/GroovyCompat.groovy
+++ b/plugin-build/src/main/groovy/io/sentry/android/gradle/util/GroovyCompat.groovy
@@ -1,0 +1,38 @@
+package io.sentry.android.gradle.util
+
+import org.gradle.api.Project
+
+/**
+ * Contains functions which exploit Groovy's metaprogramming to provide backwards
+ * compatibility for older AGP versions that would be impractical to achieve with
+ * Kotlin's static type system.
+ *
+ * Adapted under MIT license from:
+ * https://github.com/bugsnag/bugsnag-android-gradle-plugin/blob/master/src/main/groovy/com/bugsnag/android/gradle/GroovyCompat.groovy
+ */
+class GroovyCompat {
+
+    static boolean isDexguardAvailable(Project project) {
+        return project.extensions.findByName("dexguard") != null
+    }
+
+    static boolean isDexguardEnabledForVariant(Project project, String variantName) {
+        def dexguard = project.extensions.findByName("dexguard")
+
+        try {
+            if (dexguard == null) {
+                return null
+            }
+
+            if (dexguard.configurations != null) {
+                return dexguard.configurations.findByName(variantName) != null
+            } else {
+                // no configurations = assume all variants configured
+                return true
+            }
+        } catch (MissingPropertyException ignored) {
+            // running earlier version of DexGuard, ignore missing property
+            return false
+        }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -100,7 +100,7 @@ internal object SentryTasksProvider {
                 )
             )
         } else {
-            // For DexGuard the mapping file can either be inside the /apk or the /aab folder
+            // For DexGuard the mapping file can either be inside the /apk or the /bundle folder
             // (depends on the task that generated it).
             val mappingDir = "outputs${sep}dexguard${sep}mapping$sep"
             project.files(
@@ -110,7 +110,7 @@ internal object SentryTasksProvider {
                 ),
                 File(
                     project.buildDir,
-                    "${mappingDir}aab${sep}${variant.name}${sep}mapping.txt"
+                    "${mappingDir}bundle${sep}${variant.name}${sep}mapping.txt"
                 )
             )
         }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -88,36 +88,35 @@ internal object SentryTasksProvider {
     fun getMappingFileProvider(
         project: Project,
         variant: ApplicationVariant
-    ): Provider<FileCollection> = if (project.plugins.hasPlugin("com.guardsquare.proguard") ||
-        isDexguardAvailable(project)
-    ) {
-        val sep = File.separator
-        val fileCollection = if (project.plugins.hasPlugin("com.guardsquare.proguard")) {
-            project.files(
-                File(
-                    project.buildDir,
-                    "outputs${sep}proguard${sep}${variant.name}${sep}mapping${sep}mapping.txt"
+    ): Provider<FileCollection> =
+        if (project.plugins.hasPlugin("com.guardsquare.proguard") || isDexguardAvailable(project)) {
+            val sep = File.separator
+            val fileCollection = if (project.plugins.hasPlugin("com.guardsquare.proguard")) {
+                project.files(
+                    File(
+                        project.buildDir,
+                        "outputs${sep}proguard${sep}${variant.name}${sep}mapping${sep}mapping.txt"
+                    )
                 )
-            )
+            } else {
+                // For DexGuard the mapping file can either be inside the /apk or the /bundle folder
+                // (depends on the task that generated it).
+                val mappingDir = "outputs${sep}dexguard${sep}mapping$sep"
+                project.files(
+                    File(
+                        project.buildDir,
+                        "${mappingDir}apk${sep}${variant.name}${sep}mapping.txt"
+                    ),
+                    File(
+                        project.buildDir,
+                        "${mappingDir}bundle${sep}${variant.name}${sep}mapping.txt"
+                    )
+                )
+            }
+            project.provider { fileCollection }
         } else {
-            // For DexGuard the mapping file can either be inside the /apk or the /bundle folder
-            // (depends on the task that generated it).
-            val mappingDir = "outputs${sep}dexguard${sep}mapping$sep"
-            project.files(
-                File(
-                    project.buildDir,
-                    "${mappingDir}apk${sep}${variant.name}${sep}mapping.txt"
-                ),
-                File(
-                    project.buildDir,
-                    "${mappingDir}bundle${sep}${variant.name}${sep}mapping.txt"
-                )
-            )
+            variant.mappingFileProvider
         }
-        project.provider { fileCollection }
-    } else {
-        variant.mappingFileProvider
-    }
 
     /**
      * Returns the package provider

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -92,12 +92,29 @@ internal object SentryTasksProvider {
         isDexguardAvailable(project)
     ) {
         val sep = File.separator
-        val path = if (project.plugins.hasPlugin("com.guardsquare.proguard")) {
-            "outputs${sep}proguard${sep}${variant.name}${sep}mapping${sep}mapping.txt"
+        val fileCollection = if (project.plugins.hasPlugin("com.guardsquare.proguard")) {
+            project.files(
+                File(
+                    project.buildDir,
+                    "outputs${sep}proguard${sep}${variant.name}${sep}mapping${sep}mapping.txt"
+                )
+            )
         } else {
-            "outputs${sep}dexguard${sep}mapping${sep}apk${sep}${variant.name}${sep}mapping.txt"
+            // For DexGuard the mapping file can either be inside the /apk or the /aab folder
+            // (depends on the task that generated it).
+            val mappingDir = "outputs${sep}dexguard${sep}mapping$sep"
+            project.files(
+                File(
+                    project.buildDir,
+                    "${mappingDir}apk${sep}${variant.name}${sep}mapping.txt"
+                ),
+                File(
+                    project.buildDir,
+                    "${mappingDir}aab${sep}${variant.name}${sep}mapping.txt"
+                )
+            )
         }
-        project.provider { project.files(File(project.buildDir, path)) }
+        project.provider { fileCollection }
     } else {
         variant.mappingFileProvider
     }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -73,12 +73,24 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
 
     internal fun computeCommandLineArgs(): List<String> {
         val uuid = readUuidFromFile(uuidFile.get().asFile)
+        val firstExistingFile = mappingsFiles.get().files.firstOrNull { it.exists() }
+
+        val mappingFile = if (firstExistingFile == null) {
+            logger.warn(
+                "None of the provided mappingFiles was found on disk. " +
+                    "Upload is most likely going to be skipped"
+            )
+            mappingsFiles.get().files.first()
+        } else {
+            firstExistingFile
+        }
+
         val args = mutableListOf(
             cliExecutable.get(),
             "upload-proguard",
             "--uuid",
             uuid,
-            mappingsFiles.get().files.first().toString()
+            mappingFile.toString()
         )
 
         if (!autoUploadProguardMapping.get()) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
@@ -1,7 +1,7 @@
 package io.sentry.android.gradle.util
 
 import com.android.build.gradle.api.ApplicationVariant
-import io.sentry.android.gradle.util.GroovyCompat.*
+import io.sentry.android.gradle.util.GroovyCompat.isDexguardEnabledForVariant
 import java.util.Locale
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle.util
 
 import com.android.build.gradle.api.ApplicationVariant
+import io.sentry.android.gradle.util.GroovyCompat.*
 import java.util.Locale
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -33,6 +34,10 @@ internal object SentryPluginUtils {
             val variantConfiguration = proguardExtension.configurations.findByName(variant.name)
             isConfiguredWithGuardsquareProguard = variantConfiguration != null
         }
-        return isConfiguredWithGuardsquareProguard || variant.buildType.isMinifyEnabled
+        val isConfiguredWithGuardsquareDexguard = isDexguardEnabledForVariant(project, variant.name)
+
+        return isConfiguredWithGuardsquareProguard ||
+            isConfiguredWithGuardsquareDexguard ||
+            variant.buildType.isMinifyEnabled
     }
 }

--- a/scripts/add-sentry-to-iosched.patch
+++ b/scripts/add-sentry-to-iosched.patch
@@ -159,4 +159,15 @@ index 4ef510596..305667f23 100644
      fun info_basicViewsDisplayed() {
          // Title
          onView(allOf(instanceOf(TextView::class.java), withParent(ViewMatchers.withId(id.toolbar))))
-
+diff --git a/gradle/wrapper/gradle-wrapper.properties b/gradle/wrapper/gradle-wrapper.properties
+index 618a75bbd..c3ffc3aca 100644
+--- a/gradle/wrapper/gradle-wrapper.properties
++++ b/gradle/wrapper/gradle-wrapper.properties
+@@ -1,6 +1,6 @@
+ #Wed Feb 10 08:38:31 CET 2021
+ distributionBase=GRADLE_USER_HOME
+-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
++distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+ distributionPath=wrapper/dists
+ zipStorePath=wrapper/dists
+ zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## :scroll: Description
This PR adds support for Dexguard (sits on top of #263 - so please consider only https://github.com/getsentry/sentry-android-gradle-plugin/commit/d297c1460b4a9b7ef4883c62a41c9301a38988d1)

There are a couple of things that are worth discussing:
- [x] I had to add a `project.afterEvaluate` as I could not query Dexguard tasks as I believe they're not properly using Gradle Configuration Avoidance.
- [x] The Dexguard Tasks are declaring dependencies on `package*` tasks. Therefore I had to change the `package*` tasks to depend on the `generateUuidTask`. I believe this should be fine.
- [x] `getMappingFileProvider` won't work correctly when building an AAB with DexGuard.

Before I spend more time on this, I'd like to get some input and feedback.

## :bulb: Motivation and Context
Fixes #60 

## :green_heart: How did you test it?
Due to the nature of this change, I've just tested it locally.

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes