### PR TITLE
Print Gradle build error in case build fails

### DIFF
--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginMRJarTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPluginMRJarTest.kt
@@ -24,7 +24,7 @@ class SentryPluginMRJarTest :
             .appendArguments("app:assembleDebug")
             .build()
 
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     @Test
@@ -44,8 +44,8 @@ class SentryPluginMRJarTest :
             .appendArguments("app:assembleDebug")
             .build()
 
-        assertTrue { "Please update to AGP >= 7.1.2" in result.output }
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Please update to AGP >= 7.1.2" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     override val additionalRootProjectConfig: String = ""

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginKotlinCompilerTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginKotlinCompilerTest.kt
@@ -65,6 +65,6 @@ class SentryPluginKotlinCompilerTest :
             .appendArguments("app:assembleRelease")
             .build()
 
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextNonAndroidTest.kt
@@ -43,7 +43,7 @@ class SentryPluginSourceContextNonAndroidTest :
             result.task(":app:sentryBundleSourcesJava")?.outcome,
             SKIPPED
         )
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     @Test
@@ -79,7 +79,7 @@ class SentryPluginSourceContextNonAndroidTest :
             result.task(":app:sentryBundleSourcesJava")?.outcome,
             SKIPPED
         )
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     @Test
@@ -114,10 +114,10 @@ class SentryPluginSourceContextNonAndroidTest :
         val result = runner
             .appendArguments("app:assemble")
             .build()
-        assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
-        assertTrue { "\"--project\" \"sentry-android\"" in result.output }
-        assertTrue { "\"--url\" \"https://some-host.sentry.io\"" in result.output }
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "\"--org\" \"sentry-sdks\"" in result.output }
+        assertTrue(result.output) { "\"--project\" \"sentry-android\"" in result.output }
+        assertTrue(result.output) { "\"--url\" \"https://some-host.sentry.io\"" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(
             testProjectDir.root,
@@ -178,8 +178,8 @@ class SentryPluginSourceContextNonAndroidTest :
             .appendArguments("--configuration-cache")
             .build()
 
-        assertTrue { "Configuration cache entry stored." in result.output }
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Configuration cache entry stored." in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(
             testProjectDir.root,

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -52,7 +52,7 @@ class SentryPluginSourceContextTest :
             result.task(":app:sentryBundleSourcesRelease")?.outcome,
             SKIPPED
         )
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     @Test
@@ -96,10 +96,10 @@ class SentryPluginSourceContextTest :
             .appendArguments("app:assembleRelease")
             .build()
 
-        assertTrue { "\"--org\" \"sentry-sdks\"" in result.output }
-        assertTrue { "\"--project\" \"sentry-android\"" in result.output }
-        assertTrue { "\"--url\" \"https://some-host.sentry.io\"" in result.output }
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "\"--org\" \"sentry-sdks\"" in result.output }
+        assertTrue(result.output) { "\"--project\" \"sentry-android\"" in result.output }
+        assertTrue(result.output) { "\"--url\" \"https://some-host.sentry.io\"" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(
             testProjectDir.root,
@@ -164,8 +164,8 @@ class SentryPluginSourceContextTest :
             .appendArguments("--configuration-cache")
             .build()
 
-        assertTrue { "Configuration cache entry stored." in result.output }
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Configuration cache entry stored." in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
 
         verifySourceBundleContents(
             testProjectDir.root,

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithDependencyCollectorsNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithDependencyCollectorsNonAndroidTest.kt
@@ -38,7 +38,7 @@ class SentryPluginWithDependencyCollectorsNonAndroidTest :
             .appendArguments("app:collectDependencies")
             .build()
 
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     override val additionalBuildClasspath: String =

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithDependencyCollectorsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithDependencyCollectorsTest.kt
@@ -45,7 +45,7 @@ class SentryPluginWithDependencyCollectorsTest :
             .appendArguments("app:assembleRelease")
             .build()
 
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     override val additionalBuildClasspath: String =

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithFirebaseTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithFirebaseTest.kt
@@ -46,7 +46,7 @@ class SentryPluginWithFirebaseTest :
             .appendArguments("app:assembleRelease")
             .build()
 
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     override val additionalBuildClasspath: String =

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithMinifiedLibsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginWithMinifiedLibsTest.kt
@@ -30,7 +30,7 @@ class SentryPluginWithMinifiedLibsTest :
             .appendArguments("app:assembleDebug")
             .build()
 
-        assertTrue { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
     }
 
     override val additionalRootProjectConfig: String = ""


### PR DESCRIPTION
## :scroll: Description

#skip-changelog

## :bulb: Motivation and Context
In case a Gradle build fails, simply print the the build log to make it easier to find the root cause.

## :green_heart: How did you test it?
Manual test runs

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
