### PR TITLE
Make sentry-cli path calculation configuration-cache compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Consider `sentry-bom` version when auto-installing integrations and the SDK ([#625](https://github.com/getsentry/sentry-android-gradle-plugin/pull/625)) 
 
+### Fixes
+
+- Make sentry-cli path calculation configuration-cache compatible ([#631](https://github.com/getsentry/sentry-android-gradle-plugin/pull/631))
+  - This will prevent build from failing when e.g. switching branches with stale configuration cache
+
 ### Dependencies
 
 - Bump CLI from v2.23.1 to v2.24.1 ([#622](https://github.com/getsentry/sentry-android-gradle-plugin/pull/622), [#624](https://github.com/getsentry/sentry-android-gradle-plugin/pull/624))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,10 +452,6 @@ Similarly, if you have a Sentry SDK (e.g. `sentry-android-core`) dependency on o
 
 ## 3.1.4
 
-### Fixes
-
-- Detect minified classes and skip instrumentation to avoid build problems ([#362](https://github.com/getsentry/sentry-android-gradle-plugin/pull/362))
-
 ### Features
 
 - Bump AGP to 7.2.1 and Gradle to 7.5.0 ([#363](https://github.com/getsentry/sentry-android-gradle-plugin/pull/363))
@@ -465,6 +461,10 @@ Similarly, if you have a Sentry SDK (e.g. `sentry-android-core`) dependency on o
 - Bump CLI to v2.5.0 ([#358](https://github.com/getsentry/sentry-android-gradle-plugin/pull/358))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#250)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.4.1...2.5.0)
+
+### Fixes
+
+- Detect minified classes and skip instrumentation to avoid build problems ([#362](https://github.com/getsentry/sentry-android-gradle-plugin/pull/362))
 
 ## 3.1.3
 

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -171,6 +171,15 @@ tasks.register<Test>("integrationTest").configure {
     minHeapSize = "128m"
     maxHeapSize = "1g"
 
+    jvmArgs = listOf(
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+        "--add-opens=java.base/java.net=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED"
+    )
+
     filter {
         includeTestsMatching("io.sentry.android.gradle.integration.*")
     }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -51,7 +51,7 @@ fun AndroidComponentsExtension<*, *, *>.configure(
     project: Project,
     extension: SentryPluginExtension,
     buildEvents: BuildEventListenerRegistryInternal,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?,
 ) {
@@ -238,7 +238,7 @@ private fun Variant.configureDebugMetaPropertiesTask(
 private fun Variant.configureTelemetry(
     project: Project,
     extension: SentryPluginExtension,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     buildEvents: BuildEventListenerRegistryInternal
 ): Provider<SentryTelemetryService> {
@@ -265,7 +265,7 @@ private fun Variant.configureSourceBundleTasks(
     extension: SentryPluginExtension,
     sentryTelemetryProvider: Provider<SentryTelemetryService>,
     paths: OutputPaths,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?
 ): SourceContext.SourceContextTasks? {
@@ -338,7 +338,7 @@ private fun Variant.configureProguardMappingsTasks(
     extension: SentryPluginExtension,
     sentryTelemetryProvider: Provider<SentryTelemetryService>,
     paths: OutputPaths,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?
 ): TaskProvider<SentryGenerateProguardUuidTask>? {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -38,7 +38,7 @@ import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 fun AppExtension.configure(
     project: Project,
     extension: SentryPluginExtension,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?,
     buildEvents: BuildEventListenerRegistryInternal
@@ -122,7 +122,7 @@ fun AppExtension.configure(
 private fun ApplicationVariant.configureTelemetry(
     project: Project,
     extension: SentryPluginExtension,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?,
     buildEvents: BuildEventListenerRegistryInternal
@@ -187,7 +187,7 @@ private fun ApplicationVariant.configureSourceBundleTasks(
     project: Project,
     extension: SentryPluginExtension,
     sentryTelemetryProvider: Provider<SentryTelemetryService>,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?
 ): SourceContext.SourceContextTasks? {
@@ -263,7 +263,7 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
     project: Project,
     extension: SentryPluginExtension,
     sentryTelemetryProvider: Provider<SentryTelemetryService>,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?
 ): TaskProvider<SentryGenerateProguardUuidTask>? {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -8,17 +8,17 @@ import io.sentry.android.gradle.util.GradleVersions
 import io.sentry.android.gradle.util.error
 import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.warn
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.Locale
+import java.util.Properties
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Input
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.util.Locale
-import java.util.Properties
 
 internal object SentryCliProvider {
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -112,7 +112,10 @@ internal object SentryCliProvider {
         }
     }
 
-    internal fun loadCliFromResourcesToTemp(resourcePath: String, tmpDirPrefix: String?): String? {
+    internal fun loadCliFromResourcesToTemp(
+        resourcePath: String,
+        tmpDirPrefix: String? = null
+    ): String? {
         val resourceStream = javaClass.getResourceAsStream(resourcePath)
         val tempFile = File.createTempFile(
             ".sentry-cli",

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -18,6 +18,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Input
+import java.nio.file.Files
 
 internal object SentryCliProvider {
 
@@ -104,7 +105,17 @@ internal object SentryCliProvider {
 
     internal fun loadCliFromResourcesToTemp(resourcePath: String): String? {
         val resourceStream = javaClass.getResourceAsStream(resourcePath)
-        val tempFile = File.createTempFile(".sentry-cli", ".exe").apply {
+        val tmpDirPrefix = try {
+            // only specific for some tests for deterministic behavior when executing in parallel
+            System.getProperty("sentryCliTempFolder")
+        } catch (e: Throwable) {
+            null
+        }
+        val tempFile = File.createTempFile(
+            ".sentry-cli",
+            ".exe",
+            tmpDirPrefix?.let { Files.createTempDirectory(it).toFile() }
+        ).apply {
             deleteOnExit()
             setExecutable(true)
         }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -7,7 +7,6 @@ import io.sentry.android.gradle.SentryPlugin.Companion.logger
 import io.sentry.android.gradle.util.GradleVersions
 import io.sentry.android.gradle.util.error
 import io.sentry.android.gradle.util.info
-import io.sentry.android.gradle.util.warn
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -35,7 +34,7 @@ internal object SentryCliProvider {
     fun getSentryCliPath(projectDir: File, rootDir: File): String {
         val cliPath = memoizedCliPath
         if (!cliPath.isNullOrEmpty() && File(cliPath).exists()) {
-            logger.warn { "Using memoized cli path: $cliPath" }
+            logger.info { "Using memoized cli path: $cliPath" }
             return cliPath
         }
         // If a path is provided explicitly use that first.
@@ -67,7 +66,7 @@ internal object SentryCliProvider {
             logger.info { "Trying to load cli from $resourcePath in a temp file..." }
 
             loadCliFromResourcesToTemp(resourcePath)?.let {
-                logger.warn { "cli extracted from resources into: $it" }
+                logger.info { "cli extracted from resources into: $it" }
                 memoizedCliPath = it
                 return@getSentryCliPath it
             } ?: logger.info { "Failed to load sentry-cli from resource folder" }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -3,7 +3,6 @@ package io.sentry.android.gradle
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import io.sentry.BuildConfig
-import io.sentry.android.gradle.SentryCliProvider.getSentryCliPath
 import io.sentry.android.gradle.autoinstall.installDependencies
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.util.AgpVersions
@@ -52,7 +51,7 @@ abstract class SentryPlugin @Inject constructor(
             val oldAGPExtension = project.extensions.getByType(AppExtension::class.java)
             val androidComponentsExt =
                 project.extensions.getByType(AndroidComponentsExtension::class.java)
-            val cliExecutable = getSentryCliPath(project)
+            val cliExecutable = project.cliExecutableProvider()
 
             val extraProperties = project.extensions.getByName("ext")
                 as ExtraPropertiesExtension

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
@@ -166,7 +166,7 @@ abstract class BundleSourcesTask : Exec() {
             collectSourcesTask: TaskProvider<CollectSourcesTask>,
             output: Provider<Directory>,
             debug: Property<Boolean>,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             sentryOrg: Provider<String>,
             sentryProject: Provider<String>,
             sentryAuthToken: Property<String>,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/SourceContext.kt
@@ -15,7 +15,7 @@ class SourceContext {
             sentryTelemetryProvider: Provider<SentryTelemetryService>?,
             variant: SentryVariant,
             paths: OutputPaths,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             sentryOrg: String?,
             sentryProject: String?,
             taskSuffix: String

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
@@ -147,7 +147,7 @@ abstract class UploadSourceBundleTask : Exec() {
             variant: SentryVariant,
             bundleSourcesTask: TaskProvider<BundleSourcesTask>,
             debug: Property<Boolean>,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             autoUploadSourceContext: Property<Boolean>,
             sentryOrg: Provider<String>,
             sentryProject: Provider<String>,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -159,7 +159,7 @@ abstract class SentryUploadNativeSymbolsTask : Exec() {
             sentryTelemetryProvider: Provider<SentryTelemetryService>,
             variantName: String,
             debug: Property<Boolean>,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             sentryProperties: String?,
             sentryOrg: Provider<String>,
             sentryProject: Provider<String>,
@@ -197,7 +197,7 @@ fun SentryVariant.configureNativeSymbolsTask(
     project: Project,
     extension: SentryPluginExtension,
     sentryTelemetryProvider: Provider<SentryTelemetryService>,
-    cliExecutable: String,
+    cliExecutable: Provider<String>,
     sentryOrg: String?,
     sentryProject: String?
 ) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -182,7 +182,7 @@ abstract class SentryUploadProguardMappingsTask : Exec() {
             extension: SentryPluginExtension,
             sentryTelemetryProvider: Provider<SentryTelemetryService>?,
             debug: Property<Boolean>,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             sentryProperties: String?,
             generateUuidTask: Provider<SentryGenerateProguardUuidTask>,
             mappingFiles: Provider<FileCollection>,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -250,7 +250,7 @@ abstract class SentryTelemetryService :
             project: Project,
             variant: SentryVariant?,
             extension: SentryPluginExtension,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             sentryOrg: String?,
             buildType: String
         ): SentryTelemetryServiceParams {
@@ -283,7 +283,7 @@ abstract class SentryTelemetryService :
 
         private fun paramsWithExecAvailable(
             project: Project,
-            cliExecutable: String,
+            cliExecutable: Provider<String>,
             extension: SentryPluginExtension,
             variant: SentryVariant?,
             sentryOrg: String?,

--- a/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
@@ -1,9 +1,9 @@
 package io.sentry.jvm.gradle
 
-import io.sentry.android.gradle.SentryCliProvider
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.SentryTasksProvider
 import io.sentry.android.gradle.autoinstall.installDependencies
+import io.sentry.android.gradle.cliExecutableProvider
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.sourcecontext.OutputPaths
 import io.sentry.android.gradle.sourcecontext.SourceContext
@@ -53,7 +53,7 @@ class SentryJvmPlugin @Inject constructor(
 
             val javaVariant = JavaVariant(project, javaExtension)
             val outputPaths = OutputPaths(project, "java")
-            val cliExecutable = SentryCliProvider.getSentryCliPath(project)
+            val cliExecutable = project.cliExecutableProvider()
 
             val extraProperties = project.extensions.getByName("ext")
                 as ExtraPropertiesExtension

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -36,7 +36,7 @@ class SentryCliProviderTest {
 
         assertEquals(
             project.file("sentry.properties").path,
-            getSentryPropertiesPath(project)
+            getSentryPropertiesPath(project.projectDir, project.rootDir)
         )
     }
 
@@ -56,7 +56,7 @@ class SentryCliProviderTest {
 
         assertEquals(
             topLevelProject.file("sentry.properties").path,
-            getSentryPropertiesPath(project)
+            getSentryPropertiesPath(project.projectDir, project.rootDir)
         )
     }
 
@@ -67,7 +67,7 @@ class SentryCliProviderTest {
             .withProjectDir(testProjectDir.root)
             .build()
 
-        assertNull(getSentryPropertiesPath(project))
+        assertNull(getSentryPropertiesPath(project.projectDir, project.rootDir))
     }
 
     @Test
@@ -81,7 +81,7 @@ class SentryCliProviderTest {
             writeText("cli.executable=vim")
         }
 
-        assertEquals("vim", searchCliInPropertiesFile(project))
+        assertEquals("vim", searchCliInPropertiesFile(project.projectDir, project.rootDir))
     }
 
     @Test
@@ -95,7 +95,7 @@ class SentryCliProviderTest {
             writeText("another=field")
         }
 
-        assertNull(searchCliInPropertiesFile(project))
+        assertNull(searchCliInPropertiesFile(project.projectDir, project.rootDir))
     }
 
     @Test
@@ -107,7 +107,7 @@ class SentryCliProviderTest {
 
         testProjectDir.newFile("sentry.properties")
 
-        assertNull(searchCliInPropertiesFile(project))
+        assertNull(searchCliInPropertiesFile(project.projectDir, project.rootDir))
     }
 
     @Test
@@ -117,7 +117,7 @@ class SentryCliProviderTest {
             .withProjectDir(testProjectDir.root)
             .build()
 
-        assertNull(searchCliInPropertiesFile(project))
+        assertNull(searchCliInPropertiesFile(project.projectDir, project.rootDir))
     }
 
     @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
@@ -56,6 +56,7 @@ abstract class BaseSentryNonAndroidPluginTest(
             // language=Groovy
             """
             import io.sentry.android.gradle.autoinstall.AutoInstallState
+            import io.sentry.android.gradle.util.GradleVersions
 
             buildscript {
               repositories {
@@ -87,10 +88,14 @@ abstract class BaseSentryNonAndroidPluginTest(
                     AutoInstallState.clearReference()
                   }
                 }
-                tasks.register('unlockTransforms', Exec) {
-                  commandLine 'find', project.gradle.gradleUserHomeDir, '-type', 'f', '-name', 'transforms-3.lock', '-delete'
-                }
               }
+            }
+
+            if (GradleVersions.INSTANCE.CURRENT >= GradleVersions.INSTANCE.VERSION_7_5) {
+                // unlock transforms because we're running tests in parallel therefore they may conflict
+                print(providers.exec {
+                  commandLine 'find', project.gradle.gradleUserHomeDir, '-type', 'f', '-name', 'transforms-3.lock', '-delete'
+                }.standardOutput.asText.get())
             }
             """.trimIndent()
         }
@@ -102,8 +107,6 @@ abstract class BaseSentryNonAndroidPluginTest(
             .withGradleVersion(gradleVersion)
             .forwardStdOutput(writer)
             .forwardStdError(writer)
-
-        runner.appendArguments("app:unlockTransforms").build()
     }
 
     @After

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
@@ -55,6 +55,8 @@ abstract class BaseSentryNonAndroidPluginTest(
         rootBuildFile = testProjectDir.writeFile("build.gradle") {
             // language=Groovy
             """
+            import io.sentry.android.gradle.autoinstall.AutoInstallState
+
             buildscript {
               repositories {
                 google()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -53,6 +53,8 @@ abstract class BaseSentryPluginTest(
             // language=Groovy
             """
             import io.sentry.android.gradle.autoinstall.AutoInstallState
+            import io.sentry.android.gradle.util.GradleVersions
+
             buildscript {
               repositories {
                 google()
@@ -104,10 +106,14 @@ abstract class BaseSentryPluginTest(
                     AutoInstallState.clearReference()
                   }
                 }
-                tasks.register('unlockTransforms', Exec) {
-                  commandLine 'find', project.gradle.gradleUserHomeDir, '-type', 'f', '-name', 'transforms-3.lock', '-delete'
-                }
               }
+            }
+
+            if (GradleVersions.INSTANCE.CURRENT >= GradleVersions.INSTANCE.VERSION_7_5) {
+                // unlock transforms because we're running tests in parallel therefore they may conflict
+                print(providers.exec {
+                  commandLine 'find', project.gradle.gradleUserHomeDir, '-type', 'f', '-name', 'transforms-3.lock', '-delete'
+                }.standardOutput.asText.get())
             }
             """.trimIndent()
         }
@@ -120,8 +126,6 @@ abstract class BaseSentryPluginTest(
 //            .withDebug(true)
             .forwardStdOutput(writer)
             .forwardStdError(writer)
-
-        runner.appendArguments("app:unlockTransforms").build()
     }
 
     @After

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -141,6 +141,7 @@ class SentryPluginConfigurationCacheTest :
             sentry {
               autoUploadProguardMapping = false
               autoInstallation.enabled = false
+              includeDependenciesReport = false
               telemetry = false
             }
             """.trimIndent()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -4,7 +4,6 @@ import io.sentry.BuildConfig
 import io.sentry.android.gradle.util.GradleVersions
 import io.sentry.android.gradle.verifyDependenciesReportAndroid
 import java.io.File
-import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -164,15 +163,10 @@ class SentryPluginConfigurationCacheTest :
             ?.substringAfter("[sentry] Using memoized cli path:")
             ?.trim()
 
-        val cli = File(cliPath!!)
-        val tmpCli = File("tmp-cli")
-        Files.copy(cli.toPath(), tmpCli.toPath())
-        cli.delete()
+        val cli = File(cliPath!!).also { it.delete() }
         assertFalse { cli.exists() }
 
         val outputWithConfigCache = runner.build().output
         assertFalse { "BUILD FAILED" in outputWithConfigCache }
-
-        Files.copy(tmpCli.toPath(), cli.toPath())
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -152,8 +152,8 @@ class SentryPluginConfigurationCacheTest :
         val output = runner.build().output
         val cliPath = output
             .lines()
-            .find { it.startsWith("[sentry] cli extracted from resources into:") }
-            ?.substringAfter("[sentry] cli extracted from resources into:")
+            .find { it.startsWith("[sentry] Using memoized cli path:") }
+            ?.substringAfter("[sentry] Using memoized cli path:")
             ?.trim()
 
         val cli = File(cliPath!!).also { it.delete() }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -160,8 +160,8 @@ class SentryPluginConfigurationCacheTest :
         val output = runner.build().output
         val cliPath = output
             .lines()
-            .find { it.startsWith("[sentry] Using memoized cli path:") }
-            ?.substringAfter("[sentry] Using memoized cli path:")
+            .find { it.startsWith("[sentry] cli extracted from resources into:") }
+            ?.substringAfter("[sentry] cli extracted from resources into:")
             ?.trim()
 
         val cli = File(cliPath!!).also { it.delete() }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -147,9 +147,10 @@ class SentryPluginConfigurationCacheTest :
             """.trimIndent()
         )
 
-        runner.appendArguments(":app:assembleRelease")
+        runner.appendArguments(":app:assembleDebug")
             .appendArguments("--configuration-cache")
             .appendArguments("--info")
+            .appendArguments("-DsentryCliTempFolder=configCacheTest")
         val output = runner.build().output
         val cliPath = output
             .lines()
@@ -157,10 +158,10 @@ class SentryPluginConfigurationCacheTest :
             ?.substringAfter("[sentry] Using memoized cli path:")
             ?.trim()
 
-//        val cli = File(cliPath!!).also { it.delete() }
-//        assertFalse { cli.exists() }
-//
-//        val outputWithConfigCache = runner.build().output
-//        assertFalse { "BUILD FAILED" in outputWithConfigCache }
+        val cli = File(cliPath!!).also { it.delete() }
+        assertFalse { cli.exists() }
+
+        val outputWithConfigCache = runner.build().output
+        assertFalse { "BUILD FAILED" in outputWithConfigCache }
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -156,10 +156,10 @@ class SentryPluginConfigurationCacheTest :
             ?.substringAfter("[sentry] Using memoized cli path:")
             ?.trim()
 
-        val cli = File(cliPath!!).also { it.delete() }
-        assertFalse { cli.exists() }
-
-        val outputWithConfigCache = runner.build().output
-        assertFalse { "BUILD FAILED" in outputWithConfigCache }
+//        val cli = File(cliPath!!).also { it.delete() }
+//        assertFalse { cli.exists() }
+//
+//        val outputWithConfigCache = runner.build().output
+//        assertFalse { "BUILD FAILED" in outputWithConfigCache }
     }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -124,8 +124,10 @@ class SentryPluginConfigurationCacheTest :
     fun `sentry-cli path calculation respects configuration cache`() {
         assumeThat(
             "SentryCliProvider only supports " +
-                "configuration cache from Gradle 7.5 onwards",
-            GradleVersions.CURRENT >= GradleVersions.VERSION_7_5,
+                "configuration cache from Gradle 7.5 onwards and Gradle 8.1 uses cli " +
+                "from resources, so there's no extracting from .jar to a /tmp folder involved",
+            GradleVersions.CURRENT >= GradleVersions.VERSION_7_5 &&
+                GradleVersions.CURRENT <= GradleVersions.VERSION_8_0,
             `is`(true)
         )
         appBuildFile.writeText(
@@ -160,8 +162,12 @@ class SentryPluginConfigurationCacheTest :
         val output = runner.build().output
         val cliPath = output
             .lines()
-            .find { it.startsWith("[sentry] cli extracted from resources into:") }
+            .find {
+                it.startsWith("[sentry] cli extracted from resources into:") ||
+                    it.startsWith("[sentry] Using memoized cli path:")
+            }
             ?.substringAfter("[sentry] cli extracted from resources into:")
+            ?.substringAfter("[sentry] Using memoized cli path:")
             ?.trim()
 
         val cli = File(cliPath!!).also { it.delete() }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -156,6 +156,7 @@ class SentryPluginConfigurationCacheTest :
         runner.appendArguments(":app:assembleDebug")
             .appendArguments("--configuration-cache")
             .appendArguments("--info")
+            .appendArguments("-DsentryCliTempFolder=configCacheTest")
         val output = runner.build().output
         val cliPath = output
             .lines()


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Use [ValueSource](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/ValueSource.html) or project.provider to defer sentry-cli path calculation to the point where it's actually needed 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #613 

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
