### PR TITLE
Reduce log level from warn to info for some auto install messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Reduce log level from warn to info for some auto install messages ([#553](https://github.com/getsentry/sentry-android-gradle-plugin/pull/553))
+  - There was some confusion especially around our Spring and Spring Boot integrations where we offer a different set of dependencies for Spring 5 (`sentry-spring`), Spring 6 (`sentry-spring-jakarta`), Spring Boot 2 (`sentry-spring-boot`) and Spring Boot 3 (`sentry-spring-boot-jakarta`) where there's always going to be one that's installed and one that's not installed.
+
 ### Dependencies
 
 - Bump CLI from v2.20.3 to v2.20.5 ([#540](https://github.com/getsentry/sentry-android-gradle-plugin/pull/540), [#545](https://github.com/getsentry/sentry-android-gradle-plugin/pull/545))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AbstractInstallStrategy.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AbstractInstallStrategy.kt
@@ -32,7 +32,7 @@ abstract class AbstractInstallStrategy : ComponentMetadataRule {
         minSupportedThirdPartyVersion?.let {
             parseVersion(context.details.id.version)?.let { thirdPartySemVersion ->
                 if (thirdPartySemVersion < it) {
-                    logger.warn {
+                    logger.info {
                         "$sentryModuleId won't be installed because the current version is " +
                             "lower than the minimum supported version ($it)"
                     }
@@ -43,7 +43,7 @@ abstract class AbstractInstallStrategy : ComponentMetadataRule {
         maxSupportedThirdPartyVersion?.let {
             parseVersion(context.details.id.version)?.let { thirdPartySemVersion ->
                 if (thirdPartySemVersion > it) {
-                    logger.warn {
+                    logger.info {
                         "$sentryModuleId won't be installed because the current version is " +
                             "higher than the maximum supported version ($it)"
                     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users get confused and think this means auto install doesn't work especially for Spring (Boot) where we have two sets of integrations (jakarta and non-jakarta) available and there should only ever be one that's installed.
Closes #549

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
