### PR TITLE
Fix Gradle 8 dependency issue for uploadNativeSymbols task

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -180,7 +180,6 @@ private fun ApplicationVariant.configureNativeSymbolsTask(
             SentryUploadNativeSymbolsTask::class.java
         ) {
             it.workingDir(project.rootDir)
-            it.buildDir.set(project.buildDir)
             it.autoUploadNativeSymbol.set(extension.autoUploadNativeSymbols)
             it.cliExecutable.set(cliExecutable)
             it.sentryProperties.set(sentryProps?.let { file -> project.file(file) })

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -20,9 +20,6 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
         description = "Uploads native symbols to Sentry"
     }
 
-    @get:InputDirectory
-    abstract val buildDir: DirectoryProperty
-
     @get:Input
     abstract val cliExecutable: Property<String>
 
@@ -91,7 +88,7 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
         // where {variantName} could be debug/release...
         args.add(
             File(
-                buildDir.asFile.get(),
+                project.buildDir,
                 "intermediates${sep}merged_native_libs${sep}${variantName.get()}"
             ).absolutePath
         )


### PR DESCRIPTION
:scroll: Description

Fixes Gradle 8 "Task x uses this output of task y without declaring an
explicit or implicit dependency." error##

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/445


## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
