### PR TITLE
Make progard release association backward-compatible

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
@@ -3,6 +3,7 @@ package io.sentry.android.gradle.sourcecontext
 import io.sentry.android.gradle.SentryPropertiesFileProvider
 import io.sentry.android.gradle.autoinstall.SENTRY_GROUP
 import io.sentry.android.gradle.sourcecontext.GenerateBundleIdTask.Companion.SENTRY_BUNDLE_ID_PROPERTY
+import io.sentry.android.gradle.tasks.SentryCliExec
 import io.sentry.android.gradle.util.PropertiesUtil
 import io.sentry.android.gradle.util.info
 import io.sentry.gradle.common.SentryVariant
@@ -13,7 +14,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -23,7 +23,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
 
-abstract class BundleSourcesTask : Exec() {
+abstract class BundleSourcesTask : SentryCliExec() {
 
     init {
         group = SENTRY_GROUP

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
@@ -2,6 +2,7 @@ package io.sentry.android.gradle.sourcecontext
 
 import io.sentry.android.gradle.SentryPropertiesFileProvider
 import io.sentry.android.gradle.autoinstall.SENTRY_GROUP
+import io.sentry.android.gradle.tasks.SentryCliExec
 import io.sentry.android.gradle.util.info
 import io.sentry.gradle.common.SentryVariant
 import java.io.File
@@ -10,14 +11,13 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskProvider
 
-abstract class UploadSourceBundleTask : Exec() {
+abstract class UploadSourceBundleTask : SentryCliExec() {
 
     init {
         group = SENTRY_GROUP

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExec.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExec.kt
@@ -1,0 +1,34 @@
+package io.sentry.android.gradle.tasks
+
+import io.sentry.android.gradle.util.CliFailureReason
+import io.sentry.android.gradle.util.CliFailureReason.OUTDATED
+import io.sentry.android.gradle.util.warn
+import java.io.ByteArrayOutputStream
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Exec
+
+/**
+ * A base class for tasks that wrap sentry-cli, which provides common error handling.
+ */
+abstract class SentryCliExec : Exec() {
+    init {
+        errorOutput = ByteArrayOutputStream()
+        isIgnoreExitValue = true
+
+        @Suppress("LeakingThis")
+        doLast {
+            val err = errorOutput.toString()
+            if (executionResult.get().exitValue != 0) {
+                when (val reason = CliFailureReason.fromErrOut(err)) {
+                    OUTDATED -> logger.warn { reason.message(name) }
+                    else -> {
+                        logger.lifecycle(err)
+                        throw GradleException(reason.message(name))
+                    }
+                }
+            } else if (err.isNotEmpty()) {
+                logger.lifecycle(err)
+            }
+        }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -6,13 +6,12 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 
-abstract class SentryUploadNativeSymbolsTask : Exec() {
+abstract class SentryUploadNativeSymbolsTask : SentryCliExec() {
 
     init {
         description = "Uploads native symbols to Sentry"

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -12,14 +12,13 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskProvider
 
-abstract class SentryUploadProguardMappingsTask : Exec() {
+abstract class SentryUploadProguardMappingsTask : SentryCliExec() {
 
     init {
         description = "Uploads the proguard mappings file to Sentry"

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/CliFailureReason.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/CliFailureReason.kt
@@ -1,0 +1,71 @@
+package io.sentry.android.gradle.util
+
+enum class CliFailureReason(val message: (taskName: String) -> String) {
+    OUTDATED({
+        """
+    The task '$it' hit a non-existing endpoint on Sentry.
+    Most likely you have to update your self-hosted Sentry version to get all of the latest features.
+        """.trimIndent()
+    }),
+    ORG_SLUG({
+        """
+    An organization slug is required. You might want to provide your Sentry org name via the 'sentry.properties' file:
+    ```
+    defaults.org=my-org
+    ```
+
+    or via configuring the 'sentry' gradle plugin extension:
+    ```
+    sentry {
+      org.set("my-org")
+    }
+        """.trimIndent()
+    }),
+    PROJECT_SLUG({
+        """
+    A project slug is required. You might want to provide your Sentry project name via the 'sentry.properties' file:
+    ```
+    defaults.project=my-project
+    ```
+
+    or via configuring the 'sentry' gradle plugin extension:
+    ```
+    sentry {
+      projectName.set("my-project")
+    }
+    ```
+        """.trimIndent()
+    }),
+    INVALID_ORG_AUTH_TOKEN({
+        """
+    Failed to parse org auth token. You might want to provide a custom url to your self-hosted Sentry instance via the 'sentry.properties' file:
+    ```
+    defaults.url=https://mysentry.invalid/
+    ```
+
+    or via configuring the 'sentry' gradle plugin extension:
+    ```
+    sentry {
+      url.set("https://mysentry.invalid/")
+    }
+    ```
+        """.trimIndent()
+    }),
+    UNKNOWN({
+        """
+    An error occurred while executing task '$it'. Please check the detailed sentry-cli output above.
+        """.trimIndent()
+    });
+
+    companion object {
+        fun fromErrOut(errOut: String): CliFailureReason {
+            return when {
+                errOut.contains("error: resource not found") -> OUTDATED
+                errOut.contains("error: An organization slug is required") -> ORG_SLUG
+                errOut.contains("error: A project slug is required") -> PROJECT_SLUG
+                errOut.contains("error: Failed to parse org auth token") -> INVALID_ORG_AUTH_TOKEN
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -94,6 +94,7 @@ abstract class BaseSentryPluginTest(
             .withArguments("--stacktrace")
             .withPluginClasspath()
             .withGradleVersion(gradleVersion)
+            .forwardOutput()
     }
 
     companion object {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -94,7 +94,6 @@ abstract class BaseSentryPluginTest(
             .withArguments("--stacktrace")
             .withPluginClasspath()
             .withGradleVersion(gradleVersion)
-            .forwardOutput()
     }
 
     companion object {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIntegrationTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIntegrationTest.kt
@@ -46,6 +46,10 @@ class SentryPluginIntegrationTest :
             build.task(":app:uploadSentryProguardMappingsRelease")?.outcome,
             TaskOutcome.SUCCESS
         )
+        assertTrue(build.output) {
+            "Most likely you have to update your self-hosted Sentry version " +
+                "to get all of the latest features." in build.output
+        }
     }
 
     @Test
@@ -95,7 +99,12 @@ class SentryPluginIntegrationTest :
         appBuildFile.appendText(
             // language=Groovy
             """
+                dependencies {
+                    implementation 'androidx.fragment:fragment:1.3.5'
+                }
+
                 sentry {
+                  debug = true
                   includeProguardMapping = true
                   autoUploadProguardMapping = true
                   uploadNativeSymbols = false

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/CliFailureReasonTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/CliFailureReasonTest.kt
@@ -1,0 +1,37 @@
+package io.sentry.android.gradle.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class CliFailureReasonTest(
+    private val stdErr: String,
+    private val expectedReason: CliFailureReason
+) {
+
+    @Test
+    fun `parses reason from stderr`() {
+        val message = "somethingsomething\n$stdErr"
+
+        val reason = CliFailureReason.fromErrOut(message)
+
+        assertEquals(expectedReason, reason)
+    }
+
+    companion object {
+        @Parameterized.Parameters(name = "{1}")
+        @JvmStatic
+        fun parameters() = listOf(
+            arrayOf("error: resource not found", CliFailureReason.OUTDATED),
+            arrayOf("error: An organization slug is required", CliFailureReason.ORG_SLUG),
+            arrayOf("error: A project slug is required", CliFailureReason.PROJECT_SLUG),
+            arrayOf(
+                "error: Failed to parse org auth token",
+                CliFailureReason.INVALID_ORG_AUTH_TOKEN
+            ),
+            arrayOf("error: we don't do that here", CliFailureReason.UNKNOWN)
+        )
+    }
+}

--- a/test/integration-test-server.py
+++ b/test/integration-test-server.py
@@ -42,7 +42,10 @@ class Handler(BaseHTTPRequestHandler):
         self.flushLogs()
 
     def do_POST(self):
-        self.start_response(HTTPStatus.OK)
+        if self.isApi('/api/0/projects/{}/{}/files/proguard-artifact-releases/'.format(apiOrg, apiProject)):
+            self.start_response(HTTPStatus.NOT_FOUND)
+        else:
+            self.start_response(HTTPStatus.OK)
 
         if self.isApi('api/0/projects/{}/{}/files/difs/assemble/'.format(apiOrg, apiProject)):
             # Request body example:


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Introduce a new `SentryCliExec` base task that wraps all sentry-cli related tasks and provides common error handling by parsing stderr
	* If the error is known we print an explanation and fail the build
	* The only exception to the above^ is when we hit a "resource not found" (404) error, in this case we just print a warning and continue the build 
	* If the error is unknown we still fail the build but without our own explanation, relying on sentry-cli to provide details
* Tweaked the integration tests a bit, so they return 404 for the release-association endpoint to have it properly tested

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #559 
Closes #538 

## :green_heart: How did you test it?
Manually + autoamted

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
