### PR TITLE
Add Markus to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @adinauer @romtsn
+*       @markushi @romtsn


### PR DESCRIPTION
_#skip-changelog_

@adinauer I guess it's fine to replace you, since you're switching teams anyway. For Java of course it makes sense to keep you there