### PR TITLE
Add url option which is passed through to sentry-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add `url` option which is passed through to `sentry-cli` ([#572](https://github.com/getsentry/sentry-android-gradle-plugin/pull/572))
+  - In case you are self hosting Sentry, you can set `url` to your self hosted instance if your org auth token does not contain a URL
+
 ### Fixes
 
 - Use `spring-boot` instead of `spring-boot-starter` for auto install detection ([#543](https://github.com/getsentry/sentry-android-gradle-plugin/pull/543))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -296,6 +296,7 @@ private fun Variant.configureProguardMappingsTasks(
                 sentryProject = sentryProject?.let { project.provider { it } }
                     ?: extension.projectName,
                 sentryAuthToken = extension.authToken,
+                sentryUrl = extension.url,
                 taskSuffix = name.capitalized,
                 releaseInfo = releaseInfo
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -255,7 +255,8 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                     ?: extension.projectName,
                 sentryAuthToken = extension.authToken,
                 taskSuffix = name.capitalized,
-                releaseInfo = releaseInfo
+                releaseInfo = releaseInfo,
+                sentryUrl = extension.url
             )
             uploadMappingsTask.hookWithMinifyTasks(project, name, guardsquareEnabled)
 
@@ -294,6 +295,7 @@ private fun ApplicationVariant.configureNativeSymbolsTask(
             it.variantName.set(name)
             it.sentryOrganization.set(sentryOrg)
             it.sentryProject.set(sentryProject)
+            it.sentryUrl.set(extension.url)
         }
         uploadSentryNativeSymbolsTask.hookWithAssembleTasks(project, variant)
     } else {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -200,4 +200,13 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
      */
     val authToken: Property<String> = objects.property(String::class.java)
         .convention(null as String?)
+
+    /**
+     * The url of your Sentry instance. If you're using SAAS (not self hosting) you do not have to
+     * set this. If you are self hosting you can set your URL here.
+     *
+     * Default is null meaning Sentry SAAS.
+     */
+    val url: Property<String> = objects.property(String::class.java)
+        .convention(null as String?)
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
@@ -72,6 +72,10 @@ abstract class BundleSourcesTask : Exec() {
     @get:Optional
     abstract val sentryAuthToken: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val sentryUrl: Property<String>
+
     override fun exec() {
         computeCommandLineArgs().let {
             commandLine(it)
@@ -106,6 +110,11 @@ abstract class BundleSourcesTask : Exec() {
 
         if (debug.getOrElse(false)) {
             args.add("--log-level=debug")
+        }
+
+        sentryUrl.orNull?.let {
+            args.add("--url")
+            args.add(it)
         }
 
         args.add("debug-files")
@@ -149,6 +158,7 @@ abstract class BundleSourcesTask : Exec() {
             sentryOrg: Provider<String>,
             sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,
+            sentryUrl: Property<String>,
             includeSourceContext: Property<Boolean>,
             taskSuffix: String = ""
         ): TaskProvider<BundleSourcesTask> {
@@ -160,6 +170,7 @@ abstract class BundleSourcesTask : Exec() {
                 task.sentryOrganization.set(sentryOrg)
                 task.sentryProject.set(sentryProject)
                 task.sentryAuthToken.set(sentryAuthToken)
+                task.sentryUrl.set(sentryUrl)
                 task.sourceDir.set(collectSourcesTask.flatMap { it.output })
                 task.cliExecutable.set(cliExecutable)
                 SentryPropertiesFileProvider.getPropertiesFilePath(project, variant)?.let {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
@@ -51,6 +51,7 @@ class SourceContext {
                 sentryOrg?.let { project.provider { it } } ?: extension.org,
                 sentryProject?.let { project.provider { it } } ?: extension.projectName,
                 extension.authToken,
+                extension.url,
                 extension.includeSourceContext,
                 taskSuffix
             )
@@ -65,6 +66,7 @@ class SourceContext {
                 sentryOrg?.let { project.provider { it } } ?: extension.org,
                 sentryProject?.let { project.provider { it } } ?: extension.projectName,
                 extension.authToken,
+                extension.url,
                 extension.includeSourceContext,
                 taskSuffix
             )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
@@ -62,6 +62,10 @@ abstract class UploadSourceBundleTask : Exec() {
     @get:Optional
     abstract val sentryAuthToken: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val sentryUrl: Property<String>
+
     override fun exec() {
         computeCommandLineArgs().let {
             commandLine(it)
@@ -95,6 +99,11 @@ abstract class UploadSourceBundleTask : Exec() {
 
         if (debug.getOrElse(false)) {
             args.add("--log-level=debug")
+        }
+
+        sentryUrl.orNull?.let {
+            args.add("--url")
+            args.add(it)
         }
 
         args.add("debug-files")
@@ -131,6 +140,7 @@ abstract class UploadSourceBundleTask : Exec() {
             sentryOrg: Provider<String>,
             sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,
+            sentryUrl: Property<String>,
             includeSourceContext: Property<Boolean>,
             taskSuffix: String = ""
         ): TaskProvider<UploadSourceBundleTask> {
@@ -142,6 +152,7 @@ abstract class UploadSourceBundleTask : Exec() {
                 task.sentryOrganization.set(sentryOrg)
                 task.sentryProject.set(sentryProject)
                 task.sentryAuthToken.set(sentryAuthToken)
+                task.sentryUrl.set(sentryUrl)
                 task.sourceBundleDir.set(bundleSourcesTask.flatMap { it.output })
                 task.cliExecutable.set(cliExecutable)
                 task.autoUploadSourceContext.set(autoUploadSourceContext)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -41,6 +41,10 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
     abstract val sentryProject: Property<String>
 
     @get:Input
+    @get:Optional
+    abstract val sentryUrl: Property<String>
+
+    @get:Input
     abstract val includeNativeSources: Property<Boolean>
 
     @get:Internal
@@ -71,6 +75,11 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
 
         if (debug.getOrElse(false)) {
             args.add("--log-level=debug")
+        }
+
+        sentryUrl.orNull?.let {
+            args.add("--url")
+            args.add(it)
         }
 
         args.add("upload-dif")

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -60,6 +60,10 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
     @get:Optional
     abstract val sentryAuthToken: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val sentryUrl: Property<String>
+
     override fun exec() {
         if (!mappingsFiles.isPresent || mappingsFiles.get().isEmpty) {
             error("[sentry] Mapping files are missing!")
@@ -109,6 +113,11 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
 
         if (debug.getOrElse(false)) {
             args.add("--log-level=debug")
+        }
+
+        sentryUrl.orNull?.let {
+            args.add("--url")
+            args.add(it)
         }
 
         args.add("upload-proguard")
@@ -168,6 +177,7 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
             sentryOrg: Provider<String>,
             sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,
+            sentryUrl: Property<String>,
             autoUploadProguardMapping: Property<Boolean>,
             taskSuffix: String = "",
             releaseInfo: ReleaseInfo
@@ -190,6 +200,7 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
                 task.sentryProject.set(sentryProject)
                 task.releaseInfo.set(releaseInfo)
                 task.sentryAuthToken.set(sentryAuthToken)
+                task.sentryUrl.set(sentryUrl)
             }
             return uploadSentryProguardMappingsTask
         }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextNonAndroidTest.kt
@@ -100,6 +100,7 @@ class SentryPluginSourceContextNonAndroidTest :
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
               org = "sentry-sdks"
               projectName = "sentry-android"
+              url = "https://some-host.sentry.io"
             }
             """.trimIndent()
         )
@@ -115,6 +116,7 @@ class SentryPluginSourceContextNonAndroidTest :
             .build()
         assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
         assertTrue { "\"--project\" \"sentry-android\"" in result.output }
+        assertTrue { "\"--url\" \"https://some-host.sentry.io\"" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -81,6 +81,7 @@ class SentryPluginSourceContextTest :
               additionalSourceDirsForSourceContext = ["src/custom/kotlin"]
               org = "sentry-sdks"
               projectName = "sentry-android"
+              url = "https://some-host.sentry.io"
             }
             """.trimIndent()
         )
@@ -97,6 +98,7 @@ class SentryPluginSourceContextTest :
 
         assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
         assertTrue { "\"--project\" \"sentry-android\"" in result.output }
+        assertTrue { "\"--url\" \"https://some-host.sentry.io\"" in result.output }
         assertTrue { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/BundleSourcesTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/BundleSourcesTaskTest.kt
@@ -245,6 +245,31 @@ class BundleSourcesTaskTest {
         }
     }
 
+    @Test
+    fun `with sentryUrl --url is set`() {
+        val project = createProject()
+        val debugMetaPropertiesFile = createDebugMetaProperties(project)
+
+        val sourceDir = File(project.buildDir, "dummy/source")
+        val outDir = File(project.buildDir, "dummy/out")
+        val task: TaskProvider<BundleSourcesTask> =
+            project.tasks.register(
+                "testBundleSources",
+                BundleSourcesTask::class.java
+            ) {
+                it.cliExecutable.set("sentry-cli")
+                it.sourceDir.set(sourceDir)
+                it.bundleIdFile.set(debugMetaPropertiesFile)
+                it.output.set(outDir)
+                it.sentryUrl.set("https://some-host.sentry.io")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+
+        assertTrue("--url" in args)
+        assertTrue("https://some-host.sentry.io" in args)
+    }
+
     private fun createProject(): Project {
         with(ProjectBuilder.builder().build()) {
             plugins.apply("io.sentry.android.gradle")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
@@ -136,6 +136,23 @@ class SentryUploadNativeSymbolsTaskTest {
         assertTrue("dummy-proj" in args)
     }
 
+    @Test
+    fun `with sentryUrl adds --url`() {
+        val project = createProject()
+        val task = createTestTask(project) {
+            it.cliExecutable.set("sentry-cli")
+            it.sentryUrl.set("https://some-host.sentry.io")
+            it.includeNativeSources.set(true)
+            it.variantName.set("debug")
+            it.autoUploadNativeSymbol.set(true)
+        }
+
+        val args = task.computeCommandLineArgs()
+
+        assertTrue("--url" in args)
+        assertTrue("https://some-host.sentry.io" in args)
+    }
+
     private fun createProject(): Project {
         with(ProjectBuilder.builder().build()) {
             plugins.apply("io.sentry.android.gradle")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
@@ -233,6 +233,9 @@ class SentryUploadProguardMappingTaskTest {
     @Test
     fun `with sentryUrl sets --url`() {
         val project = createProject()
+        val uuidFileProvider = createFakeUuid(project)
+        val mappingFile = createMappingFileProvider(project, "dummy/folder/mapping.txt")
+        val releaseInfo = ReleaseInfo("com.test", "1.0.0")
         val task: TaskProvider<SentryUploadProguardMappingsTask> =
             project.tasks.register(
                 "testUploadProguardMapping",

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
@@ -231,6 +231,24 @@ class SentryUploadProguardMappingTaskTest {
     }
 
     @Test
+    fun `with sentryUrl sets --url`() {
+        val project = createProject()
+        val task: TaskProvider<SentryUploadProguardMappingsTask> =
+            project.tasks.register(
+                "testUploadProguardMapping",
+                SentryUploadProguardMappingsTask::class.java
+            ) {
+                it.sentryUrl.set("https://some-host.sentry.io")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+
+
+        assertTrue("--url" in args)
+        assertTrue("https://some-host.sentry.io" in args)
+    }
+
+    @Test
     fun `with sentryOrganization adds --org`() {
         val project = createProject()
         val uuidFileProvider = createFakeUuid(project)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingTaskTest.kt
@@ -239,10 +239,14 @@ class SentryUploadProguardMappingTaskTest {
                 SentryUploadProguardMappingsTask::class.java
             ) {
                 it.sentryUrl.set("https://some-host.sentry.io")
+                it.cliExecutable.set("sentry-cli")
+                it.uuidFile.set(uuidFileProvider)
+                it.mappingsFiles = mappingFile
+                it.autoUploadProguardMapping.set(false)
+                it.releaseInfo.set(ReleaseInfo("com.test", "1.0.0", 1))
             }
 
         val args = task.get().computeCommandLineArgs()
-
 
         assertTrue("--url" in args)
         assertTrue("https://some-host.sentry.io" in args)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/UploadSourceBundleTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/UploadSourceBundleTaskTest.kt
@@ -155,7 +155,6 @@ class UploadSourceBundleTaskTest {
 
         val args = task.get().computeCommandLineArgs()
 
-
         assertTrue("--url" in args)
         assertTrue("https://some-host.sentry.io" in args)
     }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/UploadSourceBundleTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/UploadSourceBundleTaskTest.kt
@@ -138,6 +138,29 @@ class UploadSourceBundleTaskTest {
     }
 
     @Test
+    fun `with sentryUrl --url is set`() {
+        val project = createProject()
+        val sourceBundleDir = File(project.buildDir, "dummy/folder")
+
+        val task: TaskProvider<UploadSourceBundleTask> =
+            project.tasks.register(
+                "testUploadSourceBundle",
+                UploadSourceBundleTask::class.java
+            ) {
+                it.cliExecutable.set("sentry-cli")
+                it.sourceBundleDir.set(sourceBundleDir)
+                it.autoUploadSourceContext.set(true)
+                it.sentryUrl.set("https://some-host.sentry.io")
+            }
+
+        val args = task.get().computeCommandLineArgs()
+
+
+        assertTrue("--url" in args)
+        assertTrue("https://some-host.sentry.io" in args)
+    }
+
+    @Test
     fun `without sentryProperties file SENTRY_PROPERTIES is not set`() {
         val project = createProject()
         val sourceBundleDir = File(project.buildDir, "dummy/folder")


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
A new option `url` which is passed through to `sentry-cli`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/571

## :green_heart: How did you test it?
Unit tests, manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
