### PR TITLE
Fix short class names should not be flagged as minified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Ignore minified classes from any instrumentation ([#389](https://github.com/getsentry/sentry-android-gradle-plugin/pull/389))
+- Fix short class names should not be flagged as minified ([#398](https://github.com/getsentry/sentry-android-gradle-plugin/pull/398))
 
 ### Dependencies
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/util/ConstantPoolHelpers.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/util/ConstantPoolHelpers.kt
@@ -91,8 +91,12 @@ private val MINIFIED_CLASSNAME_SENTRY_REGEX =
 /* ktlint-enable max-line-length */
 
 fun classNameLooksMinified(simpleClassName: String, fullClassName: String): Boolean {
-    return MINIFIED_CLASSNAME_REGEX.matches(simpleClassName) ||
-        MINIFIED_CLASSNAME_SENTRY_REGEX.matches(fullClassName)
+    return simpleClassName.isNotEmpty() &&
+        simpleClassName[0].isLowerCase() &&
+        (
+            MINIFIED_CLASSNAME_REGEX.matches(simpleClassName) ||
+                MINIFIED_CLASSNAME_SENTRY_REGEX.matches(fullClassName)
+            )
 }
 
 /**

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/util/MinifiedClassDetectionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/util/MinifiedClassDetectionTest.kt
@@ -49,4 +49,19 @@ class MinifiedClassDetectionTest {
             assertFalse(classNameLooksMinified(it, "com/example/$it"), it)
         }
     }
+
+    @Test
+    fun `does not consider short class names as minified classes`() {
+        val classNames = listOf(
+            Pair("Call", "retrofit2/Call"),
+            Pair("Call", "okhttp3/Call"),
+            Pair("Fill", "androidx/compose/ui/graphics/drawscope/Fill"),
+            Pair("Px", "androidx/annotation/Px"),
+            Pair("Dp", "androidx/annotation/Dp")
+        )
+
+        classNames.forEach { (simpleName, fullName) ->
+            assertFalse(classNameLooksMinified(simpleName, fullName))
+        }
+    }
 }


### PR DESCRIPTION
## :scroll: Description
Some class names were classified as minified, causing them to be skipped from any automatic instrumentation.


## :bulb: Motivation and Context
As discussed checking the class name for being lowercase could be a strong indicator and should work well enough for our use cases.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
