### PR TITLE
feat: logcat integration

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -53,7 +53,6 @@ fun AndroidComponentsExtension<*, *, *>.configure(
                 sentryOrg,
                 sentryProject
             )
-
             if (extension.tracingInstrumentation.enabled.get()) {
                 /**
                  * We detect sentry-android SDK version using configurations.incoming.afterResolve.
@@ -83,6 +82,12 @@ fun AndroidComponentsExtension<*, *, *>.configure(
                     )
                     params.features.setDisallowChanges(
                         extension.tracingInstrumentation.features.get()
+                    )
+                    params.logcatMinLevel.setDisallowChanges(
+                        extension.tracingInstrumentation.logcat.minLevel.get()
+                    )
+                    params.logcatEnabled.setDisallowChanges(
+                        extension.tracingInstrumentation.logcat.enabled.get()
                     )
                     params.sentryModulesService.setDisallowChanges(sentryModulesService)
                     params.tmpDir.set(tmpDir)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/LogcatExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/LogcatExtension.kt
@@ -1,0 +1,21 @@
+package io.sentry.android.gradle.extensions
+
+import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+open class LogcatExtension @Inject constructor(objects: ObjectFactory) {
+    /**
+     * Enables or disables the Logcat feature.
+     * Defaults to true.
+     */
+    val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+
+    /**
+     * The minimum log level to capture.
+     * Defaults to Level.WARNING.
+     */
+    val minLevel: Property<LogcatLevel> =
+        objects.property(LogcatLevel::class.java).convention(LogcatLevel.WARNING)
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/TracingInstrumentationExtension.kt
@@ -77,5 +77,12 @@ enum class InstrumentationFeature {
      * This feature uses bytecode manipulation and adds an OnDestinationChangedListener to all
      * navigation controllers used in Jetpack Compose.
      */
-    COMPOSE
+    COMPOSE,
+
+    /**
+     * When enabled the SDK will create breadcrumbs when using Logcat
+     * This feature uses bytecode manipulation and replaces Logcat
+     * with Sentry-specific implementations.
+     */
+    LOGCAT
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/TracingInstrumentationExtension.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.extensions
 
+import org.gradle.api.Action
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -44,8 +45,19 @@ open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFa
                 InstrumentationFeature.FILE_IO,
                 InstrumentationFeature.OKHTTP,
                 InstrumentationFeature.COMPOSE,
+                InstrumentationFeature.LOGCAT
             )
         )
+
+    val logcat: LogcatExtension = objects.newInstance(
+        LogcatExtension::class.java
+    )
+
+    fun logcat(
+        logcatAction: Action<LogcatExtension>
+    ) {
+        logcatAction.execute(logcat)
+    }
 }
 
 enum class InstrumentationFeature {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -10,6 +10,7 @@ import io.sentry.android.gradle.instrumentation.androidx.compose.ComposeNavigati
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.database.AndroidXSQLiteDatabase
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.statement.AndroidXSQLiteStatement
+import io.sentry.android.gradle.instrumentation.logcat.SentryLogcatInstrumentable
 import io.sentry.android.gradle.instrumentation.okhttp.OkHttp
 import io.sentry.android.gradle.instrumentation.remap.RemappingInstrumentable
 import io.sentry.android.gradle.instrumentation.util.findClassReader
@@ -116,6 +117,9 @@ abstract class SpanAddingClassVisitorFactory :
                     ComposeNavigation().takeIf {
                         isComposeInstrEnabled(sentryModules, parameters.get())
                     },
+                    SentryLogcatInstrumentable().takeIf {
+                        isLogcatInstrEnabled(sentryModules, parameters.get())
+                    }
                 )
             )
 
@@ -160,6 +164,15 @@ abstract class SpanAddingClassVisitorFactory :
             SentryModules.SENTRY_ANDROID_COMPOSE,
             SentryVersions.VERSION_COMPOSE
         ) && parameters.features.get().contains(InstrumentationFeature.COMPOSE)
+
+    private fun isLogcatInstrEnabled(
+        sentryModules: Map<ModuleIdentifier, SemVer>,
+        parameters: SpanAddingParameters
+    ): Boolean =
+        sentryModules.isAtLeast(
+            SentryModules.SENTRY_ANDROID_CORE,
+            SentryVersions.VERSION_LOGCAT
+        ) && parameters.features.get().contains(InstrumentationFeature.LOGCAT)
 
     private fun Map<ModuleIdentifier, SemVer>.isAtLeast(
         module: ModuleIdentifier,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -6,7 +6,6 @@ import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.extensions.InstrumentationFeature
-import io.sentry.android.gradle.extensions.LogcatExtension
 import io.sentry.android.gradle.instrumentation.androidx.compose.ComposeNavigation
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.database.AndroidXSQLiteDatabase
@@ -125,7 +124,9 @@ abstract class SpanAddingClassVisitorFactory :
                     ComposeNavigation().takeIf {
                         isComposeInstrEnabled(sentryModules, parameters.get())
                     },
-                    SentryLogcatInstrumentable(parameters.get().logcatMinLevel.get())
+                    SentryLogcatInstrumentable(parameters.get().logcatMinLevel.get()).takeIf {
+                        isLogcatInstrEnabled(sentryModules, parameters.get())
+                    }
                 )
             )
             SentryPlugin.logger.info {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatClassVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatClassVisitor.kt
@@ -1,0 +1,55 @@
+package io.sentry.android.gradle.instrumentation.logcat
+
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.commons.AdviceAdapter
+
+class LogcatClassVisitor(
+    apiVersion: Int,
+    originalVisitor: ClassVisitor,
+    private val minLevel: LogcatLevel
+) :
+    ClassVisitor(apiVersion, originalVisitor) {
+    override fun visitMethod(
+        access: Int,
+        name: String?,
+        descriptor: String?,
+        signature: String?,
+        exceptions: Array<out String>?
+    ): MethodVisitor {
+        val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+        return LogMethodVisitor(mv, access, name, descriptor, minLevel)
+    }
+}
+
+class LogMethodVisitor(
+    mv: MethodVisitor?,
+    access: Int,
+    name: String?,
+    desc: String?,
+    private val minLevel: LogcatLevel
+) :
+    AdviceAdapter(Opcodes.ASM7, mv, access, name, desc) {
+    override fun visitMethodInsn(
+        opcode: Int,
+        owner: String,
+        name: String,
+        desc: String?,
+        itf: Boolean
+    ) {
+        if (owner.contains("android/util/Log") && minLevel.allowedLogFunctions().contains(name)) {
+            // Replace call to Log with call to SentryLogcatAdapter
+            mv.visitMethodInsn(
+                INVOKESTATIC,
+                "io/sentry/android/core/SentryLogcatAdapter",
+                name,
+                desc,
+                false
+            )
+        } else {
+            super.visitMethodInsn(opcode, owner, name, desc, itf)
+        }
+    }
+}
+

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatInstrumentable.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatInstrumentable.kt
@@ -5,23 +5,18 @@ import io.sentry.android.gradle.instrumentation.ClassInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import io.sentry.android.gradle.instrumentation.util.isSentryClass
 import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.commons.ClassRemapper
-import org.objectweb.asm.commons.SimpleRemapper
 
-class SentryLogcatInstrumentable : ClassInstrumentable {
-    companion object {
-        private val mapping = mapOf(
-            "android/util/Log" to "io/sentry/android/core/SentryLogcatAdapter",
-        )
-    }
+class SentryLogcatInstrumentable(private val minLevel: LogcatLevel) :
+    ClassInstrumentable {
 
     override fun getVisitor(
         instrumentableContext: ClassContext,
         apiVersion: Int,
         originalVisitor: ClassVisitor,
         parameters: SpanAddingClassVisitorFactory.SpanAddingParameters
-    ): ClassVisitor =
-        ClassRemapper(originalVisitor, SimpleRemapper(mapping))
+    ): ClassVisitor {
+        return LogcatClassVisitor(apiVersion, originalVisitor, minLevel)
+    }
 
     override fun isInstrumentable(data: ClassContext) =
         !data.isSentryClass() && !data.currentClassData.className.contains("SentryLogcatAdapter\$Companion")

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatLevel.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatLevel.kt
@@ -1,0 +1,25 @@
+package io.sentry.android.gradle.instrumentation.logcat
+
+enum class LogcatLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR;
+
+    fun allowedLogFunctions(): List<String> {
+        return values()
+            .filter { it.ordinal >= this.ordinal }
+            .flatMap { it.functionNames() }
+    }
+
+    private fun functionNames(): List<String> {
+        return when (this) {
+            VERBOSE -> listOf("v")
+            DEBUG -> listOf("d")
+            INFO -> listOf("i")
+            WARNING -> listOf("w")
+            ERROR -> listOf("e", "wtf")
+        }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/SentryLogcatInstrumentable.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/SentryLogcatInstrumentable.kt
@@ -1,0 +1,28 @@
+package io.sentry.android.gradle.instrumentation.logcat
+
+import com.android.build.api.instrumentation.ClassContext
+import io.sentry.android.gradle.instrumentation.ClassInstrumentable
+import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
+import io.sentry.android.gradle.instrumentation.util.isSentryClass
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.commons.ClassRemapper
+import org.objectweb.asm.commons.SimpleRemapper
+
+class SentryLogcatInstrumentable : ClassInstrumentable {
+    companion object {
+        private val mapping = mapOf(
+            "android/util/Log" to "io/sentry/android/core/SentryLogcatAdapter",
+        )
+    }
+
+    override fun getVisitor(
+        instrumentableContext: ClassContext,
+        apiVersion: Int,
+        originalVisitor: ClassVisitor,
+        parameters: SpanAddingClassVisitorFactory.SpanAddingParameters
+    ): ClassVisitor =
+        ClassRemapper(originalVisitor, SimpleRemapper(mapping))
+
+    override fun isInstrumentable(data: ClassContext) =
+        !data.isSentryClass() && !data.currentClassData.className.contains("SentryLogcatAdapter\$Companion")
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -27,6 +27,7 @@ internal object SentryVersions {
     internal val VERSION_OKHTTP = SemVer(5, 0, 0)
     internal val VERSION_FILE_IO = SemVer(5, 5, 0)
     internal val VERSION_COMPOSE = SemVer(6, 7, 0)
+    internal val VERSION_LOGCAT = SemVer(6, 17, 0)
 }
 
 internal object SentryModules {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatLevelTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatLevelTest.kt
@@ -1,0 +1,37 @@
+package io.sentry.android.gradle.instrumentation.logcat
+
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class LogcatLevelTest {
+
+    @Test
+    fun `test allowedLogFunctions for VERBOSE level`() {
+        val allowedFunctions = LogcatLevel.VERBOSE.allowedLogFunctions()
+        assertEquals(listOf("v", "d", "i", "w", "e", "wtf"), allowedFunctions)
+    }
+
+    @Test
+    fun `test allowedLogFunctions for DEBUG level`() {
+        val allowedFunctions = LogcatLevel.DEBUG.allowedLogFunctions()
+        assertEquals(listOf("d", "i", "w", "e", "wtf"), allowedFunctions)
+    }
+
+    @Test
+    fun `test allowedLogFunctions for INFO level`() {
+        val allowedFunctions = LogcatLevel.INFO.allowedLogFunctions()
+        assertEquals(listOf("i", "w", "e", "wtf"), allowedFunctions)
+    }
+
+    @Test
+    fun `test allowedLogFunctions for WARNING level`() {
+        val allowedFunctions = LogcatLevel.WARNING.allowedLogFunctions()
+        assertEquals(listOf("w", "e", "wtf"), allowedFunctions)
+    }
+
+    @Test
+    fun `test allowedLogFunctions for ERROR level`() {
+        val allowedFunctions = LogcatLevel.ERROR.allowedLogFunctions()
+        assertEquals(listOf("e", "wtf"), allowedFunctions)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
Adds a `logcat` subextension that has following options:
- `enabled`
- `minLevel`

`minLevel` determines which Log functions will be replaced by `SentryLogcatAdapter` via bytecode manipulation.

`SentryLogcatAdapter` will add breadcrumbs to the respective log.

## :bulb: Motivation and Context
Ref: https://github.com/getsentry/sentry-java/issues/1620

## :green_heart: How did you test it?
 - Local/manual testing
 - Jadx
 
## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
Update sentry-docs