### PR TITLE
Rename `project` to `projectName` in SentryPluginExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- No longer ignore `org` and `project` in `sentry` config block ([#501](https://github.com/getsentry/sentry-android-gradle-plugin/pull/501))
+- Rename `project` to `projectName` in SentryPluginExtension ([#505](https://github.com/getsentry/sentry-android-gradle-plugin/pull/505))
+- No longer ignore `org` and `projectName` in `sentry` config block ([#501](https://github.com/getsentry/sentry-android-gradle-plugin/pull/501))
 
 ## 3.8.0
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -281,7 +281,7 @@ private fun Variant.configureProguardMappingsTasks(
                 mappingFiles = getMappingFileProvider(project, variant, guardsquareEnabled),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
                 sentryOrg = sentryOrg?.let { project.provider { it } } ?: extension.org,
-                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.project,
+                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.projectName,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -281,7 +281,8 @@ private fun Variant.configureProguardMappingsTasks(
                 mappingFiles = getMappingFileProvider(project, variant, guardsquareEnabled),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
                 sentryOrg = sentryOrg?.let { project.provider { it } } ?: extension.org,
-                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.projectName,
+                sentryProject = sentryProject?.let { project.provider { it } }
+                    ?: extension.projectName,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -243,7 +243,8 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                 ),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
                 sentryOrg = sentryOrg?.let { project.provider { it } } ?: extension.org,
-                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.projectName,
+                sentryProject = sentryProject?.let { project.provider { it } }
+                    ?: extension.projectName,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -243,7 +243,7 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                 ),
                 autoUploadProguardMapping = extension.autoUploadProguardMapping,
                 sentryOrg = sentryOrg?.let { project.provider { it } } ?: extension.org,
-                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.project,
+                sentryProject = sentryProject?.let { project.provider { it } } ?: extension.projectName,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -184,7 +184,7 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
      *
      * Default is null.
      */
-    val project: Property<String> = objects.property(String::class.java)
+    val projectName: Property<String> = objects.property(String::class.java)
         .convention(null as String?)
 
     /**

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
@@ -47,7 +47,7 @@ class SourceContext {
                 extension.debug,
                 cliExecutable,
                 sentryOrg?.let { project.provider { it } } ?: extension.org,
-                sentryProject?.let { project.provider { it } } ?: extension.project,
+                sentryProject?.let { project.provider { it } } ?: extension.projectName,
                 extension.authToken,
                 taskSuffix
             )
@@ -60,7 +60,7 @@ class SourceContext {
                 cliExecutable,
                 extension.autoUploadSourceContext,
                 sentryOrg?.let { project.provider { it } } ?: extension.org,
-                sentryProject?.let { project.provider { it } } ?: extension.project,
+                sentryProject?.let { project.provider { it } } ?: extension.projectName,
                 extension.authToken,
                 taskSuffix
             )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginIntegrationTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginIntegrationTest.kt
@@ -119,7 +119,7 @@ class SentryPluginIntegrationTest(
                   autoUploadProguardMapping = true
                   uploadNativeSymbols = false
                   org = 'sentry-sdks'
-                  project = 'sentry-android'
+                  projectName = 'sentry-android'
                   authToken = '<token>'
                   tracingInstrumentation {
                     enabled = false

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -59,7 +59,7 @@ class SentrySourceContextNonAndroidTest(
               autoUploadProguardMapping = false
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
               org = "sentry-sdks"
-              project = "sentry-android"
+              projectName = "sentry-android"
             }
             """.trimIndent()
         )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextTest.kt
@@ -76,7 +76,7 @@ class SentrySourceContextTest(
               autoUploadProguardMapping = false
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
               org = "sentry-sdks"
-              project = "sentry-android"
+              projectName = "sentry-android"
             }
             """.trimIndent()
         )


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Rename `project` to `projectName` in SentryPluginExtension

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`project` would shadow the Gradle `project` variable preventing users from accessing it, e.g. to use `project.findProperty`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
