### PR TITLE
Parse the sdk name in BootstrapAndroidSdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Parse the sdk name in BootstrapAndroidSdk ([#478](https://github.com/getsentry/sentry-android-gradle-plugin/pull/478))
+
 ### Dependencies
 
 - Bump CLI from v2.16.1 to v2.17.4 ([#469](https://github.com/getsentry/sentry-android-gradle-plugin/pull/469), [#475](https://github.com/getsentry/sentry-android-gradle-plugin/pull/475))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Parse the sdk name in BootstrapAndroidSdk ([#478](https://github.com/getsentry/sentry-android-gradle-plugin/pull/478))
+- Do not transform the sdk name to Int in BootstrapAndroidSdk ([#478](https://github.com/getsentry/sentry-android-gradle-plugin/pull/478))
 
 ### Dependencies
 

--- a/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/BootstrapAndroidSdk.kt
+++ b/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/BootstrapAndroidSdk.kt
@@ -25,14 +25,24 @@ object BootstrapAndroidSdk {
             val platforms = File(sdkPath, "platforms")
             val latest = platforms.listFiles()
                 ?.filter { it.isDirectory }
-                ?.maxOf { it.name.substringAfter("-").take(2).toInt() }
+                ?.maxOf { sdkNameToVersionNumber(it.name.substringAfter("-")) }
             if (latest != null) {
-                extra["androidSdkPath"] = "$sdkPath/platforms/android-${latest}/android.jar"
+                extra["androidSdkPath"] = "$sdkPath/platforms/android-$latest/android.jar"
             } else {
                 project.logger.warn("No available android sdks. The tests in plugin-build might not work")
             }
         } else {
             project.logger.warn("Unable to detect the android sdk path. The tests in plugin-build might not work")
+        }
+    }
+
+    private fun sdkNameToVersionNumber(sdkName: String): Int {
+        return when {
+            sdkName.toIntOrNull() != null -> sdkName.toInt()
+            sdkName.equals("UpsideDownCake", true) -> 34
+            sdkName.equals("Tiramisu", true) -> 33
+            sdkName.equals("TiramisuPrivacySandbox", true) -> 33
+            else -> 0
         }
     }
 }

--- a/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/BootstrapAndroidSdk.kt
+++ b/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/BootstrapAndroidSdk.kt
@@ -25,7 +25,7 @@ object BootstrapAndroidSdk {
             val platforms = File(sdkPath, "platforms")
             val latest = platforms.listFiles()
                 ?.filter { it.isDirectory }
-                ?.maxOf { sdkNameToVersionNumber(it.name.substringAfter("-")) }
+                ?.maxOf { it.name.substringAfter("-") }
             if (latest != null) {
                 extra["androidSdkPath"] = "$sdkPath/platforms/android-$latest/android.jar"
             } else {
@@ -33,16 +33,6 @@ object BootstrapAndroidSdk {
             }
         } else {
             project.logger.warn("Unable to detect the android sdk path. The tests in plugin-build might not work")
-        }
-    }
-
-    private fun sdkNameToVersionNumber(sdkName: String): Int {
-        return when {
-            sdkName.toIntOrNull() != null -> sdkName.toInt()
-            sdkName.equals("UpsideDownCake", true) -> 34
-            sdkName.equals("Tiramisu", true) -> 33
-            sdkName.equals("TiramisuPrivacySandbox", true) -> 33
-            else -> 0
         }
     }
 }


### PR DESCRIPTION
## :scroll: Description
Parse the sdk name in BootstrapAndroidSdk


## :bulb: Motivation and Context
Some sdks like Tiramisu or UpsideDownCake are installed creating a folder with the full name instead of the version number. Our plugin check the latest sdk version, but parsing the name as integer make it crash.
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/474


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
