### PR TITLE
Use new AGP api for native symbols upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Chores
 
 - Change cli command from `upload-dif` to `debug-files upload` for native symbols ([#587](https://github.com/getsentry/sentry-android-gradle-plugin/pull/587))
+- Use new AGP api for native symbols upload ([#592](https://github.com/getsentry/sentry-android-gradle-plugin/pull/592))
 
 **Breaking changes:**
 

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -23,7 +23,6 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isDebuggable = false
             isMinifyEnabled = true
             proguardFiles.add(getDefaultProguardFile("proguard-android-optimize.txt"))
             signingConfig = signingConfigs.getByName("debug")

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -23,6 +23,7 @@ android {
     }
     buildTypes {
         getByName("release") {
+            isDebuggable = false
             isMinifyEnabled = true
             proguardFiles.add(getDefaultProguardFile("proguard-android-optimize.txt"))
             signingConfig = signingConfigs.getByName("debug")

--- a/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/JavaVariant.kt
+++ b/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/JavaVariant.kt
@@ -18,6 +18,7 @@ data class JavaVariant(
     override val buildTypeName = null
     override val productFlavors = emptyList<String>()
     override val isMinifyEnabled = false
+    override val isDebuggable = false
 
     override val assembleProvider: TaskProvider<out Task>?
         get() = project.tasks.named("assemble", DefaultTask::class.java)

--- a/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/SentryVariant.kt
+++ b/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/SentryVariant.kt
@@ -17,6 +17,7 @@ interface SentryVariant {
     val buildTypeName: String?
     val productFlavors: List<String>
     val isMinifyEnabled: Boolean
+    val isDebuggable: Boolean
     val packageProvider: TaskProvider<out Task>? get() = null
     val assembleProvider: TaskProvider<out Task>? get() = null
     fun mappingFileProvider(project: Project): Provider<FileCollection>

--- a/plugin-build/src/agp70/kotlin/io/sentry/android/gradle/AGP70Compat.kt
+++ b/plugin-build/src/agp70/kotlin/io/sentry/android/gradle/AGP70Compat.kt
@@ -25,6 +25,7 @@ data class AndroidVariant70(
     override val buildTypeName: String = variant.buildType.name
     override val productFlavors: List<String> = variant.productFlavors.map { it.name }
     override val isMinifyEnabled: Boolean = variant.buildType.isMinifyEnabled
+    override val isDebuggable: Boolean = variant.buildType.isDebuggable
     override val packageProvider: TaskProvider<out Task>? = variant.packageApplicationProvider
     override val assembleProvider: TaskProvider<out Task>? = variant.assembleProvider
     override fun mappingFileProvider(project: Project): Provider<FileCollection> =

--- a/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
+++ b/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
@@ -10,6 +10,7 @@ import com.android.build.api.instrumentation.InstrumentationScope
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.CanMinifyCode
 import com.android.build.api.variant.Variant
+import com.android.build.api.variant.impl.ApplicationVariantImpl
 import com.android.build.api.variant.impl.VariantImpl
 import io.sentry.gradle.common.SentryVariant
 import org.gradle.api.Project
@@ -28,6 +29,9 @@ data class AndroidVariant74(
     override val buildTypeName: String? = variant.buildType
     override val productFlavors: List<String> = variant.productFlavors.map { it.second }
     override val isMinifyEnabled: Boolean = (variant as? CanMinifyCode)?.isMinifyEnabled == true
+
+    // TODO: replace this eventually (when targeting AGP 8.3.0) with https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-api/src/main/java/com/android/build/api/variant/Component.kt;l=103-104;bpv=1
+    override val isDebuggable: Boolean = (variant as? ApplicationVariantImpl)?.debuggable == true
 
     // internal APIs are a bit dirty, but our plugin would need a lot of rework to make proper
     // dependencies via artifacts API.

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -15,8 +15,8 @@ import io.sentry.android.gradle.sourcecontext.SourceContext
 import io.sentry.android.gradle.tasks.PropertiesFileOutputTask
 import io.sentry.android.gradle.tasks.SentryGenerateDebugMetaPropertiesTask
 import io.sentry.android.gradle.tasks.SentryGenerateProguardUuidTask
-import io.sentry.android.gradle.tasks.SentryUploadNativeSymbolsTask
 import io.sentry.android.gradle.tasks.SentryUploadProguardMappingsTask
+import io.sentry.android.gradle.tasks.configureNativeSymbolsTask
 import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTaskFactory
 import io.sentry.android.gradle.util.AgpVersions
 import io.sentry.android.gradle.util.AgpVersions.isAGP74
@@ -24,7 +24,6 @@ import io.sentry.android.gradle.util.ReleaseInfo
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.SentryPluginUtils.withLogging
-import io.sentry.android.gradle.util.asSentryCliExec
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.hookWithPackageTasks
@@ -82,7 +81,9 @@ fun AppExtension.configure(
         )
         generateProguardUuidTask?.let { tasksGeneratingProperties.add(it) }
 
-        variant.configureNativeSymbolsTask(
+        // TODO: do this only once, and all other tasks should be SentryVariant.configureSomething
+        val sentryVariant = if (isAGP74) null else AndroidVariant70(variant)
+        sentryVariant?.configureNativeSymbolsTask(
             project,
             extension,
             cliExecutable,
@@ -265,43 +266,6 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
         } else {
             return null
         }
-    }
-}
-
-private fun ApplicationVariant.configureNativeSymbolsTask(
-    project: Project,
-    extension: SentryPluginExtension,
-    cliExecutable: String,
-    sentryOrg: String?,
-    sentryProject: String?
-) {
-    // only debug symbols of non debuggable code should be uploaded (aka release builds).
-    // uploadSentryNativeSymbols task will only be executed after the assemble task
-    // and also only if `uploadNativeSymbols` is enabled, as this is an opt-in feature.
-    if (!buildType.isDebuggable && extension.uploadNativeSymbols.get()) {
-        val variant = AndroidVariant70(this)
-        val sentryProps = getPropertiesFilePath(project, variant)
-
-        // Setup the task to upload native symbols task after the assembling task
-        val uploadSentryNativeSymbolsTask = project.tasks.register(
-            "uploadSentryNativeSymbolsFor${name.capitalized}",
-            SentryUploadNativeSymbolsTask::class.java
-        ) {
-            it.workingDir(project.rootDir)
-            it.debug.set(extension.debug)
-            it.autoUploadNativeSymbol.set(extension.autoUploadNativeSymbols)
-            it.cliExecutable.set(cliExecutable)
-            it.sentryProperties.set(sentryProps?.let { file -> project.file(file) })
-            it.includeNativeSources.set(extension.includeNativeSources)
-            it.variantName.set(name)
-            it.sentryOrganization.set(sentryOrg)
-            it.sentryProject.set(sentryProject)
-            it.sentryUrl.set(extension.url)
-            it.asSentryCliExec()
-        }
-        uploadSentryNativeSymbolsTask.hookWithAssembleTasks(project, variant)
-    } else {
-        project.logger.info { "uploadSentryNativeSymbols won't be executed" }
     }
 }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -246,9 +246,8 @@ class SentryPluginTest :
             .appendArguments(":app:assembleDebug", "--info")
             .build()
 
-        val instr = "OkHttpEventListener, OkHttp"
         assertTrue {
-            "[sentry] Instrumentable: ChainedInstrumentable(instrumentables=$instr)" in build.output
+            "[sentry] Instrumentable: ChainedInstrumentable(instrumentables=OkHttp)" in build.output
         }
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -3,7 +3,6 @@ package io.sentry.android.gradle.integration
 import io.sentry.BuildConfig
 import io.sentry.android.gradle.extensions.InstrumentationFeature
 import io.sentry.android.gradle.verifyDependenciesReportAndroid
-import io.sentry.android.gradle.verifyDependenciesReportJava
 import io.sentry.android.gradle.verifyIntegrationList
 import io.sentry.android.gradle.verifyProguardUuid
 import kotlin.test.assertEquals
@@ -420,38 +419,6 @@ class SentryPluginTest :
         assertThrows(AssertionError::class.java) {
             verifyDependenciesReportAndroid(testProjectDir.root)
         }
-    }
-
-    @Test
-    fun `works for pure java modules`() {
-        moduleBuildFile.writeText(
-            // language=Groovy
-            """
-            plugins {
-                id 'java'
-                id 'io.sentry.jvm.gradle'
-            }
-
-            dependencies {
-              implementation 'ch.qos.logback:logback-classic:1.4.8'
-            }
-
-            sentry.autoInstallation.sentryVersion = "6.25.2"
-            """.trimIndent()
-        )
-
-        runner.appendArguments(":module:jar").build()
-        val deps = verifyDependenciesReportJava(testProjectDir.root)
-        assertEquals(
-            """
-            ch.qos.logback:logback-classic:1.4.8
-            ch.qos.logback:logback-core:1.4.8
-            io.sentry:sentry-logback:6.25.2
-            io.sentry:sentry:6.25.2
-            org.slf4j:slf4j-api:2.0.7
-            """.trimIndent(),
-            deps
-        )
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* This was the last remaining thing which was using an older AGP API, now we have proper decoupling per agp-compat source set

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #109 

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
* Eventually we'd need to configure tasks on the `SentryVariant` level to have it abstracted away, and then we could even move everything to the `common` module and it could be shared between Android and Jvm plugins. Probably gonna be part of #403 