### PR TITLE
Support configuration cache in dependencies report task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Do not register dependencies report task if it's disabled ([#422](https://github.com/getsentry/sentry-android-gradle-plugin/pull/422))
 - Ensure clean state before generating a new uuid by deleting the old `sentry-debug-meta.properties` file ([#420](https://github.com/getsentry/sentry-android-gradle-plugin/pull/420))
+- Support configuration cache in dependencies report task from Gradle `7.5` onwards ([#423](https://github.com/getsentry/sentry-android-gradle-plugin/pull/423))
 
 ### Dependencies
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskFactory.kt
@@ -1,0 +1,41 @@
+package io.sentry.android.gradle.tasks.dependencies
+
+import io.sentry.android.gradle.util.GradleVersions
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+
+object SentryExternalDependenciesReportTaskFactory {
+
+    fun register(
+        project: Project,
+        configurationName: String,
+        attributeValueJar: String,
+        output: Provider<RegularFile>,
+        includeReport: Provider<Boolean>,
+        taskSuffix: String = ""
+    ): TaskProvider<out Task> {
+        // gradle 7.5 supports passing configuration resolution as task input and respects config
+        // cache, so we have a different implementation from that version onwards
+        return if (GradleVersions.CURRENT >= GradleVersions.VERSION_7_5) {
+            SentryExternalDependenciesReportTaskV2.register(
+                project,
+                configurationName,
+                output,
+                includeReport,
+                taskSuffix
+            )
+        } else {
+            SentryExternalDependenciesReportTask.register(
+                project,
+                configurationName,
+                attributeValueJar,
+                output,
+                includeReport,
+                taskSuffix
+            )
+        }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskFactory.kt
@@ -23,6 +23,7 @@ object SentryExternalDependenciesReportTaskFactory {
             SentryExternalDependenciesReportTaskV2.register(
                 project,
                 configurationName,
+                attributeValueJar,
                 output,
                 includeReport,
                 taskSuffix

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskV2.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskV2.kt
@@ -1,0 +1,77 @@
+package io.sentry.android.gradle.tasks.dependencies
+
+import io.sentry.android.gradle.util.SentryPluginUtils
+import io.sentry.android.gradle.util.artifactsFor
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+@CacheableTask
+abstract class SentryExternalDependenciesReportTaskV2 : DefaultTask() {
+
+    @get:Input
+    abstract val includeReport: Property<Boolean>
+
+    init {
+        description = "Generates an external dependencies report"
+
+        @Suppress("LeakingThis")
+        onlyIf { includeReport.get() }
+    }
+
+    @get:Input
+    abstract val artifactIds: SetProperty<String>
+
+    @get:OutputFile
+    abstract val output: RegularFileProperty
+
+    @TaskAction
+    fun action() {
+        val outputFile = SentryPluginUtils.getAndDeleteFile(output)
+        outputFile.parentFile.mkdirs()
+
+        val dependencies = artifactIds.get().toSortedSet()
+
+        outputFile.writeText(dependencies.joinToString("\n"))
+    }
+
+    companion object {
+        fun register(
+            project: Project,
+            configurationName: String,
+            output: Provider<RegularFile>,
+            includeReport: Provider<Boolean>,
+            taskSuffix: String = ""
+        ): TaskProvider<out Task> {
+            return project.tasks.register(
+                "collectExternal${taskSuffix}DependenciesForSentry",
+                SentryExternalDependenciesReportTaskV2::class.java
+            ) {
+                val configuration = project.configurations.getByName(configurationName)
+                val artifacts = configuration.artifactsFor("android-classes").resolvedArtifacts
+                val artifactIds = artifacts.map { list ->
+                    list.map { artifact -> artifact.id.componentIdentifier }
+                        // we're only interested in external deps
+                        .filterIsInstance<ModuleComponentIdentifier>()
+                        // and those that have proper version defined (e.g. flat jars don't have it)
+                        .filter { id -> id.version.isNotEmpty() }
+                        .map { id -> id.displayName }
+                }
+                it.artifactIds.set(artifactIds)
+                it.includeReport.set(includeReport)
+                it.output.set(output)
+            }
+        }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskV2.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskV2.kt
@@ -50,6 +50,7 @@ abstract class SentryExternalDependenciesReportTaskV2 : DefaultTask() {
         fun register(
             project: Project,
             configurationName: String,
+            attributeValueJar: String,
             output: Provider<RegularFile>,
             includeReport: Provider<Boolean>,
             taskSuffix: String = ""
@@ -59,7 +60,7 @@ abstract class SentryExternalDependenciesReportTaskV2 : DefaultTask() {
                 SentryExternalDependenciesReportTaskV2::class.java
             ) {
                 val configuration = project.configurations.getByName(configurationName)
-                val artifacts = configuration.artifactsFor("android-classes").resolvedArtifacts
+                val artifacts = configuration.artifactsFor(attributeValueJar).resolvedArtifacts
                 val artifactIds = artifacts.map { list ->
                     list.map { artifact -> artifact.id.componentIdentifier }
                         // we're only interested in external deps

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/ArtifactUtils.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/ArtifactUtils.kt
@@ -15,7 +15,6 @@ fun Configuration.artifactsFor(
     attrValue: String
 ) = externalArtifactViewOf(attrValue)
     .artifacts
-    .artifactFiles
 
 fun Configuration.externalArtifactViewOf(
     attrValue: String

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -14,6 +14,7 @@ internal object AgpVersions {
 internal object GradleVersions {
     val CURRENT: SemVer = SemVer.parse(GradleVersion.current().version)
     val VERSION_7_4: SemVer = SemVer.parse("7.4")
+    val VERSION_7_5: SemVer = SemVer.parse("7.5")
 }
 
 internal object SentryVersions {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginConfigurationCacheTest.kt
@@ -1,0 +1,40 @@
+package io.sentry.android.gradle
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class SentryPluginConfigurationCacheTest :
+    BaseSentryPluginTest("7.3.0", "7.5") {
+
+    @Test
+    fun `respects configuration cache`() {
+        appBuildFile.appendText(
+            // language=Groovy
+            """
+
+            dependencies {
+              implementation 'com.squareup.okhttp3:okhttp:3.14.9'
+              implementation project(':module') // multi-module project dependency
+              implementation ':asm-9.2' // flat jar
+            }
+            """.trimIndent()
+        )
+        runner.appendArguments(":app:assembleDebug")
+            .appendArguments("--configuration-cache")
+
+        val output = runner.build().output
+        val deps = verifyDependenciesReportAndroid(testProjectDir.root)
+        assertEquals(
+            """
+            com.squareup.okhttp3:okhttp:3.14.9
+            com.squareup.okio:okio:1.17.2
+            """.trimIndent(),
+            deps
+        )
+        assertTrue { "Configuration cache entry stored." in output }
+
+        val outputWithConfigCache = runner.build().output
+        assertTrue { "Configuration cache entry reused." in outputWithConfigCache }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryExternalDependenciesReportTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryExternalDependenciesReportTaskTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.tasks
 
+import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTask
 import java.io.File
 import kotlin.test.assertEquals
 import org.gradle.api.Project

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskTest.kt
@@ -1,6 +1,5 @@
-package io.sentry.android.gradle.tasks
+package io.sentry.android.gradle.tasks.dependencies
 
-import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTask
 import java.io.File
 import kotlin.test.assertEquals
 import org.gradle.api.Project


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Adds a new task which is used for Gradle 7.5 and above, where we can pass the configuration resolution results as a proper task input and it respects configuration cache

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #407 
Closes #404

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes
