### PR TITLE
Fixed OkHttpEventListener crash at compile time with OkHttp4

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ object LibsVersion {
     const val JUNIT = "4.13.2"
     const val ASM = "7.0" // compatibility matrix -> https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/instrumentation/InstrumentationContext#apiversion
     const val SQLITE = "2.1.0"
-    const val SENTRY = "6.6.0"
+    const val SENTRY = "6.23.0"
 }
 
 object Libs {
@@ -48,6 +48,7 @@ object Libs {
     const val SQLITE = "androidx.sqlite:sqlite:${LibsVersion.SQLITE}"
     const val SQLITE_FRAMEWORK = "androidx.sqlite:sqlite-framework:${LibsVersion.SQLITE}"
     const val SENTRY_ANDROID = "io.sentry:sentry-android:${LibsVersion.SENTRY}"
+    const val SENTRY_ANDROID_OKHTTP = "io.sentry:sentry-android-okhttp:${LibsVersion.SENTRY}"
 
     // test
     val MOCKITO_KOTLIN = "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -90,7 +90,8 @@ dependencies {
     testImplementationAar(Libs.SQLITE)
     testImplementationAar(Libs.SQLITE_FRAMEWORK)
     testRuntimeOnly(files(androidSdkPath))
-    testRuntimeOnlyAar(Libs.SENTRY_ANDROID)
+    testImplementation(Libs.SENTRY_ANDROID)
+    testImplementationAar(Libs.SENTRY_ANDROID_OKHTTP)
 
     // Needed to read contents from APK/Source Bundles
     testImplementation(Libs.ARSC_LIB)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -81,6 +81,11 @@ abstract class SpanAddingClassVisitorFactory :
                 androidXSqliteFrameWorkModule,
                 SemVer()
             )
+            val okHttpModule = DefaultModuleIdentifier.newId(
+                "com.squareup.okhttp3",
+                "okhttp"
+            )
+            val okHttpVersion = externalModules.getOrDefault(okHttpModule, SemVer())
 
             SentryPlugin.logger.info { "Read sentry modules: $sentryModules" }
 
@@ -100,7 +105,7 @@ abstract class SpanAddingClassVisitorFactory :
                         sentryModulesService.isNewDatabaseInstrEnabled() ||
                             sentryModulesService.isOldDatabaseInstrEnabled()
                     },
-                    OkHttpEventListener().takeIf {
+                    OkHttpEventListener(okHttpVersion).takeIf {
                         sentryModulesService.isOkHttpListenerInstrEnabled()
                     },
                     OkHttp().takeIf {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/okhttp/OkHttpEventListener.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/okhttp/OkHttpEventListener.kt
@@ -7,10 +7,11 @@ import io.sentry.android.gradle.instrumentation.MethodContext
 import io.sentry.android.gradle.instrumentation.MethodInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import io.sentry.android.gradle.instrumentation.okhttp.visitor.OkHttpEventListenerMethodVisitor
+import io.sentry.android.gradle.util.SemVer
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 
-class OkHttpEventListener : ClassInstrumentable {
+class OkHttpEventListener(private val okHttpVersion: SemVer) : ClassInstrumentable {
     override val fqName: String get() = "okhttp3.OkHttpClient"
 
     override fun getVisitor(
@@ -22,12 +23,12 @@ class OkHttpEventListener : ClassInstrumentable {
         apiVersion = apiVersion,
         classVisitor = originalVisitor,
         className = fqName.substringAfterLast('.'),
-        methodInstrumentables = listOf(OkHttpEventListenerMethodInstrumentable()),
+        methodInstrumentables = listOf(OkHttpEventListenerMethodInstrumentable(okHttpVersion)),
         parameters = parameters
     )
 }
 
-class OkHttpEventListenerMethodInstrumentable : MethodInstrumentable {
+class OkHttpEventListenerMethodInstrumentable(private val okHttpVersion: SemVer) : MethodInstrumentable {
     override val fqName: String get() = "<init>"
 
     override fun getVisitor(
@@ -38,7 +39,8 @@ class OkHttpEventListenerMethodInstrumentable : MethodInstrumentable {
     ): MethodVisitor = OkHttpEventListenerMethodVisitor(
         apiVersion = apiVersion,
         originalVisitor = originalVisitor,
-        instrumentableContext = instrumentableContext
+        instrumentableContext = instrumentableContext,
+        okHttpVersion = okHttpVersion
     )
 
     override fun isInstrumentable(data: MethodContext): Boolean {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/VisitorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/VisitorTest.kt
@@ -12,6 +12,7 @@ import io.sentry.android.gradle.instrumentation.fakes.TestClassData
 import io.sentry.android.gradle.instrumentation.fakes.TestSpanAddingParameters
 import io.sentry.android.gradle.instrumentation.logcat.LogcatInstrumentable
 import io.sentry.android.gradle.instrumentation.okhttp.OkHttp
+import io.sentry.android.gradle.instrumentation.okhttp.OkHttpEventListener
 import io.sentry.android.gradle.instrumentation.remap.RemappingInstrumentable
 import io.sentry.android.gradle.instrumentation.wrap.WrappingInstrumentable
 import io.sentry.android.gradle.util.SemVer
@@ -153,6 +154,8 @@ class VisitorTest(
             ),
             arrayOf("okhttp/v3", "RealCall", OkHttp(), null),
             arrayOf("okhttp/v4", "RealCall", OkHttp(), null),
+            arrayOf("okhttp/v3", "OkHttpClient", OkHttpEventListener(SemVer(3, 0, 0)), null),
+            arrayOf("okhttp/v4", "OkHttpClient", OkHttpEventListener(SemVer(4, 0, 0)), null),
             arrayOf("androidxCompose", "NavHostControllerKt", ComposeNavigation(), null),
             arrayOf("logcat", "LogcatTest", LogcatInstrumentable(), null)
         )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/classloader/mapping/OkHttpMapping.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/classloader/mapping/OkHttpMapping.kt
@@ -5,5 +5,8 @@ import io.sentry.android.gradle.instrumentation.classloader.standardClassSource
 val okHttpMissingClasses = arrayOf<Pair<String, (String) -> String>>(
     "okhttp3.internal.http.RealInterceptorChain" to { name ->
         standardClassSource(name, interfaces = arrayOf("okhttp3.Interceptor.Chain"))
+    },
+    "okhttp3.OkHttpClient\$1" to { name ->
+        standardClassSource(name, superclass = "okhttp3.internal.Internal")
     }
 )

--- a/plugin-build/src/test/kotlin/okhttp3/Call.kt
+++ b/plugin-build/src/test/kotlin/okhttp3/Call.kt
@@ -1,0 +1,3 @@
+package okhttp3
+
+interface Call

--- a/plugin-build/src/test/kotlin/okhttp3/EventListener.kt
+++ b/plugin-build/src/test/kotlin/okhttp3/EventListener.kt
@@ -1,0 +1,3 @@
+package okhttp3
+
+abstract class EventListener

--- a/plugin-build/src/test/kotlin/okhttp3/WebSocket.kt
+++ b/plugin-build/src/test/kotlin/okhttp3/WebSocket.kt
@@ -1,0 +1,3 @@
+package okhttp3
+
+interface WebSocket

--- a/plugin-build/src/test/kotlin/okhttp3/internal/Internal.kt
+++ b/plugin-build/src/test/kotlin/okhttp3/internal/Internal.kt
@@ -1,0 +1,3 @@
+package okhttp3.internal
+
+abstract class Internal


### PR DESCRIPTION
## :scroll: Description
OkHttp 4 switched to Kotlin, and changed few implementation details. We now check the version and apply the appropriate instrumentation


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/513


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
