### PR TITLE
Changelog and v7 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Version 4 of the Sentry Android Gradle plugin brings a variety of features and f
 - Rename `experimentalGuardsquareSupport` flag to `dexguardEnabled`
 - Add new `excludes` option to allow excluding certain classes from instrumentation. It's available under the `sentry.tracingInstrumentation` extension
 
+## Sentry Android SDK Compatibility
+
+Make sure to use Sentry Gradle plugin 4.+ together with the Sentry Android SDK 7.+, otherwise it might crash at runtime due to binary incompatibility. (E.g. if you're using `-timber`, `-okhttp` or other packages)
+
+If you can't do that for some reason, you can specify sentry version via the plugin config block:
+
+```kotlin
+sentry {
+  autoInstallation {
+    sentryVersion.set("7.0.0")
+  }
+}
+```
+
+Similarly, if you have a Sentry SDK (e.g. `sentry-android-core`) dependency on one of your Gradle modules and you're updating it to 7.+, make sure the Gradle plugin is at 4.+ or specify the SDK version as shown in the snippet above.
+
 ## Breaking Changes
 
 - Rename `experimentalGuardsquareSupport` flag to `dexguardEnabled` ([#589](https://github.com/getsentry/sentry-android-gradle-plugin/pull/589))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,38 @@
 
 ## Unreleased
 
-### Fixes
+Version 4 of the Sentry Android Gradle plugin brings a variety of features and fixes. The most notable changes are:
+- Bump Sentry Android SDK to `7.0.0`. Please, refer to the [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#700) of the SDK for more details
+- Rename `experimentalGuardsquareSupport` flag to `dexguardEnabled`
+- Add new `excludes` option to allow excluding certain classes from instrumentation. It's available under the `sentry.tracingInstrumentation` extension
 
-- Retrieve `sentryOrg` from the `SentryPluginExtension` for telemetry ([#599](https://github.com/getsentry/sentry-android-gradle-plugin/pull/599))
+## Breaking Changes
 
-### Dependencies
+- Rename `experimentalGuardsquareSupport` flag to `dexguardEnabled` ([#589](https://github.com/getsentry/sentry-android-gradle-plugin/pull/589))
+- Bump Sentry Android SDK to `7.0.0`
 
-- Bump CLI from v2.21.5 to v2.22.3 ([#598](https://github.com/getsentry/sentry-android-gradle-plugin/pull/598), [#600](https://github.com/getsentry/sentry-android-gradle-plugin/pull/600))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2223)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.21.5...2.22.3)
-
-## 4.0.0-beta.1
+## Other Changes
 
 ### Features
 
 - Print a warning if the Sentry plugin is not applied on the app module ([#586](https://github.com/getsentry/sentry-android-gradle-plugin/pull/586))
 - Add new `excludes` option to exclude classes from instrumentation ([#590](https://github.com/getsentry/sentry-android-gradle-plugin/pull/590))
 - Send telemetry data for plugin usage ([#582](https://github.com/getsentry/sentry-android-gradle-plugin/pull/582))
-  - This will collect errors and timings of the plugin and its tasks (anonymized, except the sentry org id), so we can better understand how the plugin is performing. If you wish to opt-out of this behavior, set `telemetry = false` in the `sentry` plugin configuration block.
+    - This will collect errors and timings of the plugin and its tasks (anonymized, except the sentry org id), so we can better understand how the plugin is performing. If you wish to opt-out of this behavior, set `telemetry = false` in the `sentry` plugin configuration block.
 
 ### Chores
 
 - Change cli command from `upload-dif` to `debug-files upload` for native symbols ([#587](https://github.com/getsentry/sentry-android-gradle-plugin/pull/587))
 - Use new AGP api for native symbols upload ([#592](https://github.com/getsentry/sentry-android-gradle-plugin/pull/592))
 
-**Breaking changes:**
-
-- Rename `experimentalGuardsquareSupport` flag to `dexguardEnabled` ([#589](https://github.com/getsentry/sentry-android-gradle-plugin/pull/589))
-
 ### Dependencies
 
-- Bump Android SDK from v6.32.0 to v6.34.0 ([#588](https://github.com/getsentry/sentry-android-gradle-plugin/pull/588), [#593](https://github.com/getsentry/sentry-android-gradle-plugin/pull/593), [#597](https://github.com/getsentry/sentry-android-gradle-plugin/pull/597))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6340)
-  - [diff](https://github.com/getsentry/sentry-java/compare/6.32.0...6.34.0)
-- Bump CLI from v2.21.2 to v2.21.5 ([#594](https://github.com/getsentry/sentry-android-gradle-plugin/pull/594), [#596](https://github.com/getsentry/sentry-android-gradle-plugin/pull/596))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2215)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.21.2...2.21.5)
+- Bump Android SDK from v6.32.0 to v7.0.0 ([#588](https://github.com/getsentry/sentry-android-gradle-plugin/pull/588), [#593](https://github.com/getsentry/sentry-android-gradle-plugin/pull/593), [#597](https://github.com/getsentry/sentry-android-gradle-plugin/pull/597))
+    - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#700)
+    - [diff](https://github.com/getsentry/sentry-java/compare/6.32.0...7.0.0)
+- Bump CLI from v2.21.2 to v2.22.3 ([#598](https://github.com/getsentry/sentry-android-gradle-plugin/pull/598), [#600](https://github.com/getsentry/sentry-android-gradle-plugin/pull/600))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2223)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.21.2...2.22.3)
 
 ## 3.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Version 4 of the Sentry Android Gradle plugin brings a variety of features and f
 - Print a warning if the Sentry plugin is not applied on the app module ([#586](https://github.com/getsentry/sentry-android-gradle-plugin/pull/586))
 - Add new `excludes` option to exclude classes from instrumentation ([#590](https://github.com/getsentry/sentry-android-gradle-plugin/pull/590))
 - Send telemetry data for plugin usage ([#582](https://github.com/getsentry/sentry-android-gradle-plugin/pull/582))
-    - This will collect errors and timings of the plugin and its tasks (anonymized, except the sentry org id), so we can better understand how the plugin is performing. If you wish to opt-out of this behavior, set `telemetry = false` in the `sentry` plugin configuration block.
+  - This will collect errors and timings of the plugin and its tasks (anonymized, except the sentry org id), so we can better understand how the plugin is performing. If you wish to opt-out of this behavior, set `telemetry = false` in the `sentry` plugin configuration block.
 
 ### Chores
 
@@ -29,8 +29,8 @@ Version 4 of the Sentry Android Gradle plugin brings a variety of features and f
 ### Dependencies
 
 - Bump Android SDK from v6.32.0 to v7.0.0 ([#588](https://github.com/getsentry/sentry-android-gradle-plugin/pull/588), [#593](https://github.com/getsentry/sentry-android-gradle-plugin/pull/593), [#597](https://github.com/getsentry/sentry-android-gradle-plugin/pull/597))
-    - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#700)
-    - [diff](https://github.com/getsentry/sentry-java/compare/6.32.0...7.0.0)
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#700)
+  - [diff](https://github.com/getsentry/sentry-java/compare/6.32.0...7.0.0)
 - Bump CLI from v2.21.2 to v2.22.3 ([#598](https://github.com/getsentry/sentry-android-gradle-plugin/pull/598), [#600](https://github.com/getsentry/sentry-android-gradle-plugin/pull/600))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2223)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.21.2...2.22.3)

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/EditActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/EditActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.appcompat.widget.Toolbar
 import io.sentry.Sentry
 import io.sentry.SpanStatus
+import io.sentry.TransactionOptions
 import io.sentry.samples.instrumentation.R
 import io.sentry.samples.instrumentation.SampleApp
 import io.sentry.samples.instrumentation.data.Track
@@ -36,7 +37,7 @@ class EditActivity : ComponentActivity() {
                 val transaction = Sentry.startTransaction(
                     "Track Interaction",
                     if (originalTrack == null) "ui.action.add" else "ui.action.edit",
-                    true
+                    TransactionOptions().apply { isBindToScope = true }
                 )
 
                 val name = nameInput.text.toString()

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/LyricsActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/LyricsActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.appcompat.widget.Toolbar
 import io.sentry.Sentry
 import io.sentry.SpanStatus
+import io.sentry.TransactionOptions
 import io.sentry.samples.instrumentation.R
 import io.sentry.samples.instrumentation.data.Track
 import io.sentry.samples.instrumentation.util.Filesystem
@@ -25,7 +26,7 @@ class LyricsActivity : ComponentActivity() {
         val transaction = Sentry.startTransaction(
             "Track Interaction",
             "ui.action.lyrics",
-            true
+            TransactionOptions().apply { isBindToScope = true }
         )
 
         lyricsInput = findViewById(R.id.lyrics)
@@ -46,7 +47,7 @@ class LyricsActivity : ComponentActivity() {
         val transaction = Sentry.getSpan() ?: Sentry.startTransaction(
             "Track Interaction",
             "ui.action.lyrics_finish",
-            true
+            TransactionOptions().apply { isBindToScope = true }
         )
         filesystem.write(this, "${track.id}.txt", lyricsInput.text.toString())
         transaction.finish(SpanStatus.OK)

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/MainActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.sentry.Sentry
 import io.sentry.SpanStatus
+import io.sentry.TransactionOptions
 import io.sentry.samples.instrumentation.R
 import io.sentry.samples.instrumentation.SampleApp
 import io.sentry.samples.instrumentation.network.TrackService
@@ -32,7 +33,7 @@ class MainActivity : ComponentActivity() {
             val transaction = Sentry.startTransaction(
                 "Track Interaction",
                 "ui.action.load",
-                true
+                TransactionOptions().apply { isBindToScope = true }
             )
             SampleApp.database.tracksDao()
                 .all()

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/list/TrackAdapter.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/list/TrackAdapter.kt
@@ -8,6 +8,7 @@ import android.widget.ArrayAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.sentry.Sentry
 import io.sentry.SpanStatus
+import io.sentry.TransactionOptions
 import io.sentry.samples.instrumentation.R
 import io.sentry.samples.instrumentation.SampleApp
 import io.sentry.samples.instrumentation.data.Track
@@ -43,7 +44,7 @@ class TrackAdapter : RecyclerView.Adapter<TrackAdapter.ViewHolder>() {
             val transaction = Sentry.startTransaction(
                 "Track Interaction",
                 "ui.action.delete",
-                true
+                TransactionOptions().apply { isBindToScope = true }
             )
             runBlocking {
                 SampleApp.database.tracksDao().delete(data[holder.bindingAdapterPosition])

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 name = sentry-android-gradle-plugin
 group = io.sentry
 version = 4.0.0-beta.1
-sdk_version = 6.34.0
+sdk_version = 7.0.0
 
 # publication pom properties
 POM_NAME=Sentry Android Gradle Plugin


### PR DESCRIPTION
_#skip-changelog_

* Bump runtime sdk version to 7.0.0 and update broken sources
* Revamp changelog entry