### PR TITLE
Fix VerifyError when optimized code is instrumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix VerifyError when optimized code is instrumented ([#619](https://github.com/getsentry/sentry-android-gradle-plugin/pull/619))
+
 ## 4.1.0
 
 ### Features

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/appstart/ContentProviderMethodVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/appstart/ContentProviderMethodVisitor.kt
@@ -1,9 +1,25 @@
 package io.sentry.android.gradle.instrumentation.appstart
 
 import io.sentry.android.gradle.instrumentation.MethodContext
+import io.sentry.android.gradle.instrumentation.util.Types
 import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Type
 import org.objectweb.asm.commons.AdviceAdapter
 
+/**
+ * Decorates the onCreate method of a ContentProvider and adds Sentry performance monitoring by
+ * calling AppStartMetrics.onContentProviderCreate and AppStartMetrics.onContentProviderPostCreate
+ *
+ * Due to bytecode optimization of some popular libraries (e.g. androidx.startup, MlKit)
+ * we can't trust that the instrumented bytecode conforms to the Java bytecode specification.
+ *
+ * E.g. the following is no longer true
+ * Quoting docs.oracle.com/javase/specs/jvms/se7/html/jvms-2.html#jvms-2.6.1:
+ * On instance method invocation, local variable 0 is always used to pass a reference
+ * to the object on which the instance method is being invoked
+ * (this in the Java programming language).
+ *
+ */
 class ContentProviderMethodVisitor(
     apiVersion: Int,
     originalVisitor: MethodVisitor,
@@ -16,10 +32,24 @@ class ContentProviderMethodVisitor(
     instrumentableContext.descriptor
 ) {
 
-    override fun onMethodEnter() {
-        super.onMethodEnter()
+    private var counterIdx = 0
+    private var safeThisIdx = 0
 
-        loadThis()
+    override fun onMethodEnter() {
+        newLocal(Types.OBJECT)
+        counterIdx = newLocal(Types.INT)
+        safeThisIdx = newLocal(Types.OBJECT)
+
+        // finally load this and store it in the local variable
+        visitVarInsn(ALOAD, 0)
+        visitVarInsn(ASTORE, safeThisIdx)
+
+        visitInsn(ICONST_5)
+        visitVarInsn(ISTORE, counterIdx)
+
+        visitVarInsn(ALOAD, safeThisIdx)
+        box(Type.getType("Landroid/content/ContentProvider;"))
+
         visitMethodInsn(
             INVOKESTATIC,
             "io/sentry/android/core/performance/AppStartMetrics",
@@ -30,9 +60,8 @@ class ContentProviderMethodVisitor(
     }
 
     override fun onMethodExit(opcode: Int) {
-        super.onMethodExit(opcode)
-
-        loadThis()
+        visitVarInsn(ALOAD, safeThisIdx)
+        box(Type.getType("Landroid/content/ContentProvider;"))
         visitMethodInsn(
             INVOKESTATIC,
             "io/sentry/android/core/performance/AppStartMetrics",
@@ -40,5 +69,7 @@ class ContentProviderMethodVisitor(
             "(Landroid/content/ContentProvider;)V",
             false
         )
+        visitInsn(ICONST_3)
+        visitVarInsn(ISTORE, counterIdx)
     }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/appstart/ContentProviderMethodVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/appstart/ContentProviderMethodVisitor.kt
@@ -43,9 +43,9 @@ class ContentProviderMethodVisitor(
         // finally load this and store it in the local variable
         visitVarInsn(ALOAD, 0)
         visitVarInsn(ASTORE, safeThisIdx)
-
-        visitInsn(ICONST_5)
-        visitVarInsn(ISTORE, counterIdx)
+//
+//        visitInsn(ICONST_5)
+//        visitVarInsn(ISTORE, counterIdx)
 
         visitVarInsn(ALOAD, safeThisIdx)
         box(Type.getType("Landroid/content/ContentProvider;"))
@@ -69,7 +69,7 @@ class ContentProviderMethodVisitor(
             "(Landroid/content/ContentProvider;)V",
             false
         )
-        visitInsn(ICONST_3)
-        visitVarInsn(ISTORE, counterIdx)
+//        visitInsn(ICONST_3)
+//        visitVarInsn(ISTORE, counterIdx)
     }
 }


### PR DESCRIPTION
## :scroll: Description
App startup instrumentation fails for some pre-bundled libraries due to bytecode optimizations which produce non spec-compliant JVM bytecode.

As an example the stack frame variable of member functions at index 0 is not a `this` reference anymore.
This mainly affects `ContentProvider` instrumentation as those (opposed to `Application` classes) are usually shipped within libraries.

Affected Examples:
* `com.google.mlkit.common.internal.MlKitInitProvider`
* `androidx.startup.InitializationProvider`

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/618

## :green_heart: How did you test it?
Manual testing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
