### PR TITLE
Disable source context tasks if not enabled

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
@@ -65,6 +65,21 @@ class SourceContext {
                 taskSuffix
             )
 
+            project.afterEvaluate {
+                generateBundleIdTask.configure {
+                    it.enabled = extension.includeSourceContext.get()
+                }
+                collectSourcesTask.configure {
+                    it.enabled = extension.includeSourceContext.get()
+                }
+                bundleSourcesTask.configure {
+                    it.enabled = extension.includeSourceContext.get()
+                }
+                uploadSourceBundleTask.configure {
+                    it.enabled = extension.includeSourceContext.get()
+                }
+            }
+
             return SourceContextTasks(
                 generateBundleIdTask,
                 collectSourcesTask,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateDebugMetaPropertiesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateDebugMetaPropertiesTask.kt
@@ -34,7 +34,7 @@ abstract class SentryGenerateDebugMetaPropertiesTask : DirectoryOutputTask() {
         val props = Properties()
         props.setProperty("io.sentry.build-tool", "gradle")
         inputFiles.forEach { inputFile ->
-            props.putAll(PropertiesUtil.load(inputFile))
+            PropertiesUtil.loadMaybe(inputFile)?.let { props.putAll(it) }
         }
         debugMetaPropertiesFile.writer().use {
             props.store(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/PropertiesUtil.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/PropertiesUtil.kt
@@ -16,5 +16,13 @@ class PropertiesUtil {
                 }
             }
         }
+
+        fun loadMaybe(file: File): Properties? {
+            if (!file.exists()) {
+                return null
+            }
+
+            return load(file)
+        }
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentrySourceContextNonAndroidTest.kt
@@ -43,6 +43,42 @@ class SentrySourceContextNonAndroidTest(
     }
 
     @Test
+    fun `skips bundle and upload tasks if disabled`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "org.jetbrains.kotlin.jvm"
+              id "io.sentry.jvm.gradle"
+            }
+
+            sentry {
+              includeSourceContext = false
+            }
+            """.trimIndent()
+        )
+
+        sentryPropertiesFile.writeText("")
+
+        testProjectDir.withDummyKtFile()
+        testProjectDir.withDummyJavaFile()
+
+        val result = runner
+            .appendArguments("app:assemble")
+            .build()
+
+        assertEquals(
+            result.task(":app:sentryUploadSourceBundleJava")?.outcome,
+            SKIPPED
+        )
+        assertEquals(
+            result.task(":app:sentryBundleSourcesJava")?.outcome,
+            SKIPPED
+        )
+        assertTrue { "BUILD SUCCESSFUL" in result.output }
+    }
+
+    @Test
     fun `bundles source context`() {
         appBuildFile.writeText(
             // language=Groovy


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use `afterEvaluate` to disable source context tasks. Wasn't able to not add them depending on the value of `includeSourceContext` as that wasn't available yet.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/525

## :green_heart: How did you test it?
Manually using Spring sample and unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
