### PR TITLE
Fix obfuscated libs instrumentation (adcolony)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: obfuscated libs instrumentation (adcolony) (#307)
+
 ## 3.0.1
 
 * Fix: obfuscated libs instrumentation (gms) (#303)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginWithMinifiedLibsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginWithMinifiedLibsTest.kt
@@ -21,6 +21,7 @@ class SentryPluginWithMinifiedLibsTest :
               implementation 'com.google.android.play:core-ktx:1.8.1'
               implementation 'com.google.android.gms:play-services-vision:20.1.3'
               implementation 'com.google.android.gms:play-services-mlkit-text-recognition:18.0.0'
+              implementation 'com.adcolony:sdk:4.7.1'
             }
             """.trimIndent()
         )


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Fix another edge-case with obfuscate library (use of uninitialized instance)

Discussed this with Bruno - it's fine to ship it as part of a new 3.1.0-beta.1 (which we anyway wanted to release and promote on wizard to prompt users for auto-installation). Also, to avoid craft issues when releasing from a tag rather than `main`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #304 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
If this happens again we should prioritize #306 over the new issues to unblock users without disabling entire auto-instrumentation.
