### PR TITLE
Retrieve org from extension, disable telemetry on CI

### DIFF
--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -103,6 +103,8 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-version: ${{ matrix.gradle }}
+          gradle-home-cache-excludes: |
+            caches/transforms-3
           arguments: integrationTest
 
       - name: Upload Test Results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Retrieve `sentryOrg` from the `SentryPluginExtension` for telemetry ([#599](https://github.com/getsentry/sentry-android-gradle-plugin/pull/599))
+
 ### Dependencies
 
 - Bump CLI from v2.21.5 to v2.22.2 ([#598](https://github.com/getsentry/sentry-android-gradle-plugin/pull/598))

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -58,6 +58,7 @@ object Libs {
 }
 
 object CI {
+    const val SENTRY_SDKS_DSN = "https://dd1f82ad30a331bd7def2a0dce926c6e@o447951.ingest.sentry.io/4506031723446272"
     fun canAutoUpload(): Boolean {
         return System.getenv("AUTO_UPLOAD").toBoolean() &&
                 !System.getenv("SENTRY_AUTH_TOKEN").isNullOrEmpty()

--- a/examples/android-gradle-kts/build.gradle.kts
+++ b/examples/android-gradle-kts/build.gradle.kts
@@ -23,6 +23,7 @@ android {
 sentry {
     autoUploadProguardMapping.set(CI.canAutoUpload())
 
+    telemetryDsn.set(CI.SENTRY_SDKS_DSN)
     tracingInstrumentation {
         enabled.set(false)
     }

--- a/examples/android-gradle/build.gradle
+++ b/examples/android-gradle/build.gradle
@@ -34,6 +34,7 @@ android {
 sentry {
     autoUploadProguardMapping = CI.INSTANCE.canAutoUpload()
 
+    telemetryDsn = CI.INSTANCE.SENTRY_SDKS_DSN
     tracingInstrumentation {
         enabled = false
     }

--- a/examples/android-guardsquare-proguard/build.gradle
+++ b/examples/android-guardsquare-proguard/build.gradle
@@ -50,6 +50,7 @@ sentry {
 
     dexguardEnabled = true
 
+    telemetryDsn = CI.INSTANCE.SENTRY_SDKS_DSN
     tracingInstrumentation {
         enabled = false
     }

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -110,6 +110,7 @@ sentry {
 
     org.set("sentry-sdks")
     projectName.set("sentry-android")
+    telemetryDsn.set(CI.SENTRY_SDKS_DSN)
 
     tracingInstrumentation {
         forceInstrumentDependencies.set(true)

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -108,6 +108,9 @@ sentry {
     autoUploadSourceContext.set(CI.canAutoUpload())
     additionalSourceDirsForSourceContext.set(setOf("src/custom/java"))
 
+    org.set("sentry-sdks")
+    projectName.set("sentry-android")
+
     tracingInstrumentation {
         forceInstrumentDependencies.set(true)
     }

--- a/examples/android-instrumentation-sample/sentry.properties
+++ b/examples/android-instrumentation-sample/sentry.properties
@@ -1,2 +1,0 @@
-defaults.project=sentry-android
-defaults.org=sentry-sdks

--- a/examples/android-ndk/build.gradle
+++ b/examples/android-ndk/build.gradle
@@ -41,6 +41,7 @@ if (System.getenv("AUTO_UPLOAD")) {
         includeNativeSources = true
         autoUploadNativeSymbols = CI.INSTANCE.canAutoUpload()
 
+        telemetryDsn = CI.INSTANCE.SENTRY_SDKS_DSN
         tracingInstrumentation {
             enabled = false
         }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -113,7 +113,11 @@ abstract class SentryTelemetryService :
 
                 hub.configureScope { scope ->
                     scope.user = User().also { user ->
-                        startParameters.defaultSentryOrganization?.let { user.id = it }
+                        startParameters.defaultSentryOrganization?.let { org ->
+                            if (org != "-") {
+                                user.id = org
+                            }
+                        }
                         startParameters.sentryOrganization?.let { user.id = it }
                     }
                 }
@@ -245,6 +249,7 @@ abstract class SentryTelemetryService :
             buildType: String
         ): SentryTelemetryServiceParams {
             val tags = extraTagsFromExtension(project, extension)
+            val org = sentryOrg ?: extension.org.orNull
 
             if (isExecAvailable()) {
                 return paramsWithExecAvailable(
@@ -252,7 +257,7 @@ abstract class SentryTelemetryService :
                     cliExecutable,
                     extension,
                     variant,
-                    sentryOrg,
+                    org,
                     buildType,
                     tags
                 )
@@ -260,7 +265,7 @@ abstract class SentryTelemetryService :
                 return SentryTelemetryServiceParams(
                     extension.telemetry.get(),
                     extension.telemetryDsn.get(),
-                    sentryOrg,
+                    org,
                     buildType,
                     tags,
                     extension.debug.get(),

--- a/plugin-build/src/test/resources/testFixtures/appTestProject/app/build.gradle
+++ b/plugin-build/src/test/resources/testFixtures/appTestProject/app/build.gradle
@@ -18,4 +18,5 @@ sentry {
     autoInstallation {
         enabled = false
     }
+    telemetry = false
 }

--- a/plugin-build/src/test/resources/testFixtures/appTestProject/gradle.properties
+++ b/plugin-build/src/test/resources/testFixtures/appTestProject/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+CrashOnOutOfMemoryError
 org.gradle.daemon=false
-org.gradle.parallel=false
+org.gradle.parallel=true
 
 android.useAndroidX=true

--- a/plugin-build/src/test/resources/testFixtures/appTestProject/gradle.properties
+++ b/plugin-build/src/test/resources/testFixtures/appTestProject/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+CrashOnOutOfMemoryError
 org.gradle.daemon=false
-org.gradle.parallel=true
+org.gradle.parallel=false
 
 android.useAndroidX=true


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Disables telemetry for the test fixture project to not flood sentry with CI events
* Retrieve sentryOrg from the extension, if it's not available in extra properties
  * Also, don't set it to `-`, because it means it's empty on the cli 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
