### PR TITLE
Do not register dependencies report task if it's disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Do not register dependencies report task if it's disabled ([#422](https://github.com/getsentry/sentry-android-gradle-plugin/pull/422))
+
 ### Dependencies
 
 - Bump Android SDK from v6.7.0 to v6.9.2 ([#406](https://github.com/getsentry/sentry-android-gradle-plugin/pull/406), [#408](https://github.com/getsentry/sentry-android-gradle-plugin/pull/408), [#411](https://github.com/getsentry/sentry-android-gradle-plugin/pull/411), [#414](https://github.com/getsentry/sentry-android-gradle-plugin/pull/414))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -227,16 +227,18 @@ class SentryPlugin : Plugin<Project> {
                     )
                 androidExtension.sourceSets.getByName(variant.name).assets.srcDir(sentryAssetDir)
 
-                val reportDependenciesTask = project.registerDependenciesTask(
-                    configurationName = "${variant.name}RuntimeClasspath",
-                    attributeValueJar = "android-classes",
-                    includeReport = extension.includeDependenciesReport,
-                    output = sentryAssetDir.flatMap { dir ->
-                        dir.file(project.provider { SENTRY_DEPENDENCIES_REPORT_OUTPUT })
-                    },
-                    taskSuffix = taskSuffix
-                )
-                reportDependenciesTask.setupMergeAssetsDependencies(mergeAssetsDependants)
+                if (extension.includeDependenciesReport.get()) {
+                    val reportDependenciesTask = project.registerDependenciesTask(
+                        configurationName = "${variant.name}RuntimeClasspath",
+                        attributeValueJar = "android-classes",
+                        includeReport = extension.includeDependenciesReport,
+                        output = sentryAssetDir.flatMap { dir ->
+                            dir.file(project.provider { SENTRY_DEPENDENCIES_REPORT_OUTPUT })
+                        },
+                        taskSuffix = taskSuffix
+                    )
+                    reportDependenciesTask.setupMergeAssetsDependencies(mergeAssetsDependants)
+                }
 
                 if (isMinificationEnabled && extension.includeProguardMapping.get()) {
                     // Setup the task to generate a UUID asset file

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -11,11 +11,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @Suppress("FunctionName")
-@RunWith(Parameterized::class)
-class SentryPluginTest(
-    androidGradlePluginVersion: String,
-    gradleVersion: String
-) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
+//@RunWith(Parameterized::class)
+class SentryPluginTest : BaseSentryPluginTest("7.3.0", "7.5") {
 
     @Test
     fun `plugin can be applied`() {
@@ -382,7 +379,7 @@ class SentryPluginTest(
             .build()
             .output
 
-        assertTrue { "> Task :app:collectExternalDebugDependenciesForSentry SKIPPED" in output }
+        assertTrue { "collectExternalDebugDependenciesForSentry" !in output }
         assertThrows(AssertionError::class.java) {
             verifyDependenciesReportAndroid(testProjectDir.root)
         }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -11,8 +11,11 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @Suppress("FunctionName")
-//@RunWith(Parameterized::class)
-class SentryPluginTest : BaseSentryPluginTest("7.3.0", "7.5") {
+@RunWith(Parameterized::class)
+class SentryPluginTest(
+    androidGradlePluginVersion: String,
+    gradleVersion: String
+) : BaseSentryPluginTest(androidGradlePluginVersion, gradleVersion) {
 
     @Test
     fun `plugin can be applied`() {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Do not register task if the dependencies report flag is turned off. This will prevent configuration cache from being discarded, as the task will not even be created.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #407 

## :green_heart: How did you test it?
manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes
