### PR TITLE
Print a warning if the plugin is not applied on the app module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Print a warning if the Sentry plugin is not applied on the app module ([#586](https://github.com/getsentry/sentry-android-gradle-plugin/pull/586))
+
 ## 3.14.0
 
 ### Features

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -33,6 +33,15 @@ abstract class SentryPlugin : Plugin<Project> {
                 """.trimIndent()
             )
         }
+        if (!project.plugins.hasPlugin("com.android.application")) {
+            project.logger.warn(
+                """
+                WARNING: Using 'io.sentry.android.gradle' is only supported for the app module.
+                Please make sure that you apply the Sentry gradle plugin alongside 'com.android.application' on the _module_ level, and not on the root project level.
+                https://docs.sentry.io/platforms/android/configuration/gradle/
+                """.trimIndent()
+            )
+        }
 
         val extension = project.extensions.create(
             "sentry",


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
In theory we could even fail the build, but I don't dare doing that because not sure how it will behave for custom build logic, so warning is good enough

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #301 

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
