### PR TITLE
No longer ignore `org` and `project` in `sentry` config block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- No longer ignore `org` and `project` in `sentry` config block ([#501](https://github.com/getsentry/sentry-android-gradle-plugin/pull/501))
+
 ## 3.8.0
 
 ### Features

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -280,8 +280,8 @@ private fun Variant.configureProguardMappingsTasks(
                 sentryProperties = sentryProps,
                 mappingFiles = getMappingFileProvider(project, variant, guardsquareEnabled),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
-                sentryOrg = sentryOrg ?: extension.org.orNull,
-                sentryProject = sentryProject ?: extension.project.orNull,
+                sentryOrg = sentryOrg?.let { project.provider { it }} ?: extension.org,
+                sentryProject = sentryProject?.let { project.provider { it }} ?: extension.project,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -280,8 +280,8 @@ private fun Variant.configureProguardMappingsTasks(
                 sentryProperties = sentryProps,
                 mappingFiles = getMappingFileProvider(project, variant, guardsquareEnabled),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
-                sentryOrg = sentryOrg?.let { project.provider { it }} ?: extension.org,
-                sentryProject = sentryProject?.let { project.provider { it }} ?: extension.project,
+                sentryOrg = sentryOrg?.let { project.provider { it } } ?: extension.org,
+                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.project,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -242,8 +242,8 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                     guardsquareEnabled
                 ),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
-                sentryOrg = sentryOrg?.let { project.provider { it }} ?: extension.org,
-                sentryProject = sentryProject?.let { project.provider { it }} ?: extension.project,
+                sentryOrg = sentryOrg?.let { project.provider { it } } ?: extension.org,
+                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.project,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -242,8 +242,8 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                     guardsquareEnabled
                 ),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
-                sentryOrg = sentryOrg ?: extension.org.orNull,
-                sentryProject = sentryProject ?: extension.project.orNull,
+                sentryOrg = sentryOrg?.let { project.provider { it }} ?: extension.org,
+                sentryProject = sentryProject?.let { project.provider { it }} ?: extension.project,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
@@ -137,8 +137,8 @@ abstract class BundleSourcesTask : Exec() {
             output: Provider<Directory>,
             debug: Property<Boolean>,
             cliExecutable: String,
-            sentryOrg: String?,
-            sentryProject: String?,
+            sentryOrg: Provider<String>,
+            sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,
             taskSuffix: String = ""
         ): TaskProvider<BundleSourcesTask> {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
@@ -46,8 +46,8 @@ class SourceContext {
                 output = paths.bundleDir,
                 extension.debug,
                 cliExecutable,
-                sentryOrg ?: extension.org.orNull,
-                sentryProject ?: extension.project.orNull,
+                sentryOrg?.let { project.provider { it }} ?: extension.org,
+                sentryProject?.let { project.provider { it }} ?: extension.project,
                 extension.authToken,
                 taskSuffix
             )
@@ -59,8 +59,8 @@ class SourceContext {
                 extension.debug,
                 cliExecutable,
                 extension.autoUploadSourceContext,
-                sentryOrg ?: extension.org.orNull,
-                sentryProject ?: extension.project.orNull,
+                sentryOrg?.let { project.provider { it }} ?: extension.org,
+                sentryProject?.let { project.provider { it }} ?: extension.project,
                 extension.authToken,
                 taskSuffix
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
@@ -46,8 +46,8 @@ class SourceContext {
                 output = paths.bundleDir,
                 extension.debug,
                 cliExecutable,
-                sentryOrg?.let { project.provider { it }} ?: extension.org,
-                sentryProject?.let { project.provider { it }} ?: extension.project,
+                sentryOrg?.let { project.provider { it } } ?: extension.org,
+                sentryProject?.let { project.provider { it } } ?: extension.project,
                 extension.authToken,
                 taskSuffix
             )
@@ -59,8 +59,8 @@ class SourceContext {
                 extension.debug,
                 cliExecutable,
                 extension.autoUploadSourceContext,
-                sentryOrg?.let { project.provider { it }} ?: extension.org,
-                sentryProject?.let { project.provider { it }} ?: extension.project,
+                sentryOrg?.let { project.provider { it } } ?: extension.org,
+                sentryProject?.let { project.provider { it } } ?: extension.project,
                 extension.authToken,
                 taskSuffix
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -118,8 +119,8 @@ abstract class UploadSourceBundleTask : Exec() {
             debug: Property<Boolean>,
             cliExecutable: String,
             autoUploadSourceContext: Property<Boolean>,
-            sentryOrg: String?,
-            sentryProject: String?,
+            sentryOrg: Provider<String>,
+            sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,
             taskSuffix: String = ""
         ): TaskProvider<UploadSourceBundleTask> {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -150,8 +150,8 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
             sentryProperties: String?,
             generateUuidTask: Provider<SentryGenerateProguardUuidTask>,
             mappingFiles: Provider<FileCollection>,
-            sentryOrg: String?,
-            sentryProject: String?,
+            sentryOrg: Provider<String>,
+            sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,
             autoUploadProguardMapping: Property<Boolean>,
             taskSuffix: String = ""

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryNonAndroidPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/BaseSentryNonAndroidPluginTest.kt
@@ -21,6 +21,7 @@ abstract class BaseSentryNonAndroidPluginTest(
     private lateinit var rootBuildFile: File
     protected lateinit var appBuildFile: File
     protected lateinit var moduleBuildFile: File
+    protected lateinit var sentryPropertiesFile: File
     protected lateinit var runner: GradleRunner
 
     protected open val additionalRootProjectConfig: String = ""
@@ -36,6 +37,7 @@ abstract class BaseSentryNonAndroidPluginTest(
 
         appBuildFile = File(testProjectDir.root, "app/build.gradle")
         moduleBuildFile = File(testProjectDir.root, "module/build.gradle")
+        sentryPropertiesFile = File(testProjectDir.root, "sentry.properties")
         rootBuildFile = testProjectDir.writeFile("build.gradle") {
             // language=Groovy
             """

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -64,7 +64,6 @@ class SentrySourceContextNonAndroidTest(
             """.trimIndent()
         )
 
-        println(sentryPropertiesFile.readText())
         sentryPropertiesFile.writeText("")
 
         val ktContents = testProjectDir.withDummyKtFile()
@@ -74,8 +73,6 @@ class SentrySourceContextNonAndroidTest(
         val result = runner
             .appendArguments("app:assemble")
             .build()
-
-        println(result.output)
         assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
         assertTrue { "\"--project\" \"sentry-android\"" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -27,9 +27,6 @@ class SentrySourceContextNonAndroidTest(
             }
             """.trimIndent()
         )
-
-        sentryPropertiesFile.writeText("")
-
         val result = runner
             .appendArguments("app:assemble")
             .build()
@@ -62,7 +59,7 @@ class SentrySourceContextNonAndroidTest(
               autoUploadProguardMapping = false
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
               org = "sentry-sdks"
-              project = "sentry-java"
+              project = "sentry-android"
             }
             """.trimIndent()
         )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -75,7 +75,7 @@ class SentrySourceContextNonAndroidTest(
             .build()
 
         assertTrue { "--org=sentry-sdks" in result.output }
-        assertTrue { "--project=sentry-java" in result.output }
+        assertTrue { "--project=sentry-android" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -27,6 +27,9 @@ class SentrySourceContextNonAndroidTest(
             }
             """.trimIndent()
         )
+
+        sentryPropertiesFile.writeText("")
+
         val result = runner
             .appendArguments("app:assemble")
             .build()
@@ -53,13 +56,18 @@ class SentrySourceContextNonAndroidTest(
             }
 
             sentry {
+              debug = true
               includeSourceContext = true
               autoUploadSourceContext = false
               autoUploadProguardMapping = false
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
+              org = "sentry-sdks"
+              project = "sentry-java"
             }
             """.trimIndent()
         )
+
+        sentryPropertiesFile.writeText("")
 
         val ktContents = testProjectDir.withDummyKtFile()
         val javaContents = testProjectDir.withDummyJavaFile()
@@ -69,6 +77,8 @@ class SentrySourceContextNonAndroidTest(
             .appendArguments("app:assemble")
             .build()
 
+        assertTrue { "--org=sentry-sdks" in result.output }
+        assertTrue { "--project=sentry-java" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -64,6 +64,7 @@ class SentrySourceContextNonAndroidTest(
             """.trimIndent()
         )
 
+        println(sentryPropertiesFile.readText())
         sentryPropertiesFile.writeText("")
 
         val ktContents = testProjectDir.withDummyKtFile()
@@ -74,6 +75,7 @@ class SentrySourceContextNonAndroidTest(
             .appendArguments("app:assemble")
             .build()
 
+        println(result.output)
         assertTrue { "--org=sentry-sdks" in result.output }
         assertTrue { "--project=sentry-android" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -76,8 +76,8 @@ class SentrySourceContextNonAndroidTest(
             .build()
 
         println(result.output)
-        assertTrue { "--org=sentry-sdks" in result.output }
-        assertTrue { "--project=sentry-android" in result.output }
+        assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
+        assertTrue { "\"--project\" \"sentry-android\"" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -36,6 +36,9 @@ class SentrySourceContextTest(
             }
             """.trimIndent()
         )
+
+        sentryPropertiesFile.writeText("")
+
         val result = runner
             .appendArguments("app:assembleRelease")
             .build()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -92,7 +92,7 @@ class SentrySourceContextTest(
             .build()
 
         assertTrue { "--org=sentry-sdks" in result.output }
-        assertTrue { "--project=sentry-java" in result.output }
+        assertTrue { "--project=sentry-android" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -93,8 +93,8 @@ class SentrySourceContextTest(
             .build()
 
         println(result.output)
-        assertTrue { "--org=sentry-sdks" in result.output }
-        assertTrue { "--project=sentry-android" in result.output }
+        assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
+        assertTrue { "\"--project\" \"sentry-android\"" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -81,7 +81,6 @@ class SentrySourceContextTest(
             """.trimIndent()
         )
 
-        println(sentryPropertiesFile.readText())
         sentryPropertiesFile.writeText("")
 
         val ktContents = testProjectDir.withDummyComposeFile()
@@ -92,7 +91,6 @@ class SentrySourceContextTest(
             .appendArguments("app:assembleRelease")
             .build()
 
-        println(result.output)
         assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
         assertTrue { "\"--project\" \"sentry-android\"" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -36,9 +36,6 @@ class SentrySourceContextTest(
             }
             """.trimIndent()
         )
-
-        sentryPropertiesFile.writeText("")
-
         val result = runner
             .appendArguments("app:assembleRelease")
             .build()
@@ -79,10 +76,12 @@ class SentrySourceContextTest(
               autoUploadProguardMapping = false
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
               org = "sentry-sdks"
-              project = "sentry-java"
+              project = "sentry-android"
             }
             """.trimIndent()
         )
+
+        sentryPropertiesFile.writeText("")
 
         val ktContents = testProjectDir.withDummyComposeFile()
         val javaContents = testProjectDir.withDummyJavaFile()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -70,10 +70,13 @@ class SentrySourceContextTest(
             }
 
             sentry {
+              debug = true
               includeSourceContext = true
               autoUploadSourceContext = false
               autoUploadProguardMapping = false
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
+              org = "sentry-sdks"
+              project = "sentry-java"
             }
             """.trimIndent()
         )
@@ -86,6 +89,8 @@ class SentrySourceContextTest(
             .appendArguments("app:assembleRelease")
             .build()
 
+        assertTrue { "--org=sentry-sdks" in result.output }
+        assertTrue { "--project=sentry-java" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -81,6 +81,7 @@ class SentrySourceContextTest(
             """.trimIndent()
         )
 
+        println(sentryPropertiesFile.readText())
         sentryPropertiesFile.writeText("")
 
         val ktContents = testProjectDir.withDummyComposeFile()
@@ -91,6 +92,7 @@ class SentrySourceContextTest(
             .appendArguments("app:assembleRelease")
             .build()
 
+        println(result.output)
         assertTrue { "--org=sentry-sdks" in result.output }
         assertTrue { "--project=sentry-android" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Pass `Provider<String>` instead of `String?` into tasks so they can lazily resolve the sentry `org` and `project` properties.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`org` and `project` in `sentry` config block was ignored.

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
