### PR TITLE
Fix MetaInfStripTransform breaking Kotlin IDE plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Fix MetaInfStripTransform breaking Kotlin Gradle and IDE plugin (#283)
+
 ## 3.0.0-rc.2
-
-### Various fixes & improvements
-
-- Prepare 3.0.0-rc.2 (d8f1ab31) by @bruno-garcia
 
 * Bump: AGP to 7.1.2 (#287)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix MetaInfStripTransform breaking Kotlin Gradle and IDE plugin (#283)
+* Fix MetaInfStripTransform breaking Kotlin Gradle and IDE plugin (#291)
 
 ## 3.0.0-rc.2
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -118,17 +118,18 @@ class SentryPlugin : Plugin<Project> {
                      * that will strip-out unnecessary files from the MR-JAR, so the AGP transforms
                      * will consume corrected artifacts. We only do this when auto-instrumentation is
                      * enabled (otherwise there's no need in this fix) AND when AGP version
-                     * is below 7.2.0-alpha06, where this issue has been fixed.
-                     * (https://issuetracker.google.com/issues/206655905#comment5)
+                     * is below 7.1.2, where this issue has been fixed.
+                     * (https://androidstudio.googleblog.com/2022/02/android-studio-bumblebee-202111-patch-2.html)
                      */
                     if (extension.tracingInstrumentation.enabled.get() &&
-                        AgpVersions.CURRENT < AgpVersions.VERSION_7_2_0_alpha06
+                        AgpVersions.CURRENT < AgpVersions.VERSION_7_1_2
                     ) {
-                        project.configurations.all {
-                            // request metaInfStripped attribute for all configurations to trigger our
-                            // transform
-                            it.attributes.attribute(metaInfStripped, true)
-                        }
+                        // we are only interested in runtime configuration (as ASM transform is
+                        // also run just for the runtime configuration)
+                        project.configurations.named("${variant.name}RuntimeClasspath")
+                            .configure {
+                                it.attributes.attribute(metaInfStripped, true)
+                            }
                         MetaInfStripTransform.register(
                             project.dependencies,
                             extension.tracingInstrumentation.forceInstrumentDependencies.get()

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -6,7 +6,7 @@ import kotlin.math.min
 
 internal object AgpVersions {
     val CURRENT: SemVer = SemVer.parse(Version.ANDROID_GRADLE_PLUGIN_VERSION)
-    val VERSION_7_2_0_alpha06: SemVer = SemVer.parse("7.2.0-alpha06")
+    val VERSION_7_1_2: SemVer = SemVer.parse("7.1.2")
 }
 
 /**

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/AgpVersionsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/AgpVersionsTest.kt
@@ -7,8 +7,8 @@ class AgpVersionsTest {
 
     @Test
     fun `agp versions`() {
-        assertTrue { SemVer.parse("7.1.0") < AgpVersions.VERSION_7_2_0_alpha06 }
-        assertTrue { SemVer.parse("7.2.0-alpha07") > AgpVersions.VERSION_7_2_0_alpha06 }
-        assertTrue { SemVer.parse("7.2.0") > AgpVersions.VERSION_7_2_0_alpha06 }
+        assertTrue { SemVer.parse("7.1.0") < AgpVersions.VERSION_7_1_2 }
+        assertTrue { SemVer.parse("7.2.0-alpha07") > AgpVersions.VERSION_7_1_2 }
+        assertTrue { SemVer.parse("7.2.0") > AgpVersions.VERSION_7_1_2 }
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We were breaking the kotlin-gradle-plugin and its IDE integration, because we were requesting our transform on all configurations, and the kotlin plugin seems to be collecting dependencies for IDE integration (imports) from the compileClasspath configuration. Since we are using the same attribute for the transform as AGP (`processed-jar`), we intervene into the transform chain and this seems to break the [collection logic](https://cs.android.com/android-studio/kotlin/+/master:libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/android/internal/AndroidDependencyResolver.kt;l=187-191) of the kotlin plugin. So I simply changed to requesting the transform on the runtimeClasspath configuration, because ASM is also just run for runtime and that fixed the issue.

So it's not really a fix, but rather avoiding the problem, but I think it's still fine.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #283 

## :green_heart: How did you test it?
Manually everything, since it's the IDE integration

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
