### PR TITLE
Add new 'excludes' option to exclude classes from instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Print a warning if the Sentry plugin is not applied on the app module ([#586](https://github.com/getsentry/sentry-android-gradle-plugin/pull/586))
+- Add new `excludes` option to exclude classes from instrumentation ([#590](https://github.com/getsentry/sentry-android-gradle-plugin/pull/590))
 
 ### Chores
 

--- a/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
+++ b/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
@@ -18,6 +18,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskProvider
 
 data class AndroidVariant74(
@@ -73,6 +74,7 @@ fun <T : InstrumentationParameters> configureInstrumentationFor74(
     classVisitorFactoryImplClass: Class<out AsmClassVisitorFactory<T>>,
     scope: InstrumentationScope,
     mode: FramesComputationMode,
+    excludes: SetProperty<String>,
     instrumentationParamsConfig: (T) -> Unit
 ) {
     variant.instrumentation.transformClassesWith(
@@ -81,6 +83,7 @@ fun <T : InstrumentationParameters> configureInstrumentationFor74(
         instrumentationParamsConfig
     )
     variant.instrumentation.setAsmFramesComputationMode(mode)
+    variant.instrumentation.excludes.set(excludes)
 }
 
 fun onVariants74(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -39,6 +39,7 @@ import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.info
 import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.build.event.BuildEventsListenerRegistry
 
@@ -116,6 +117,7 @@ fun AndroidComponentsExtension<*, *, *>.configure(
                     SpanAddingClassVisitorFactory::class.java,
                     InstrumentationScope.ALL,
                     FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS,
+                    extension.tracingInstrumentation.excludes
                 ) { params ->
                     if (extension.tracingInstrumentation.forceInstrumentDependencies.get()) {
                         params.invalidate.setDisallowChanges(System.currentTimeMillis())
@@ -319,6 +321,7 @@ private fun <T : InstrumentationParameters> Variant.configureInstrumentation(
     classVisitorFactoryImplClass: Class<out AsmClassVisitorFactory<T>>,
     scope: InstrumentationScope,
     mode: FramesComputationMode,
+    excludes: SetProperty<String>,
     instrumentationParamsConfig: (T) -> Unit,
 ) {
     if (isAGP74) {
@@ -327,6 +330,7 @@ private fun <T : InstrumentationParameters> Variant.configureInstrumentation(
             classVisitorFactoryImplClass,
             scope,
             mode,
+            excludes,
             instrumentationParamsConfig
         )
     } else {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/TracingInstrumentationExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/TracingInstrumentationExtension.kt
@@ -48,6 +48,24 @@ open class TracingInstrumentationExtension @Inject constructor(objects: ObjectFa
             )
         )
 
+    /**
+     * The set of glob patterns to exclude from instrumentation. Classes matching any of these
+     * patterns in the project sources and dependencies jars do not get instrumented by the Sentry
+     * Gradle plugin.
+     *
+     * Do not add the file extension to the end as the filtration is done on compiled classes and
+     * the .class suffix is not included in the pattern matching.
+     *
+     * Example usage:
+     * ```
+     * excludes.set(setOf("com/example/donotinstrument/**", "**/*Test"))
+     * ```
+     *
+     * Only supported when using Android Gradle plugin (AGP) version 7.4.0 and above.
+     */
+    val excludes: SetProperty<String> = objects.setProperty(String::class.java)
+        .convention(emptySet())
+
     val logcat: LogcatExtension = objects.newInstance(
         LogcatExtension::class.java
     )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -13,7 +13,7 @@ import org.junit.rules.TemporaryFolder
 
 @Suppress("FunctionName")
 abstract class BaseSentryPluginTest(
-    private val androidGradlePluginVersion: String,
+    protected val androidGradlePluginVersion: String,
     private val gradleVersion: String
 ) {
     @get:Rule

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -2,6 +2,8 @@ package io.sentry.android.gradle.integration
 
 import io.sentry.BuildConfig
 import io.sentry.android.gradle.extensions.InstrumentationFeature
+import io.sentry.android.gradle.util.AgpVersions
+import io.sentry.android.gradle.util.SemVer
 import io.sentry.android.gradle.verifyDependenciesReportAndroid
 import io.sentry.android.gradle.verifyDependenciesReportJava
 import io.sentry.android.gradle.verifyIntegrationList
@@ -11,7 +13,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import org.gradle.util.GradleVersion
+import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.assertThrows
+import org.junit.Assume.assumeThat
 import org.junit.Test
 
 class SentryPluginTest :
@@ -566,6 +570,11 @@ class SentryPluginTest :
 
     @Test
     fun `does not instrument classes that are provided in excludes`() {
+        assumeThat(
+            "We only support the 'excludes' option from AGP 7.4.0 onwards",
+            SemVer.parse(androidGradlePluginVersion) >= AgpVersions.VERSION_7_4_0,
+            `is`(true)
+        )
         applyTracingInstrumentation(
             features = setOf(InstrumentationFeature.OKHTTP),
             debug = true,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Add new `excludes` option to exclude classes from instrumentation. The option just wires to the existing [excludes API](https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/variant/Instrumentation#excludes()) from AGP, and only available on AGP 7.4+

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #306 
Closes #218 

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
- [ ] Update docs