### PR TITLE
Add okhttp event listener only on sentry above 6.20

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -101,7 +101,7 @@ abstract class SpanAddingClassVisitorFactory :
                             sentryModulesService.isOldDatabaseInstrEnabled()
                     },
                     OkHttpEventListener().takeIf {
-                        sentryModulesService.isOkHttpInstrEnabled()
+                        sentryModulesService.isOkHttpListenerInstrEnabled()
                     },
                     OkHttp().takeIf {
                         sentryModulesService.isOkHttpInstrEnabled()

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
@@ -79,6 +79,11 @@ abstract class SentryModulesService : BuildService<SentryModulesService.Paramete
             SentryVersions.VERSION_FILE_IO
         ) && parameters.features.get().contains(InstrumentationFeature.FILE_IO)
 
+    fun isOkHttpListenerInstrEnabled(): Boolean = sentryModules.isAtLeast(
+        SentryModules.SENTRY_ANDROID_OKHTTP,
+        SentryVersions.VERSION_OKHTTP_LISTENER
+    ) && parameters.features.get().contains(InstrumentationFeature.OKHTTP)
+
     fun isOkHttpInstrEnabled(): Boolean = sentryModules.isAtLeast(
         SentryModules.SENTRY_ANDROID_OKHTTP,
         SentryVersions.VERSION_OKHTTP

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -27,6 +27,7 @@ internal object SentryVersions {
     internal val VERSION_COMPOSE = SemVer(6, 7, 0)
     internal val VERSION_LOGCAT = SemVer(6, 17, 0)
     internal val VERSION_SQLITE = SemVer(6, 21, 0)
+    internal val VERSION_OKHTTP_LISTENER = SemVer(6, 20, 0)
 }
 
 internal object SentryModules {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginTest.kt
@@ -260,6 +260,43 @@ class SentryPluginTest(
     }
 
     @Test
+    fun `does not apply okhttp listener on older version of sentry-android-okhttp`() {
+        applyTracingInstrumentation(
+            features = setOf(InstrumentationFeature.OKHTTP),
+            dependencies = setOf(
+                "com.squareup.okhttp3:okhttp:3.14.9",
+                "io.sentry:sentry-android-okhttp:6.19.0"
+            )
+        )
+        val build = runner
+            .appendArguments(":app:assembleDebug", "--info")
+            .build()
+
+        assertTrue {
+            "[sentry] Instrumentable: ChainedInstrumentable(instrumentables=OkHttp)" in build.output
+        }
+    }
+
+    @Test
+    fun `apply okhttp listener on sentry-android-okhttp 6_20`() {
+        applyTracingInstrumentation(
+            features = setOf(InstrumentationFeature.OKHTTP),
+            dependencies = setOf(
+                "com.squareup.okhttp3:okhttp:3.14.9",
+                "io.sentry:sentry-android-okhttp:6.20.0"
+            )
+        )
+        val build = runner
+            .appendArguments(":app:assembleDebug", "--info")
+            .build()
+
+        assertTrue {
+            "[sentry] Instrumentable: ChainedInstrumentable(instrumentables=" +
+                "OkHttpEventListener, OkHttp)" in build.output
+        }
+    }
+
+    @Test
     fun `applies all instrumentables when all features are enabled`() {
         applyTracingInstrumentation(
             features = setOf(
@@ -271,7 +308,7 @@ class SentryPluginTest(
             dependencies = setOf(
                 "androidx.sqlite:sqlite:2.0.0",
                 "com.squareup.okhttp3:okhttp:3.14.9",
-                "io.sentry:sentry-android-okhttp:6.6.0",
+                "io.sentry:sentry-android-okhttp:6.20.0",
                 "androidx.compose.runtime:runtime:1.1.0",
                 "io.sentry:sentry-compose-android:6.7.0",
                 "io.sentry:sentry-android-sqlite:6.21.0"


### PR DESCRIPTION
## :scroll: Description
added minimum version of sentry-android-okhttp 6.20.0 to enable okhttp event listener instrumentation

(feature was not merged yet, so no need for changelog entry)
#skip-changelog


## :bulb: Motivation and Context
Okhttp event listener instrumentation uses `SentryOkHttpEventListener`, which was introduced only in Sentry Android SDK version 6.20.0


## :green_heart: How did you test it?
Unit test


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
