### PR TITLE
Fallback to findTask if assembleProvider is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fall back to `findTask` if `assembleProvider` of AndroidVariant is null when hooking source bundle and native symbols upload tasks ([#639](https://github.com/getsentry/sentry-android-gradle-plugin/pull/639))
+
 ## 4.2.0
 
 ### Features

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -2,6 +2,7 @@ package io.sentry.android.gradle
 
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.tasks.MergeSourceSetFolders
+import io.sentry.android.gradle.SentryTasksProvider.capitalized
 import io.sentry.android.gradle.util.GroovyCompat.isDexguardAvailable
 import io.sentry.android.gradle.util.SentryPluginUtils.capitalizeUS
 import io.sentry.gradle.common.SentryVariant
@@ -74,8 +75,8 @@ internal object SentryTasksProvider {
      * @return the provider if found or null otherwise
      */
     @JvmStatic
-    fun getAssembleTaskProvider(variant: SentryVariant): TaskProvider<out Task>? =
-        variant.assembleProvider
+    fun getAssembleTaskProvider(project: Project, variant: SentryVariant): TaskProvider<out Task>? =
+        variant.assembleProvider ?: project.findTask(listOf("assemble${variant.name.capitalized}"))
 
     /**
      * Returns the merge asset provider

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/tasks.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/tasks.kt
@@ -84,7 +84,7 @@ fun TaskProvider<out Task>.hookWithAssembleTasks(
         val bundleTask = withLogging(project.logger, "bundleTask") {
             getBundleTask(project, variant.name)
         }
-        getAssembleTaskProvider(variant)?.configure {
+        getAssembleTaskProvider(project, variant)?.configure {
             it.finalizedBy(this)
         }
         // if its a bundle aab, assemble might not be executed, so we hook into bundle task

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -151,18 +151,18 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getAssembleTaskProvider works correctly for all the variants AGP70`() {
-        val android = getAndroidExtFromProject()
+        val (project, android) = getAndroidExtFromProject()
 
         android.applicationVariants.configureEach {
             if (it.name == "debug") {
                 assertEquals(
                     "assembleDebug",
-                    getAssembleTaskProvider(AndroidVariant70(it))?.get()?.name
+                    getAssembleTaskProvider(project, AndroidVariant70(it))?.get()?.name
                 )
             } else {
                 assertEquals(
                     "assembleRelease",
-                    getAssembleTaskProvider(AndroidVariant70(it))?.get()?.name
+                    getAssembleTaskProvider(project, AndroidVariant70(it))?.get()?.name
                 )
             }
         }
@@ -170,7 +170,7 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getMergeAssetsProvider works correctly for all the variants`() {
-        val android = getAndroidExtFromProject()
+        val (_, android) = getAndroidExtFromProject()
 
         android.applicationVariants.configureEach {
             if (it.name == "debug") {
@@ -183,7 +183,7 @@ class SentryTaskProviderTest {
 
     @Test
     fun `getPackageProvider works correctly for all the variants`() {
-        val android = getAndroidExtFromProject()
+        val (_, android) = getAndroidExtFromProject()
 
         android.applicationVariants.configureEach {
             if (it.name == "debug") {
@@ -236,7 +236,7 @@ class SentryTaskProviderTest {
         assertEquals(task, getProcessResourcesProvider(project)?.get())
     }
 
-    private fun getAndroidExtFromProject(): AppExtension {
+    private fun getAndroidExtFromProject(): Pair<Project, AppExtension> {
         val project = ProjectBuilder.builder().build()
         project.plugins.apply("com.android.application")
         val android = project.extensions.getByType(AppExtension::class.java).apply {
@@ -245,7 +245,7 @@ class SentryTaskProviderTest {
 
         // This forces the project to be evaluated
         project.getTasksByName("assembleDebug", false)
-        return android
+        return project to android
     }
 
     private fun getTestProjectWithTask(taskName: String): Pair<Project, Task> {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -11,10 +11,12 @@ import io.sentry.android.gradle.SentryTasksProvider.getPackageProvider
 import io.sentry.android.gradle.SentryTasksProvider.getPreBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getProcessResourcesProvider
 import io.sentry.android.gradle.SentryTasksProvider.getTransformerTask
+import io.sentry.gradle.common.SentryVariant
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -163,6 +165,28 @@ class SentryTaskProviderTest {
                 assertEquals(
                     "assembleRelease",
                     getAssembleTaskProvider(project, AndroidVariant70(it))?.get()?.name
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `getAssembleTaskProvider falls back to findTask if assembleProvider is null`() {
+        val (project, android) = getAndroidExtFromProject()
+
+        android.applicationVariants.configureEach {
+            val sentryVariant = object : SentryVariant by AndroidVariant70(it) {
+                override val assembleProvider: TaskProvider<out Task>? get() = null
+            }
+            if (it.name == "debug") {
+                assertEquals(
+                    "assembleDebug",
+                    getAssembleTaskProvider(project, sentryVariant)?.get()?.name
+                )
+            } else {
+                assertEquals(
+                    "assembleRelease",
+                    getAssembleTaskProvider(project, sentryVariant)?.get()?.name
                 )
             }
         }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fallback to findTask if assembleProvider is null when hooking source bundle and native symbols upload tasks

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@krystofwoldrich had problems on his machine although on mine it somehow just worked 🤷 

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
