### PR TITLE
fix: Okhttp v3 was not instrumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Skip jar processing on AGP < 7.1.2 for signed multi release jars ([#334](https://github.com/getsentry/sentry-android-gradle-plugin/pull/334))
+- Fix `OkHttp` version `3.x` was not instrumented ([#351](https://github.com/getsentry/sentry-android-gradle-plugin/pull/351))
 
 ## 3.1.2
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/okhttp/OkHttp.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/okhttp/OkHttp.kt
@@ -11,7 +11,7 @@ import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 
 class OkHttp : ClassInstrumentable {
-    override val fqName: String get() = "okhttp3.internal.connection.RealCall"
+    override val fqName: String get() = "RealCall"
 
     override fun getVisitor(
         instrumentableContext: ClassContext,
@@ -25,6 +25,12 @@ class OkHttp : ClassInstrumentable {
         methodInstrumentables = listOf(ResponseWithInterceptorChain()),
         parameters = parameters
     )
+
+    // OkHttp has renamed the class in v4, hence we are looking for both old and new package names
+    // https://github.com/square/okhttp/commit/3d3b0f64005f7d2dd7cde80a9eaf665f8df86fb6#diff-e46bb5c1117393fbfb8cd1496fc4a2dcfcd6fcf70d065c50be83ce9215b2ec7b
+    override fun isInstrumentable(data: ClassContext): Boolean =
+        data.currentClassData.className == "okhttp3.internal.connection.RealCall" ||
+            data.currentClassData.className == "okhttp3.RealCall"
 }
 
 class ResponseWithInterceptorChain : MethodInstrumentable {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The Okhttp version `3.x` hasn't been instrumented because the class was located in a different folder. This PR fixes it by instrumenting both old and new location.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Manually and automated with integration test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
