### PR TITLE
Fix url parameter position

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -46,7 +46,7 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug --no-daemon
 
       - name: Build the Release variant
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --no-daemon

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -46,7 +46,7 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        run: ./gradlew assembleDebug --stacktrace
+        run: ./gradlew assembleDebug
 
       - name: Build the Release variant
-        run: ./gradlew assembleRelease --stacktrace
+        run: ./gradlew assembleRelease

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -46,7 +46,7 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug --stacktrace
 
       - name: Build the Release variant
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --stacktrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ dependencies {
 
 Then in both cases it will use `7.0.0` when installing the `sentry-android-okhttp` integration and print a warning that we have overridden the version.
 
+### Fixes
+
+- Fix sentry-cli url parameter position ([#610](https://github.com/getsentry/sentry-android-gradle-plugin/pull/610))
+
 ### Dependencies
 
 - Bump CLI from v2.22.3 to v2.23.0 ([#607](https://github.com/getsentry/sentry-android-gradle-plugin/pull/607))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -101,6 +101,11 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
             cliExecutable.get()
         )
 
+        sentryUrl.orNull?.let {
+            args.add("--url")
+            args.add(it)
+        }
+
         args.add("debug-files")
         args.add("upload")
 
@@ -109,11 +114,6 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
         }
 
         sentryTelemetryService.orNull?.traceCli()?.let { args.addAll(it) }
-
-        sentryUrl.orNull?.let {
-            args.add("--url")
-            args.add(it)
-        }
 
         if (!autoUploadNativeSymbol.get()) {
             args.add("--no-upload")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
@@ -154,6 +154,22 @@ class SentryUploadNativeSymbolsTaskTest {
         assertTrue("https://some-host.sentry.io" in args)
     }
 
+    @Test
+    fun `the --url parameter is placed as the first argument`() {
+        val project = createProject()
+        val task = createTestTask(project) {
+            it.cliExecutable.set("sentry-cli")
+            it.sentryUrl.set("https://some-host.sentry.io")
+            it.includeNativeSources.set(true)
+            it.variantName.set("debug")
+            it.autoUploadNativeSymbol.set(true)
+        }
+
+        val args = task.computeCommandLineArgs()
+
+        assertEquals(1, args.indexOf("--url"))
+    }
+
     private fun createProject(): Project {
         with(ProjectBuilder.builder().build()) {
             plugins.apply("io.sentry.android.gradle")


### PR DESCRIPTION
## :scroll: Description

For some reason our cli is very picky about parameter position
```shell
sentry-cli --url https://myserver.invalid/ login # works

sentry-cli login --url https://myserver.invalid/ # fails
```

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/609

## :green_heart: How did you test it?
Added a unit test. In the long run it could make sense to have a base class ~`BaseSentryCliTask`, as we have similar logic spread out a few times already.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
