### PR TITLE
Fix instrumenting obfuscated libs (play-core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix instrumenting obfuscated libs (play-core) (#293)
+
 ## 3.0.0-rc.3
 
 * Fix MetaInfStripTransform breaking Kotlin Gradle and IDE plugin (#291)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginWithPlayCoreTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginWithPlayCoreTest.kt
@@ -1,0 +1,36 @@
+package io.sentry.android.gradle
+
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class SentryPluginWithPlayCoreTest :
+    BaseSentryPluginTest(androidGradlePluginVersion = "7.1.2", gradleVersion = "7.4") {
+
+    @Test
+    fun `does not break when there is a play-core obfuscated dependency`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            dependencies {
+              implementation 'io.sentry:sentry-android-core:5.6.0'
+              implementation 'com.google.android.play:core-ktx:1.8.1'
+            }
+            """.trimIndent()
+        )
+
+        val result = runner
+            .appendArguments("app:assembleDebug")
+            .build()
+
+        print(result.output)
+
+        assertTrue { "BUILD SUCCESSFUL" in result.output }
+    }
+
+    override val additionalRootProjectConfig: String = ""
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/wrap/visitor/WrappingVisitorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/wrap/visitor/WrappingVisitorTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.assertTrue
 import org.junit.Test
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
-import org.objectweb.asm.Type
 import org.objectweb.asm.tree.MethodNode
 
 class WrappingVisitorTest {
@@ -269,8 +268,7 @@ class WrappingVisitorTest {
             firstPassVisitor = firstPassVisitor
         ).run {
             visitTypeInsn(Opcodes.NEW, "java/io/FileInputStream")
-            val local = newLocal(Type.getObjectType("java/io/FileInputStream"))
-            storeLocal(local)
+            visitVarInsn(Opcodes.ASTORE, 1)
             visitMethodInsn(
                 methodVisit.opcode,
                 methodVisit.owner,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Capture the original variable index of the instrumented type to later use it when storing a wrapped type

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #286

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
