### PR TITLE
Add the `experimentalGuardsquareSupport` flag

### DIFF
--- a/examples/android-guardsquare-proguard/build.gradle
+++ b/examples/android-guardsquare-proguard/build.gradle
@@ -43,6 +43,8 @@ proguard {
 sentry {
     autoUploadProguardMapping = CI.INSTANCE.canAutoUpload()
 
+    experimentalGuardsquareSupport = true
+
     tracingInstrumentation {
         enabled = false
     }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -146,7 +146,11 @@ class SentryPlugin : Plugin<Project> {
 
                 val sentryProperties = getPropertiesFilePath(project, variant)
 
-                val isMinificationEnabled = isMinificationEnabled(project, variant)
+                val isMinificationEnabled = isMinificationEnabled(
+                    project,
+                    variant,
+                    extension.experimentalGuardsquareSupport.get()
+                )
                 val isDebuggable = variant.buildType.isDebuggable
 
                 var preBundleTaskProvider: TaskProvider<Task>? = null
@@ -158,7 +162,11 @@ class SentryPlugin : Plugin<Project> {
                         getPreBundleTask(project, variant.name)
                     }
                     transformerTaskProvider = withLogging(project.logger, "transformerTask") {
-                        getTransformerTask(project, variant.name)
+                        getTransformerTask(
+                            project,
+                            variant.name,
+                            extension.experimentalGuardsquareSupport.get()
+                        )
                     }
                     packageBundleTaskProvider = withLogging(project.logger, "packageBundleTask") {
                         getPackageBundleTask(project, variant.name)
@@ -202,7 +210,11 @@ class SentryPlugin : Plugin<Project> {
                             sentryProperties?.let { file -> project.file(file) }
                         )
                         task.uuidDirectory.set(generateUuidTask.flatMap { it.outputDirectory })
-                        task.mappingsFiles = getMappingFileProvider(project, variant)
+                        task.mappingsFiles = getMappingFileProvider(
+                            project,
+                            variant,
+                            extension.experimentalGuardsquareSupport.get()
+                        )
                         task.autoUploadProguardMapping.set(extension.autoUploadProguardMapping)
                         task.sentryOrganization.set(sentryOrgParameter)
                         task.sentryProject.set(sentryProjectParameter)
@@ -211,7 +223,9 @@ class SentryPlugin : Plugin<Project> {
                         generateUuidTask.flatMap { it.outputDirectory }
                     )
 
-                    if (GroovyCompat.isDexguardEnabledForVariant(project, variant.name)) {
+                    if (extension.experimentalGuardsquareSupport.get() &&
+                        GroovyCompat.isDexguardEnabledForVariant(project, variant.name)
+                    ) {
                         // If Dexguard is enabled, we will have to wait for the project to be evaluated
                         // to be able to let the uploadSentryProguardMappings run after them.
                         project.afterEvaluate {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPluginExtension.kt
@@ -89,6 +89,15 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
     )
 
     /**
+     * Experimental flag to turn on support for GuardSquare's tools integration (Dexguard and External Proguard).
+     * If enabled, the plugin will try to consume and upload the mapping file
+     * produced by Dexguard and External Proguard.
+     * Default is disabled.
+     */
+    val experimentalGuardsquareSupport: Property<Boolean> = objects
+        .property(Boolean::class.java).convention(false)
+
+    /**
      * Configure the tracing instrumentation.
      * Default configuration is enabled.
      */

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -30,12 +30,34 @@ class SentryTaskProviderTest {
     }
 
     @Test
-    fun `getTransformerTask returns transformClassesAndResources for standalone Proguard`() {
+    fun `getTransformerTask returns transform task for standalone Proguard with opt-in`() {
         val (project, task) = getTestProjectWithTask(
             "transformClassesAndResourcesWithProguardTransformForDebug"
         )
 
-        assertEquals(task, getTransformerTask(project, "debug")?.get())
+        assertEquals(
+            task,
+            getTransformerTask(
+                project,
+                "debug",
+                experimentalGuardsquareSupport = true
+            )?.get()
+        )
+    }
+
+    @Test
+    fun `getTransformerTask returns null for standalone Proguard without opt-in`() {
+        val (project, task) = getTestProjectWithTask(
+            "transformClassesAndResourcesWithProguardTransformForDebug"
+        )
+
+        assertNull(
+            getTransformerTask(
+                project,
+                "debug",
+                experimentalGuardsquareSupport = false
+            )
+        )
     }
 
     @Test
@@ -53,13 +75,32 @@ class SentryTaskProviderTest {
     }
 
     @Test
-    fun `getTransformerTask gives standalone Proguard priority`() {
+    fun `getTransformerTask gives standalone Proguard priority with opt-in`() {
         val (project, _) = getTestProjectWithTask("minifyDebugWithR8")
         project.tasks.register("transformClassesAndResourcesWithProguardTransformForDebug")
 
         assertEquals(
             "transformClassesAndResourcesWithProguardTransformForDebug",
-            getTransformerTask(project, "debug")?.get()?.name
+            getTransformerTask(
+                project,
+                "debug",
+                experimentalGuardsquareSupport = true
+            )?.get()?.name
+        )
+    }
+
+    @Test
+    fun `getTransformerTask ignores standalone Proguard priority without opt-in`() {
+        val (project, r8task) = getTestProjectWithTask("minifyDebugWithR8")
+        project.tasks.register("transformClassesAndResourcesWithProguardTransformForDebug")
+
+        assertEquals(
+            r8task,
+            getTransformerTask(
+                project,
+                "debug",
+                experimentalGuardsquareSupport = false
+            )?.get()
         )
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryPluginUtilsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryPluginUtilsTest.kt
@@ -30,7 +30,10 @@ class SentryPluginUtilsTest {
         val (project, android) = createTestProguardProject()
         val debug = android.applicationVariants.first { it.name == "debug" }
 
-        assertEquals(false, isMinificationEnabled(project, debug))
+        assertEquals(
+            false,
+            isMinificationEnabled(project, debug, experimentalGuardsquareSupport = true)
+        )
     }
 
     @Test
@@ -43,7 +46,26 @@ class SentryPluginUtilsTest {
         }
         val debug = android.applicationVariants.first { it.name == "debug" }
 
-        assertEquals(true, isMinificationEnabled(project, debug))
+        assertEquals(
+            true,
+            isMinificationEnabled(project, debug, experimentalGuardsquareSupport = true)
+        )
+    }
+
+    @Test
+    fun `isMinificationEnabled returns false for standalone Proguard without opt-in`() {
+        val (project, android) = createTestProguardProject()
+        project.extensions.getByType(ProGuardAndroidExtension::class.java).apply {
+            configurations.create("debug") {
+                it.defaultConfiguration("proguard-android-optimize.txt")
+            }
+        }
+        val debug = android.applicationVariants.first { it.name == "debug" }
+
+        assertEquals(
+            false,
+            isMinificationEnabled(project, debug, experimentalGuardsquareSupport = false)
+        )
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
This PR sits on top of #267 and adds a `experimentalGuardsquareSupport` that enables/disables  
the whole Proguard/External Dexguard logic and makes it opt-in.

The relevant commit is 39bdece

#skip-changelog

## :bulb: Motivation and Context
See discussion in #267

## :green_heart: How did you test it?
Tested with the sample project + JUnit

## :pencil: Checklist
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
Docs should be updated once we finalize the naming.