### PR TITLE
fix: Do not rely on visitFrame calls 

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4608m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.workers.max=2
+
+kotlin.compiler.execution.strategy=in-process

--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,5 +1,0 @@
-org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx4608m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.workers.max=2
-
-kotlin.compiler.execution.strategy=in-process

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -15,12 +15,15 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
+    env:
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g"
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Copy CI gradle.properties
-        run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+#      - name: Copy CI gradle.properties
+#        run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Setup Java Version
         uses: actions/setup-java@v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
       - name: Setup Java Version
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,14 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g"
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4608m -XX:MaxMetaspaceSize=1024m"
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-
-#      - name: Copy CI gradle.properties
-#        run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Setup Java Version
         uses: actions/setup-java@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix: Strip out unsupported java classes from META-INF/ (so AGP does not fail before our code is reached) (#264)
 * Bump sentry-cli 1.72.0 which prevent daemonize mode from crashing upload process (#262)
+* Fix: Incompatibilities with other Gradle plugins using the same API from AGP for bytecode instrumentation (#228)
 
 ## 3.0.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix: Strip out unsupported java classes from META-INF/ (so AGP does not fail before our code is reached) (#264)
 * Bump sentry-cli 1.72.0 which prevent daemonize mode from crashing upload process (#262)
-* Fix: Incompatibilities with other Gradle plugins using the same API from AGP for bytecode instrumentation (#228)
+* Fix: Incompatibilities with other Gradle plugins using the same API from AGP for bytecode instrumentation (#270)
 
 ## 3.0.0-beta.3
 

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/data/TracksDao.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/data/TracksDao.kt
@@ -22,7 +22,7 @@ abstract class TracksDao {
     abstract fun allByArtist(bandName: String): List<Track>
 
     @Transaction
-    @Query("DELETE FROM Track")
+    @Query("SELECT COUNT(*) FROM Track")
     abstract suspend fun count(): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/room/visitor/RoomQueryVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/room/visitor/RoomQueryVisitor.kt
@@ -25,7 +25,6 @@ class RoomQueryVisitor(
     private val label9 = Label()
 
     private val labelsRemapTable = mutableMapOf<Label, Label>()
-    private var skipVarVisit = false
     private var finallyVisitCount = 0
 
     init {
@@ -69,45 +68,11 @@ class RoomQueryVisitor(
         // the original method does not have a catch block, but we add ours here
         if (remapped == label2 && !instrumenting.getAndSet(true)) {
             originalVisitor.visitCatchBlock(catchLabel = label2, throwLabel = label8)
+            originalVisitor.visitStoreException(handler = label3, end = label4)
             instrumenting.set(false)
         } else {
             super.visitLabel(remapped)
         }
-    }
-
-    override fun visitVarInsn(opcode: Int, `var`: Int) {
-        if (skipVarVisit) {
-            skipVarVisit = false
-            return
-        }
-        super.visitVarInsn(opcode, `var`)
-    }
-
-    override fun visitFrame(
-        type: Int,
-        numLocal: Int,
-        local: Array<out Any>?,
-        numStack: Int,
-        stack: Array<out Any>?
-    ) {
-        if (type == Opcodes.F_FULL || type == Opcodes.F_NEW) {
-            val hasThrowableOnStack = (stack?.getOrNull(0) as? String) == "java/lang/Throwable"
-
-            /**
-             * We visit the labels in case there's a Throwable on stack AND it's not a transaction:
-             *      - It's a query, and it's a finally block
-             */
-            if (hasThrowableOnStack) {
-                originalVisitor.visitLabel(label3)
-                super.visitFrame(type, numLocal, local, numStack, stack)
-                val exceptionIndex = nextLocal
-                originalVisitor.visitVarInsn(Opcodes.ASTORE, exceptionIndex)
-                originalVisitor.visitLabel(label4)
-                skipVarVisit = true
-                return
-            }
-        }
-        super.visitFrame(type, numLocal, local, numStack, stack)
     }
 
     override fun visitLocalVariable(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryPluginTest.kt
@@ -22,7 +22,8 @@ abstract class BaseSentryPluginTest(
     protected lateinit var appBuildFile: File
     protected lateinit var runner: GradleRunner
 
-    abstract val additionalRootProjectConfig: String
+    protected open val additionalRootProjectConfig: String = ""
+    protected open val additionalBuildClasspath: String = ""
 
     @Before
     fun setup() {
@@ -46,6 +47,7 @@ abstract class BaseSentryPluginTest(
                 // This is needed to populate the plugin classpath instead of using
                 // withPluginClasspath on the Gradle Runner.
                 classpath files($pluginClasspath)
+                $additionalBuildClasspath
               }
             }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
@@ -15,8 +15,6 @@ class SentryPluginCheckAndroidSdkTest(
     gradleVersion: String
 ) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
 
-    override val additionalRootProjectConfig: String = ""
-
     @Test
     fun `when tracingInstrumentation is disabled does not check sentry-android sdk state`() {
         appBuildFile.writeText(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -303,6 +303,4 @@ class SentryPluginTest(
             """.trimIndent()
         )
     }
-
-    override val additionalRootProjectConfig: String = ""
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginWithFirebaseTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginWithFirebaseTest.kt
@@ -1,0 +1,57 @@
+package io.sentry.android.gradle
+
+import kotlin.test.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class SentryPluginWithFirebaseTest(
+    androidGradlePluginVersion: String,
+    gradleVersion: String
+) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
+
+    @Test
+    fun `does not break when there is a firebase-perf plugin applied`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+              id "com.google.firebase.firebase-perf"
+            }
+
+            android {
+              buildTypes {
+                release {
+                  minifyEnabled = true
+                }
+              }
+            }
+
+            dependencies {
+              implementation 'io.sentry:sentry-android-core:5.6.0'
+              implementation 'androidx.work:work-runtime:2.5.0'
+            }
+
+            sentry {
+              autoUploadProguardMapping = false
+            }
+            """.trimIndent()
+        )
+
+        val result = runner
+            .appendArguments("app:assembleRelease")
+            .build()
+
+        print(result.output)
+
+        assertTrue { "BUILD SUCCESSFUL" in result.output }
+    }
+
+    override val additionalBuildClasspath: String =
+        """
+        classpath 'com.google.firebase:perf-plugin:1.4.1'
+        """.trimIndent()
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/VisitorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/VisitorTest.kt
@@ -58,7 +58,7 @@ class VisitorTest(
         )
         // here we visit the bytecode, so it gets modified by our instrumentation visitor
         // the ClassReader flags here are identical to those that are set by AGP and R8
-        classReader.accept(classVisitor, ClassReader.EXPAND_FRAMES)
+        classReader.accept(classVisitor, ClassReader.SKIP_FRAMES)
 
         // after that we convert the modified bytecode with computed MAXS back to byte array
         // and pass it through CheckClassAdapter to verify that the bytecode is correct and can be accepted by JVM


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Do not rely on `visitFrame` calls during instrumentation, as they can be skipped depending on flag set to the AGP (the flag can be overridden by any plugin doing bytecode transformation)
* Adapted VisitorTest to reflect AGP behavior
* Added integration test with firebase-perf plugin

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #228

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
