### PR TITLE
Skip jar processing on AGP < 7.1.2 if it is a signed multi release ja…

### DIFF
--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/transforms/MetaInfStripTransformTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/transforms/MetaInfStripTransformTest.kt
@@ -180,7 +180,7 @@ class MetaInfStripTransformTest {
     }
 
     @Test
-    fun `when multi-release, signed jar with supported classes, keeps them and multi-release flag`() {
+    fun `when multi-release jar with supported classes, keeps them and multi-release flag`() {
         val outputs = FakeTransformOutputs(tmp)
 
         val sut = fixture.getSut(tmp, includeSupportedVersion = true)


### PR DESCRIPTION
## :scroll: Description
Detect signed multi release jars and let the user know that these cause problems and that they should upgrade to AGP >= 7.1.2


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/309


## :green_heart: How did you test it?
Added TestCase to ensure that a signed jar is not touched by the transform.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
Add Entry to Android Troubleshooting Guide
