### PR TITLE
Fix failing room 2.5.0 instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix failing room 2.5.0 instrumentation ([#435](https://github.com/getsentry/sentry-android-gradle-plugin/pull/435))
+
 ### Dependencies
 
 - Bump CLI from v2.11.0 to v2.12.0 ([#433](https://github.com/getsentry/sentry-android-gradle-plugin/pull/433))

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -79,7 +79,7 @@ object Samples {
     }
 
     object Room {
-        private const val version = "2.4.3"
+        private const val version = "2.5.0"
         const val runtime = "androidx.room:room-runtime:${version}"
         const val ktx = "androidx.room:room-ktx:${version}"
         const val compiler = "androidx.room:room-compiler:${version}"

--- a/examples/spring-boot-sample/build.gradle.kts
+++ b/examples/spring-boot-sample/build.gradle.kts
@@ -2,8 +2,10 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id(Samples.SpringBoot.springBoot) version BuildPluginsVersion.SPRING_BOOT
-    id(Samples.SpringBoot.springDependencyManagement) version BuildPluginsVersion.SPRING_DEP_MANAGEMENT
+    id(Samples.SpringBoot.springBoot) version
+        BuildPluginsVersion.SPRING_BOOT
+    id(Samples.SpringBoot.springDependencyManagement) version
+        BuildPluginsVersion.SPRING_DEP_MANAGEMENT
     kotlin("jvm")
     kotlin("plugin.spring") version BuildPluginsVersion.KOTLIN
     id("io.sentry.android.gradle")

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -25,7 +25,7 @@ import io.sentry.android.gradle.util.AgpVersions
 import io.sentry.android.gradle.util.AgpVersions.isAGP74
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
-import io.sentry.android.gradle.util.detectSentryAndroidSdk
+import io.sentry.android.gradle.util.collectModules
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.info
 import java.io.File
@@ -64,7 +64,7 @@ fun AndroidComponentsExtension<*, *, *>.configure(
                  * are run in parallel.
                  */
                 val sentryModulesService = SentryModulesService.register(project)
-                project.detectSentryAndroidSdk(
+                project.collectModules(
                     "${variant.name}RuntimeClasspath",
                     variant.name,
                     sentryModulesService

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -74,8 +74,14 @@ abstract class SpanAddingClassVisitorFactory :
 
             val sentryModules = parameters.get().sentryModulesService.get().sentryModules
             val externalModules = parameters.get().sentryModulesService.get().externalModules
-            val androidXSqliteFrameWorkModule = DefaultModuleIdentifier.newId("androidx.sqlite", "sqlite-framework")
-            val androidXSqliteFrameWorkVersion = externalModules.getOrDefault(androidXSqliteFrameWorkModule, SemVer())
+            val androidXSqliteFrameWorkModule = DefaultModuleIdentifier.newId(
+                "androidx.sqlite",
+                "sqlite-framework"
+            )
+            val androidXSqliteFrameWorkVersion = externalModules.getOrDefault(
+                androidXSqliteFrameWorkModule,
+                SemVer()
+            )
 
             SentryPlugin.logger.info { "Read sentry modules: $sentryModules" }
             /**

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/AndroidXSQLiteStatement.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/AndroidXSQLiteStatement.kt
@@ -10,10 +10,11 @@ import io.sentry.android.gradle.instrumentation.MethodInstrumentable
 import io.sentry.android.gradle.instrumentation.ReturnType
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.statement.visitor.ExecuteStatementMethodVisitor
+import io.sentry.android.gradle.util.SemVer
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 
-class AndroidXSQLiteStatement : ClassInstrumentable {
+class AndroidXSQLiteStatement(private val androidXSqliteVersion: SemVer) : ClassInstrumentable {
 
     override val fqName: String get() = "androidx.sqlite.db.framework.FrameworkSQLiteStatement"
 
@@ -26,12 +27,15 @@ class AndroidXSQLiteStatement : ClassInstrumentable {
         apiVersion = apiVersion,
         classVisitor = originalVisitor,
         className = fqName.substringAfterLast('.'),
-        methodInstrumentables = listOf(ExecuteInsert(), ExecuteUpdateDelete()),
+        methodInstrumentables = listOf(
+            ExecuteInsert(androidXSqliteVersion),
+            ExecuteUpdateDelete(androidXSqliteVersion)
+        ),
         parameters = parameters
     )
 }
 
-class ExecuteInsert : MethodInstrumentable {
+class ExecuteInsert(private val androidXSqliteVersion: SemVer) : MethodInstrumentable {
     override val fqName: String get() = "executeInsert"
 
     override fun getVisitor(
@@ -44,11 +48,12 @@ class ExecuteInsert : MethodInstrumentable {
         apiVersion,
         originalVisitor,
         instrumentableContext.access,
-        instrumentableContext.descriptor
+        instrumentableContext.descriptor,
+        androidXSqliteVersion
     )
 }
 
-class ExecuteUpdateDelete : MethodInstrumentable {
+class ExecuteUpdateDelete(private val androidXSqliteVersion: SemVer) : MethodInstrumentable {
     override val fqName: String get() = "executeUpdateDelete"
 
     override fun getVisitor(
@@ -61,6 +66,7 @@ class ExecuteUpdateDelete : MethodInstrumentable {
         apiVersion,
         originalVisitor,
         instrumentableContext.access,
-        instrumentableContext.descriptor
+        instrumentableContext.descriptor,
+        androidXSqliteVersion
     )
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/visitor/ExecuteStatementMethodVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/visitor/ExecuteStatementMethodVisitor.kt
@@ -4,6 +4,7 @@ import io.sentry.android.gradle.instrumentation.AbstractSpanAddingMethodVisitor
 import io.sentry.android.gradle.instrumentation.ReturnType
 import io.sentry.android.gradle.instrumentation.SpanOperations
 import io.sentry.android.gradle.instrumentation.util.Types
+import io.sentry.android.gradle.util.SemVer
 import kotlin.properties.Delegates
 import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
@@ -22,7 +23,8 @@ class ExecuteStatementMethodVisitor(
     api: Int,
     private val originalVisitor: MethodVisitor,
     access: Int,
-    descriptor: String?
+    descriptor: String?,
+    private val androidXSqliteVersion: SemVer
 ) : AbstractSpanAddingMethodVisitor(
     api = api,
     originalVisitor = originalVisitor,
@@ -105,16 +107,17 @@ class ExecuteStatementMethodVisitor(
     }
 
     /*
-    String description = mDelegate.toString();
+    String description = delegate.toString();
     int index = description.indexOf(':');
     description = description.substring(index + 2);
      */
     private fun MethodVisitor.visitExtractDescription() {
         visitVarInsn(ALOAD, 0) // this
+        val name = if (androidXSqliteVersion >= SemVer(2, 3, 0)) "delegate" else "mDelegate"
         visitFieldInsn(
             GETFIELD,
             "androidx/sqlite/db/framework/FrameworkSQLiteStatement",
-            "mDelegate",
+            name,
             "Landroid/database/sqlite/SQLiteStatement;"
         )
         visitMethodInsn(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/visitor/ExecuteStatementMethodVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/visitor/ExecuteStatementMethodVisitor.kt
@@ -113,6 +113,8 @@ class ExecuteStatementMethodVisitor(
      */
     private fun MethodVisitor.visitExtractDescription() {
         visitVarInsn(ALOAD, 0) // this
+
+        // androidx.sqlite changed the name of the variable in version 2.3.0
         val name = if (androidXSqliteVersion >= SemVer(2, 3, 0)) "delegate" else "mDelegate"
         visitFieldInsn(
             GETFIELD,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
@@ -5,6 +5,7 @@ package io.sentry.android.gradle.services
 import io.sentry.android.gradle.util.SemVer
 import io.sentry.android.gradle.util.getBuildServiceName
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -13,7 +14,11 @@ abstract class SentryModulesService : BuildService<BuildServiceParameters.None> 
 
     @get:Synchronized
     @set:Synchronized
-    var modules: Map<String, SemVer> = emptyMap()
+    var sentryModules: Map<ModuleIdentifier, SemVer> = emptyMap()
+
+    @get:Synchronized
+    @set:Synchronized
+    var externalModules: Map<ModuleIdentifier, SemVer> = emptyMap()
 
     companion object {
         fun register(project: Project): Provider<SentryModulesService> {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkChecker.kt
@@ -3,6 +3,7 @@ package io.sentry.android.gradle.util
 import io.sentry.android.gradle.services.SentryModulesService
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Provider
@@ -18,35 +19,46 @@ fun Project.detectSentryAndroidSdk(
         logger.warn {
             "Unable to find configuration $configurationName for variant $variantName."
         }
-        sentryModulesService.get().modules = emptyMap()
+        sentryModulesService.get().sentryModules = emptyMap()
+        sentryModulesService.get().externalModules = emptyMap()
         return
     }
 
     configProvider.configure { configuration ->
         configuration.incoming.afterResolve {
-            val sentryModules = it.resolutionResult.allComponents.filterSentryModules(logger)
+            val allModules = it.resolutionResult.allComponents.versionMap(logger)
+            val sentryModules = allModules.filter { (identifier, _) ->
+                identifier.group == "io.sentry"
+            }.toMap()
+
+            val externalModules = allModules.filter { (identifier, _) ->
+                identifier.group != "io.sentry"
+            }.toMap()
+
             logger.info {
                 "Detected Sentry modules $sentryModules " +
                     "for variant: $variantName, config: $configurationName"
             }
-            sentryModulesService.get().modules = sentryModules
+            sentryModulesService.get().sentryModules = sentryModules
+            sentryModulesService.get().externalModules = externalModules
         }
     }
 }
 
-private fun Set<ResolvedComponentResult>.filterSentryModules(logger: Logger): Map<String, SemVer> {
-    return filter { resolvedComponent: ResolvedComponentResult ->
-        val moduleVersion = resolvedComponent.moduleVersion ?: return@filter false
-        moduleVersion.group == "io.sentry"
-    }.associate {
-        val name = it.moduleVersion?.name ?: ""
-        val version = it.moduleVersion?.version ?: ""
-        val semver = try {
-            SemVer.parse(version)
-        } catch (e: Throwable) {
-            logger.info { "Unable to parse version $version of $name" }
-            SemVer()
+private fun Set<ResolvedComponentResult>.versionMap(logger: Logger):
+    List<Pair<ModuleIdentifier, SemVer>> {
+    return mapNotNull {
+        it.moduleVersion?.let { moduleVersion ->
+            val identifier = moduleVersion.module
+            val version = it.moduleVersion?.version ?: ""
+            val semver = try {
+                SemVer.parse(version)
+            } catch (e: Throwable) {
+                logger.info { "Unable to parse version $version of $identifier" }
+                SemVer()
+            }
+            return@mapNotNull Pair(identifier, semver)
         }
-        name to semver
+        null
     }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryModulesCollector.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryModulesCollector.kt
@@ -8,7 +8,7 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Provider
 
-fun Project.detectSentryAndroidSdk(
+fun Project.collectModules(
     configurationName: String,
     variantName: String,
     sentryModulesService: Provider<SentryModulesService>

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -3,6 +3,7 @@ package io.sentry.android.gradle.util
 import com.android.builder.model.Version
 import io.sentry.android.gradle.util.SemVer.Companion.equals
 import kotlin.math.min
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.util.GradleVersion
 
 internal object AgpVersions {
@@ -29,9 +30,18 @@ internal object SentryVersions {
 }
 
 internal object SentryModules {
-    internal const val SENTRY_ANDROID_CORE = "sentry-android-core"
-    internal const val SENTRY_ANDROID_OKHTTP = "sentry-android-okhttp"
-    internal const val SENTRY_ANDROID_COMPOSE = "sentry-compose-android"
+    internal val SENTRY_ANDROID_CORE = DefaultModuleIdentifier.newId(
+        "io.sentry",
+        "sentry-android-core"
+    )
+    internal val SENTRY_ANDROID_OKHTTP = DefaultModuleIdentifier.newId(
+        "io.sentry",
+        "sentry-android-okhttp"
+    )
+    internal val SENTRY_ANDROID_COMPOSE = DefaultModuleIdentifier.newId(
+        "io.sentry",
+        "sentry-compose-android"
+    )
 }
 
 /**

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
@@ -104,7 +104,7 @@ class SentryPluginCheckAndroidSdkTest(
           println(
             "SENTRY MODULES: " + BuildServicesKt
               .getBuildService(project.gradle.sharedServices, SentryModulesService.class)
-              .get().modules
+              .get().sentryModules
           )
         }
         """.trimIndent()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginCheckAndroidSdkTest.kt
@@ -90,8 +90,10 @@ class SentryPluginCheckAndroidSdkTest(
             .build()
 
         assertTrue {
-            "SENTRY MODULES: [sentry-android:5.4.0, sentry-android-core:5.4.0, " +
-                "sentry:5.4.0, sentry-android-ndk:5.4.0]" in result.output
+            "SENTRY MODULES: [io.sentry:sentry-android:5.4.0, " +
+                "io.sentry:sentry-android-core:5.4.0, " +
+                "io.sentry:sentry:5.4.0, " +
+                "io.sentry:sentry-android-ndk:5.4.0]" in result.output
         }
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/VisitorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/VisitorTest.kt
@@ -12,6 +12,7 @@ import io.sentry.android.gradle.instrumentation.fakes.TestSpanAddingParameters
 import io.sentry.android.gradle.instrumentation.okhttp.OkHttp
 import io.sentry.android.gradle.instrumentation.remap.RemappingInstrumentable
 import io.sentry.android.gradle.instrumentation.wrap.WrappingInstrumentable
+import io.sentry.android.gradle.util.SemVer
 import java.io.FileInputStream
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -100,7 +101,12 @@ class VisitorTest(
         @JvmStatic
         fun parameters() = listOf(
             arrayOf("androidxSqlite", "FrameworkSQLiteDatabase", AndroidXSQLiteDatabase(), null),
-            arrayOf("androidxSqlite", "FrameworkSQLiteStatement", AndroidXSQLiteStatement(), null),
+            arrayOf(
+                "androidxSqlite",
+                "FrameworkSQLiteStatement",
+                AndroidXSQLiteStatement(SemVer(2, 3, 0)),
+                null
+            ),
             roomDaoTestParameters("DeleteAndReturnUnit"),
             roomDaoTestParameters("InsertAndReturnLong"),
             roomDaoTestParameters("InsertAndReturnUnit"),

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -65,7 +65,7 @@ class SentryAndroidSdkCheckerTest {
             return project
         }
 
-        fun getModules() = sentryModulesServiceProvider.get().modules
+        fun getModules() = sentryModulesServiceProvider.get().sentryModules
     }
 
     @get:Rule

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -15,6 +15,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.result.ResolutionResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.provider.Provider
 import org.gradle.testfixtures.ProjectBuilder
@@ -126,13 +127,14 @@ class SentryAndroidSdkCheckerTest {
             fixture.sentryModulesServiceProvider
         )
 
+        val moduleIdentifier = DefaultModuleIdentifier.newId("io.sentry", "sentry-android-core")
         assertTrue {
             fixture.getModules().size == 1 &&
-                fixture.getModules()["sentry-android-core"] == SemVer()
+                fixture.getModules()[moduleIdentifier] == SemVer()
         }
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] Detected Sentry modules {sentry-android-core=0.0.0} for variant: debug," +
+                "[sentry] Detected Sentry modules {io.sentry:sentry-android-core=0.0.0} for variant: debug," +
                 " config: debugRuntimeClasspath"
         }
     }
@@ -156,13 +158,14 @@ class SentryAndroidSdkCheckerTest {
             fixture.sentryModulesServiceProvider
         )
 
+        val moduleIdentifier = DefaultModuleIdentifier.newId("io.sentry", "sentry-android-core")
         assertTrue {
             fixture.getModules().size == 1 &&
-                fixture.getModules()["sentry-android-core"] == SemVer(4, 1, 0)
+                fixture.getModules()[moduleIdentifier] == SemVer(4, 1, 0)
         }
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] Detected Sentry modules {sentry-android-core=4.1.0} for variant: debug," +
+                "[sentry] Detected Sentry modules {io.sentry:sentry-android-core=4.1.0} for variant: debug," +
                 " config: debugRuntimeClasspath"
         }
     }
@@ -207,17 +210,23 @@ class SentryAndroidSdkCheckerTest {
             fixture.sentryModulesServiceProvider
         )
 
+        val sentryAndroidModule = DefaultModuleIdentifier
+            .newId("io.sentry", "sentry-android")
+        val sentryAndroidCoreModule = DefaultModuleIdentifier
+            .newId("io.sentry", "sentry-android-core")
+        val sentryAndroidOkHttpModule = DefaultModuleIdentifier
+            .newId("io.sentry", "sentry-android-okhttp")
         assertTrue {
             fixture.getModules().size == 3 &&
-                fixture.getModules()["sentry-android"] == SemVer(5, 5, 0) &&
-                fixture.getModules()["sentry-android-core"] == SemVer(5, 5, 0) &&
-                fixture.getModules()["sentry-android-okhttp"] == SemVer(6, 0, 0)
+                fixture.getModules()[sentryAndroidModule] == SemVer(5, 5, 0) &&
+                fixture.getModules()[sentryAndroidCoreModule] == SemVer(5, 5, 0) &&
+                fixture.getModules()[sentryAndroidOkHttpModule] == SemVer(6, 0, 0)
         }
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] Detected Sentry modules {sentry-android=5.5.0, " +
-                "sentry-android-core=5.5.0, sentry-android-okhttp=6.0.0} for variant: debug," +
-                " config: debugRuntimeClasspath"
+                "[sentry] Detected Sentry modules {io.sentry:sentry-android=5.5.0, " +
+                "io.sentry:sentry-android-core=5.5.0, io.sentry:sentry-android-okhttp=6.0.0} " +
+                "for variant: debug, config: debugRuntimeClasspath"
         }
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryAndroidSdkCheckerTest.kt
@@ -127,15 +127,16 @@ class SentryAndroidSdkCheckerTest {
             fixture.sentryModulesServiceProvider
         )
 
-        val moduleIdentifier = DefaultModuleIdentifier.newId("io.sentry", "sentry-android-core")
+        val moduleIdentifier = DefaultModuleIdentifier
+            .newId("io.sentry", "sentry-android-core")
         assertTrue {
             fixture.getModules().size == 1 &&
                 fixture.getModules()[moduleIdentifier] == SemVer()
         }
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] Detected Sentry modules {io.sentry:sentry-android-core=0.0.0} for variant: debug," +
-                " config: debugRuntimeClasspath"
+                "[sentry] Detected Sentry modules {io.sentry:sentry-android-core=0.0.0} " +
+                "for variant: debug, config: debugRuntimeClasspath"
         }
     }
 
@@ -158,15 +159,16 @@ class SentryAndroidSdkCheckerTest {
             fixture.sentryModulesServiceProvider
         )
 
-        val moduleIdentifier = DefaultModuleIdentifier.newId("io.sentry", "sentry-android-core")
+        val moduleIdentifier = DefaultModuleIdentifier
+            .newId("io.sentry", "sentry-android-core")
         assertTrue {
             fixture.getModules().size == 1 &&
                 fixture.getModules()[moduleIdentifier] == SemVer(4, 1, 0)
         }
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] Detected Sentry modules {io.sentry:sentry-android-core=4.1.0} for variant: debug," +
-                " config: debugRuntimeClasspath"
+                "[sentry] Detected Sentry modules {io.sentry:sentry-android-core=4.1.0} " +
+                "for variant: debug, config: debugRuntimeClasspath"
         }
     }
 


### PR DESCRIPTION
## :scroll: Description
Due to the recent `2.3.0` release of `androidx.sqlite:sqlite-framework:2.3.0`([link]( https://developer.android.com/jetpack/androidx/releases/sqlite#version_230_3)) which is used by room `2.5.0` our bytecode instrumentation fails and causes a runtime crash.


## :bulb: Motivation and Context
Fixes #434

## :green_heart: How did you test it?
Sadly just some manual testing, ideally we can have automated tests for this and make the instrumentation itself more stable, any input welcome!

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
