### PR TITLE
Add missing Kotlin Compiler Plugin Marker config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -12,3 +12,4 @@ targets:
   - name: registry
     sdks:
       maven:io.sentry:sentry-android-gradle-plugin:
+      maven:io:sentry:sentry-kotlin-compiler-plugin:

--- a/.craft.yml
+++ b/.craft.yml
@@ -12,4 +12,4 @@ targets:
   - name: registry
     sdks:
       maven:io.sentry:sentry-android-gradle-plugin:
-      maven:io:sentry:sentry-kotlin-compiler-plugin:
+      maven:io.sentry:sentry-kotlin-compiler-plugin:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add missing Kotlin Compiler Plugin Marker config ([#488](https://github.com/getsentry/sentry-android-gradle-plugin/pull/488))
+
 ## 3.6.0
 
 ### Features

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -209,6 +209,11 @@ distributions {
             from("build${sep}publications${sep}sentryPluginPluginMarkerMaven")
         }
     }
+    create("sentryKotlinCompilerPluginMarker") {
+        contents {
+            from("build${sep}publications${sep}kotlinCompilerPluginPluginMarkerMaven")
+        }
+    }
 }
 
 apply {


### PR DESCRIPTION
## :scroll: Description
Apparently the plugin marker pom file is missing in order to correctly apply our Kotlin Compiler Plugin.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
