### PR TITLE
Add UI transactions for compose clickables

### DIFF
--- a/examples/android-instrumentation-sample/src/main/AndroidManifest.xml
+++ b/examples/android-instrumentation-sample/src/main/AndroidManifest.xml
@@ -38,8 +38,12 @@
             android:value="1.0" />
 
         <meta-data
+            android:name="io.sentry.traces.user-interaction.enable"
+            android:value="true" />
+
+        <meta-data
             android:name="io.sentry.traces.activity.auto-finish.enable"
-            android:value="false" />
+            android:value="true" />
     </application>
 
 </manifest>

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -19,8 +22,28 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import io.sentry.Sentry
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.random.Random
+
+class ViewModel {
+    val randomNumber = mutableStateOf(42)
+
+    fun onRandomNumberClicked() {
+        GlobalScope.launch {
+            val span = Sentry.getSpan()?.startChild("op.random_calculation")
+            delay(1000)
+            randomNumber.value = Random.nextInt(100)
+            span?.finish()
+        }
+    }
+}
 
 class ComposeActivity : ComponentActivity() {
+
+    private val model = ViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,11 +66,25 @@ class ComposeActivity : ComponentActivity() {
                             modifier = Modifier
                                 .border(2.dp, Color.Gray, pillShape)
                                 .clip(pillShape)
-                                .clickable {
+                                .clickable(onClickLabel = "Details.Route") {
                                     navController.navigate(Destination.Details.route)
                                 }
                                 .padding(24.dp),
                             text = "Home. Tap to go to Details."
+                        )
+
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        BasicText(
+                            modifier = Modifier
+                                .border(2.dp, Color.Gray, pillShape)
+                                .clip(pillShape)
+                                .clickable(onClickLabel = "Generate Random number") {
+                                    model.onRandomNumberClicked()
+                                }
+                                .padding(24.dp),
+                            text = "${model.randomNumber.value}. " +
+                                "Tap to calculate a new random number."
                         )
                     }
                 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -6,6 +6,7 @@ import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.extensions.InstrumentationFeature
+import io.sentry.android.gradle.instrumentation.androidx.compose.ComposeClickable
 import io.sentry.android.gradle.instrumentation.androidx.compose.ComposeNavigation
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.database.AndroidXSQLiteDatabase
@@ -102,7 +103,10 @@ abstract class SpanAddingClassVisitorFactory :
                         )
                     },
                     ComposeNavigation().takeIf {
-                        isComposeInstrEnabled(sentryModules, parameters.get())
+                        isComposeNavInstrEnabled(sentryModules, parameters.get())
+                    },
+                    ComposeClickable().takeIf {
+                        isComposeClickableInstrEnabled(sentryModules, parameters.get())
                     },
                 )
             )
@@ -140,13 +144,22 @@ abstract class SpanAddingClassVisitorFactory :
         SentryVersions.VERSION_OKHTTP
     ) && parameters.features.get().contains(InstrumentationFeature.OKHTTP)
 
-    private fun isComposeInstrEnabled(
+    private fun isComposeNavInstrEnabled(
         sentryModules: Map<String, SemVer>,
         parameters: SpanAddingParameters
     ): Boolean =
         sentryModules.isAtLeast(
             SentryModules.SENTRY_ANDROID_COMPOSE,
-            SentryVersions.VERSION_COMPOSE
+            SentryVersions.VERSION_COMPOSE_NAVIGATION
+        ) && parameters.features.get().contains(InstrumentationFeature.COMPOSE)
+
+    private fun isComposeClickableInstrEnabled(
+        sentryModules: Map<String, SemVer>,
+        parameters: SpanAddingParameters
+    ): Boolean =
+        sentryModules.isAtLeast(
+            SentryModules.SENTRY_ANDROID_COMPOSE,
+            SentryVersions.VERSION_COMPOSE_CLICKABLE
         ) && parameters.features.get().contains(InstrumentationFeature.COMPOSE)
 
     private fun Map<String, SemVer>.isAtLeast(module: String, minVersion: SemVer): Boolean =

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/compose/ComposeClickable.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/compose/ComposeClickable.kt
@@ -1,0 +1,61 @@
+package io.sentry.android.gradle.instrumentation.androidx.compose
+
+import com.android.build.api.instrumentation.ClassContext
+import io.sentry.android.gradle.instrumentation.ClassInstrumentable
+import io.sentry.android.gradle.instrumentation.CommonClassVisitor
+import io.sentry.android.gradle.instrumentation.MethodContext
+import io.sentry.android.gradle.instrumentation.MethodInstrumentable
+import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
+import io.sentry.android.gradle.instrumentation.androidx.compose.visitor.ModifierClickableMethodVisitor
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+
+open class ComposeClickable : ClassInstrumentable {
+
+    companion object {
+        private const val CLICKABLE_CLASSNAME =
+            "androidx.compose.foundation.ClickableKt"
+    }
+
+    override fun getVisitor(
+        instrumentableContext: ClassContext,
+        apiVersion: Int,
+        originalVisitor: ClassVisitor,
+        parameters: SpanAddingClassVisitorFactory.SpanAddingParameters
+    ): ClassVisitor {
+        return CommonClassVisitor(
+            apiVersion,
+            originalVisitor,
+            CLICKABLE_CLASSNAME,
+            listOf(object : MethodInstrumentable {
+
+                override val fqName: String get() = ""
+
+                /* ktlint-disable max-line-length */
+                override fun isInstrumentable(data: MethodContext): Boolean {
+                    return data.name?.startsWith("clickable") ?: false &&
+                        data.descriptor == "(Landroidx/compose/ui/Modifier;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;"
+                }
+                /* ktlint-enable max-line-length */
+
+                override fun getVisitor(
+                    instrumentableContext: MethodContext,
+                    apiVersion: Int,
+                    originalVisitor: MethodVisitor,
+                    parameters: SpanAddingClassVisitorFactory.SpanAddingParameters
+                ): MethodVisitor {
+                    return ModifierClickableMethodVisitor(
+                        instrumentableContext,
+                        apiVersion,
+                        originalVisitor
+                    )
+                }
+            }),
+            parameters
+        )
+    }
+
+    override fun isInstrumentable(data: ClassContext): Boolean {
+        return data.currentClassData.className == CLICKABLE_CLASSNAME
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/compose/visitor/ModifierClickableMethodVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/compose/visitor/ModifierClickableMethodVisitor.kt
@@ -1,0 +1,44 @@
+package io.sentry.android.gradle.instrumentation.androidx.compose.visitor
+
+import io.sentry.android.gradle.instrumentation.MethodContext
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Type
+import org.objectweb.asm.commons.AdviceAdapter
+import org.objectweb.asm.commons.Method
+
+class ModifierClickableMethodVisitor(
+    methodContext: MethodContext,
+    apiVersion: Int,
+    originalVisitor: MethodVisitor
+) : AdviceAdapter(
+    apiVersion,
+    originalVisitor,
+    methodContext.access,
+    methodContext.name,
+    methodContext.descriptor
+) {
+    override fun onMethodEnter() {
+        super.onMethodEnter()
+        val clickableIdx = argumentTypes.indexOfFirst {
+            it.descriptor == "Lkotlin/jvm/functions/Function0;"
+        }
+        val clickLabelIdx = argumentTypes.indexOfFirst {
+            it.descriptor == "Ljava/lang/String;"
+        }
+        /* ktlint-disable max-line-length */
+        if (clickableIdx != -1 && clickLabelIdx != -1) {
+            loadArg(clickableIdx)
+            loadArg(clickLabelIdx)
+
+            invokeStatic(
+                Type.getType("Lio/sentry/compose/SentryClickableIntegrationKt;"),
+                Method(
+                    "wrapClickable",
+                    "(Lkotlin/jvm/functions/Function0;Ljava/lang/String;)Lkotlin/jvm/functions/Function0;"
+                )
+            )
+            storeArg(clickableIdx)
+        }
+        /* ktlint-enable max-line-length */
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -21,7 +21,8 @@ internal object SentryVersions {
     internal val VERSION_PERFORMANCE = SemVer(4, 0, 0)
     internal val VERSION_OKHTTP = SemVer(5, 0, 0)
     internal val VERSION_FILE_IO = SemVer(5, 5, 0)
-    internal val VERSION_COMPOSE = SemVer(6, 7, 0)
+    internal val VERSION_COMPOSE_NAVIGATION = SemVer(6, 7, 0)
+    internal val VERSION_COMPOSE_CLICKABLE = SemVer(6, 9, 0)
 }
 
 internal object SentryModules {


### PR DESCRIPTION
## :scroll: Description

Instruments the `Modifier.clickable` method to wrap the clickable lamda using `SentryClickableIntegration.wrapClickable` (which is part of `sentry-compose`).


## :bulb: Motivation and Context
We want to have automatic UI transactions and clickable breadcrumb events. 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
