### PR TITLE
Use Spring Boot autoconfigure modules (`sentry-spring-boot` and `sentry-spring-boot-jakarta`) for auto install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add release information args to proguard mapping upload task ([#476](https://github.com/getsentry/sentry-android-gradle-plugin/pull/476))
 - Auto install Sentry integrations for Java Backend, Desktop, etc. ([#521](https://github.com/getsentry/sentry-android-gradle-plugin/pull/521))
+- Use Spring Boot autoconfigure modules (`sentry-spring-boot` and `sentry-spring-boot-jakarta`) for auto install ([#542](https://github.com/getsentry/sentry-android-gradle-plugin/pull/542))
 
 ### Fixes
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategy.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategy.kt
@@ -28,12 +28,12 @@ abstract class SpringBoot2InstallStrategy : AbstractInstallStrategy {
 
     override val maxSupportedThirdPartyVersion: SemVer get() = MAX_SUPPORTED_VERSION
 
-    override val minSupportedSentryVersion: SemVer get() = SemVer(6, 25, 2)
+    override val minSupportedSentryVersion: SemVer get() = SemVer(6, 28, 0)
 
     companion object Registrar : InstallStrategyRegistrar {
         private const val SPRING_GROUP = "org.springframework.boot"
         private const val SPRING_BOOT_2_ID = "spring-boot-starter"
-        internal const val SENTRY_SPRING_BOOT_2_ID = "sentry-spring-boot-starter"
+        internal const val SENTRY_SPRING_BOOT_2_ID = "sentry-spring-boot"
 
         private val MIN_SUPPORTED_VERSION = SemVer(2, 1, 0)
         private val MAX_SUPPORTED_VERSION = SemVer(2, 9999, 9999)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategy.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategy.kt
@@ -26,12 +26,12 @@ abstract class SpringBoot3InstallStrategy : AbstractInstallStrategy {
 
     override val minSupportedThirdPartyVersion: SemVer get() = MIN_SUPPORTED_VERSION
 
-    override val minSupportedSentryVersion: SemVer get() = SemVer(6, 25, 2)
+    override val minSupportedSentryVersion: SemVer get() = SemVer(6, 28, 0)
 
     companion object Registrar : InstallStrategyRegistrar {
         private const val SPRING_GROUP = "org.springframework.boot"
         private const val SPRING_BOOT_3_ID = "spring-boot-starter"
-        internal const val SENTRY_SPRING_BOOT_3_ID = "sentry-spring-boot-starter-jakarta"
+        internal const val SENTRY_SPRING_BOOT_3_ID = "sentry-spring-boot-jakarta"
 
         private val MIN_SUPPORTED_VERSION = SemVer(3, 0, 0)
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginAutoInstallNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginAutoInstallNonAndroidTest.kt
@@ -58,9 +58,9 @@ class SentryPluginAutoInstallNonAndroidTest(
         assertFalse { "io.sentry:sentry:$SENTRY_SDK_VERSION" in result.output }
         assertFalse { "io.sentry:sentry-spring:$SENTRY_SDK_VERSION" in result.output }
         assertFalse { "io.sentry:sentry-spring-jakarta:$SENTRY_SDK_VERSION" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter:$SENTRY_SDK_VERSION" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot:$SENTRY_SDK_VERSION" in result.output }
         assertFalse {
-            "io.sentry:sentry-spring-boot-starter-jakarta:$SENTRY_SDK_VERSION" in result.output
+            "io.sentry:sentry-spring-boot-jakarta:$SENTRY_SDK_VERSION" in result.output
         }
         assertFalse { "io.sentry:sentry-logback:$SENTRY_SDK_VERSION" in result.output }
         assertFalse { "io.sentry:sentry-log4j2:$SENTRY_SDK_VERSION" in result.output }
@@ -88,17 +88,17 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-spring-jakarta:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-spring-boot-starter-jakarta:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-logback:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-log4j2:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-spring-jakarta:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-spring-boot-jakarta:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-logback:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-log4j2:6.28.0" in result.output }
         assertTrue { "io.sentry:sentry-jdbc:6.10.0" in result.output }
 
         // ensure all dependencies could be resolved
@@ -119,13 +119,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-logback:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-logback:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -144,13 +144,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-log4j2:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-log4j2:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -169,13 +169,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -194,7 +194,7 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
@@ -202,7 +202,7 @@ class SentryPluginAutoInstallNonAndroidTest(
 
         println(result.output)
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -221,13 +221,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -246,13 +246,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -271,13 +271,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -296,13 +296,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -321,13 +321,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-jdbc:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-jdbc:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -346,13 +346,13 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-kotlin-extensions:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-kotlin-extensions:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -371,16 +371,16 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-spring:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-jakarta:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter-jakarta:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-spring:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-jakarta:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot-jakarta:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -399,16 +399,16 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertFalse { "io.sentry:sentry-spring:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-spring-jakarta:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter-jakarta:6.25.2" in result.output }
+        assertFalse { "io.sentry:sentry-spring:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-spring-jakarta:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot-jakarta:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -427,16 +427,16 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertTrue { "io.sentry:sentry-spring:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-spring-boot-starter:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-jakarta:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter-jakarta:6.25.2" in result.output }
+        assertTrue { "io.sentry:sentry-spring:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-spring-boot:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-jakarta:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot-jakarta:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }
@@ -455,16 +455,16 @@ class SentryPluginAutoInstallNonAndroidTest(
             }
 
             sentry.autoInstallation.enabled = true
-            sentry.autoInstallation.sentryVersion = "6.25.2"
+            sentry.autoInstallation.sentryVersion = "6.28.0"
             """.trimIndent()
         )
 
         val result = runListDependenciesTask()
 
-        assertFalse { "io.sentry:sentry-spring:6.25.2" in result.output }
-        assertFalse { "io.sentry:sentry-spring-boot-starter:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-spring-jakarta:6.25.2" in result.output }
-        assertTrue { "io.sentry:sentry-spring-boot-starter-jakarta:6.25.2" in result.output }
+        assertFalse { "io.sentry:sentry-spring:6.28.0" in result.output }
+        assertFalse { "io.sentry:sentry-spring-boot:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-spring-jakarta:6.28.0" in result.output }
+        assertTrue { "io.sentry:sentry-spring-boot-jakarta:6.28.0" in result.output }
         // ensure all dependencies could be resolved
         assertFalse { "FAILED" in result.output }
     }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategyTest.kt
@@ -49,7 +49,7 @@ class SpringBoot2InstallStrategyTest {
 
             with(AutoInstallState.getInstance()) {
                 this.installSpring = installSpring
-                this.sentryVersion = "6.25.2"
+                this.sentryVersion = "6.28.0"
             }
             return SpringBoot2InstallStrategyImpl(logger)
         }
@@ -58,13 +58,13 @@ class SpringBoot2InstallStrategyTest {
     private val fixture = Fixture()
 
     @Test
-    fun `when sentry-spring-boot-starter is a direct dependency logs a message and does nothing`() {
+    fun `when sentry-spring-boot is a direct dependency logs a message and does nothing`() {
         val sut = fixture.getSut(installSpring = false)
         sut.execute(fixture.metadataContext)
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter won't be installed because it was already " +
+                "[sentry] sentry-spring-boot won't be installed because it was already " +
                 "installed directly"
         }
         verify(fixture.metadataContext, never()).details
@@ -77,7 +77,7 @@ class SpringBoot2InstallStrategyTest {
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter won't be installed because the current " +
+                "[sentry] sentry-spring-boot won't be installed because the current " +
                 "version is lower than the minimum supported version (2.1.0)"
         }
         verify(fixture.metadataDetails, never()).allVariants(any())
@@ -90,25 +90,25 @@ class SpringBoot2InstallStrategyTest {
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter won't be installed because the current " +
+                "[sentry] sentry-spring-boot won't be installed because the current " +
                 "version is higher than the maximum supported version (2.9999.9999)"
         }
         verify(fixture.metadataDetails, never()).allVariants(any())
     }
 
     @Test
-    fun `installs sentry-spring-boot-starter with info message`() {
+    fun `installs sentry-spring-boot with info message`() {
         val sut = fixture.getSut()
         sut.execute(fixture.metadataContext)
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter was successfully installed with version: " +
-                "6.25.2"
+                "[sentry] sentry-spring-boot was successfully installed with version: " +
+                "6.28.0"
         }
         verify(fixture.dependencies).add(
             com.nhaarman.mockitokotlin2.check<String> {
-                assertEquals("io.sentry:sentry-spring-boot-starter:6.25.2", it)
+                assertEquals("io.sentry:sentry-spring-boot:6.28.0", it)
             }
         )
     }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategyTest.kt
@@ -49,7 +49,7 @@ class SpringBoot3InstallStrategyTest {
 
             with(AutoInstallState.getInstance()) {
                 this.installSpring = installSpring
-                this.sentryVersion = "6.25.2"
+                this.sentryVersion = "6.28.0"
             }
             return SpringBoot3InstallStrategyImpl(logger)
         }
@@ -58,13 +58,13 @@ class SpringBoot3InstallStrategyTest {
     private val fixture = Fixture()
 
     @Test
-    fun `when sentry-spring-boot-starter-jakarta is direct dependency logs and does nothing`() {
+    fun `when sentry-spring-boot-jakarta is direct dependency logs and does nothing`() {
         val sut = fixture.getSut(installSpring = false)
         sut.execute(fixture.metadataContext)
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter-jakarta won't be installed because it was " +
+                "[sentry] sentry-spring-boot-jakarta won't be installed because it was " +
                 "already installed directly"
         }
         verify(fixture.metadataContext, never()).details
@@ -77,25 +77,25 @@ class SpringBoot3InstallStrategyTest {
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter-jakarta won't be installed because the " +
+                "[sentry] sentry-spring-boot-jakarta won't be installed because the " +
                 "current version is lower than the minimum supported version (3.0.0)"
         }
         verify(fixture.metadataDetails, never()).allVariants(any())
     }
 
     @Test
-    fun `installs sentry-spring-boot-starter-jakarta with info message`() {
+    fun `installs sentry-spring-boot-jakarta with info message`() {
         val sut = fixture.getSut()
         sut.execute(fixture.metadataContext)
 
         assertTrue {
             fixture.logger.capturedMessage ==
-                "[sentry] sentry-spring-boot-starter-jakarta was successfully installed with " +
-                "version: 6.25.2"
+                "[sentry] sentry-spring-boot-jakarta was successfully installed with " +
+                "version: 6.28.0"
         }
         verify(fixture.dependencies).add(
             com.nhaarman.mockitokotlin2.check<String> {
-                assertEquals("io.sentry:sentry-spring-boot-starter-jakarta:6.25.2", it)
+                assertEquals("io.sentry:sentry-spring-boot-jakarta:6.28.0", it)
             }
         )
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use Spring Boot autoconfigure modules (`sentry-spring-boot` and `sentry-spring-boot-jakarta`) for auto install

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After introducing new modules for autoconfigure and making our starter modules bring `spring-boot-starter` this is needed to avoid `StackOverflowException` when combining SAGP with certain other build tool plugins.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
