### PR TITLE
Ensure clean state for GenerateUuidTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Ensure clean state before generating a new uuid by deleting the old `sentry-debug-meta.properties` file ([#420](https://github.com/getsentry/sentry-android-gradle-plugin/pull/420))
+
 ### Dependencies
 
 - Bump Android SDK from v6.7.0 to v6.9.2 ([#406](https://github.com/getsentry/sentry-android-gradle-plugin/pull/406), [#408](https://github.com/getsentry/sentry-android-gradle-plugin/pull/408), [#411](https://github.com/getsentry/sentry-android-gradle-plugin/pull/411), [#414](https://github.com/getsentry/sentry-android-gradle-plugin/pull/414))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.tasks
 
+import io.sentry.android.gradle.util.SentryPluginUtils
 import io.sentry.android.gradle.util.info
 import java.util.UUID
 import org.gradle.api.DefaultTask
@@ -20,13 +21,14 @@ abstract class SentryGenerateProguardUuidTask : DefaultTask() {
 
     @TaskAction
     fun generateProperties() {
-        logger.info {
-            "SentryGenerateProguardUuidTask - outputFile: ${output.get()}"
-        }
+        val outputFile = SentryPluginUtils.getAndDeleteFile(output)
+        outputFile.parentFile.mkdirs()
 
-        UUID.randomUUID().also {
-            output.get().asFile.parentFile.mkdirs()
-            output.get().asFile.writeText("io.sentry.ProguardUuids=$it")
+        val uuid = UUID.randomUUID()
+        outputFile.writeText("io.sentry.ProguardUuids=$uuid")
+
+        logger.info {
+            "SentryGenerateProguardUuidTask - outputFile: $outputFile, uuid: $uuid"
         }
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Ensure clean state before generating a new uuid by deleting the old `sentry-debug-meta.properties` file

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Potentially fixes #415 

## :green_heart: How did you test it?
manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

