### PR TITLE
Bump gradle-build-action to resolve secruity issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.10.5'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.10.5'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
 
       - name: Build project
         run: ./gradlew spotlessCheck assembleDebug --stacktrace

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: 11
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
 
       - name: Build project
         run: ./gradlew spotlessCheck assembleDebug --stacktrace

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
 
       - name: Run Gradle tasks
         if: runner.os != 'Windows'

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
 
       - name: Run Gradle tasks
         if: runner.os != 'Windows'

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -60,7 +60,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build the Release variant
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
@@ -76,7 +76,7 @@ jobs:
           rm -r output
 
       - name: Build the Release Bundle variant
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}

--- a/.github/workflows/test-publish-dry-run.yaml
+++ b/.github/workflows/test-publish-dry-run.yaml
@@ -60,7 +60,7 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Build the Release variant
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
@@ -76,7 +76,7 @@ jobs:
           rm -r output
 
       - name: Build the Release Bundle variant
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2
+        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
 
       - name: Build the Release variant
         run: ./gradlew assembleRelease | tee gradle.log


### PR DESCRIPTION
_#skip-changelog_

There is a security alert from dependabot saying that we should update to v2.4.2 of the github action. https://github.com/getsentry/sentry-android-gradle-plugin/security/dependabot/1

This changes the commit hash to the latest one (which is equal to 2.4.2).

We are actually not affected by this, because there are no entries of `configuration-cache-*` in our action caches, but still good to bump this:
https://github.com/getsentry/sentry-android-gradle-plugin/actions/caches