### PR TITLE
Bump AGP versions and run only artifacts job for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,5 +52,6 @@ jobs:
           zipfile=$(ls -1 plugin-build/build/distributions | grep -v "PluginMarker")
           filename=${zipfile/\.zip/}
           unzip plugin-build/build/distributions/$filename.zip -d /tmp
+          find /tmp/$filename | grep "pom-default.xml"
           unzip /tmp/$filename/$filename.jar -d /tmp/jar/
           find /tmp/jar | grep "bin/sentry-cli"

--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
 
 concurrency:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
 
 concurrency:

--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -60,13 +60,13 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
-      - name: Run ./gradlew (Fixes Gradle < 7.4)
-        continue-on-error: true
-        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-          gradle-version: ${{ matrix.gradle }}
-          arguments: tasks
+#      - name: Run ./gradlew (Fixes Gradle < 7.4)
+#        continue-on-error: true
+#        uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2
+#        with:
+#          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+#          gradle-version: ${{ matrix.gradle }}
+#          arguments: tasks
 
       - name: Build the Release variant
         uses: gradle/gradle-build-action@7e48093f71aa12588241894ff3695e83c4b5e4b0 # pin@v2.4.2

--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
 
 concurrency:
@@ -36,11 +35,14 @@ jobs:
           - agp: "8.1.2"
             gradle: "8.1"
             java: "17"
-          - agp: "8.2.0-beta05"
+          - agp: "8.2.2"
             gradle: "8.2"
             java: "17"
-          - agp: "8.3.0-alpha06"
-            gradle: "8.3"
+          - agp: "8.3.0-beta02"
+            gradle: "8.4"
+            java: "17"
+          - agp: "8.4.0-alpha06"
+            gradle: "8.4"
             java: "17"
 
     name: Test Matrix - AGP ${{ matrix.agp }} - Gradle ${{ matrix.gradle }}

--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -42,7 +42,7 @@ jobs:
             gradle: "8.4"
             java: "17"
           - agp: "8.4.0-alpha06"
-            gradle: "8.4"
+            gradle: "8.6-rc-1"
             java: "17"
 
     name: Test Matrix - AGP ${{ matrix.agp }} - Gradle ${{ matrix.gradle }}

--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
 
 concurrency:

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -12,7 +12,7 @@ object BuildPluginsVersion {
     // build/publications/maven
     const val MAVEN_PUBLISH = "0.17.0"
     const val PROGUARD = "7.1.0"
-    const val GROOVY_REDISTRIBUTED = "1.6.10"
+    const val GROOVY_REDISTRIBUTED = "1.5"
     const val BUILDCONFIG = "3.1.0"
 
     const val SPRING_BOOT = "2.7.4"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -12,7 +12,7 @@ object BuildPluginsVersion {
     // build/publications/maven
     const val MAVEN_PUBLISH = "0.17.0"
     const val PROGUARD = "7.1.0"
-    const val GROOVY_REDISTRIBUTED = "1.2"
+    const val GROOVY_REDISTRIBUTED = "1.6.10"
     const val BUILDCONFIG = "3.1.0"
 
     const val SPRING_BOOT = "2.7.4"

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -187,7 +187,11 @@ tasks.register<Test>("integrationTest").configure {
 
 gradlePlugin {
     compatibility {
-        gradleApiVersion.set(GradleVersion.current().baseVersion.version)
+        // TODO: remove after dev.gradleplugins:gradle-api:8.6 is published
+        // TODO: just a workaround for our test matrix for now
+        if (GradleVersion.current().baseVersion.version == "8.6") {
+            gradleApiVersion.set("8.4")
+        }
     }
     plugins {
         register("sentryPlugin") {

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -186,6 +186,9 @@ tasks.register<Test>("integrationTest").configure {
 }
 
 gradlePlugin {
+    compatibility {
+        gradleApiVersion.set(GradleVersion.current().baseVersion.version)
+    }
     plugins {
         register("sentryPlugin") {
             id = "io.sentry.android.gradle"

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -1,6 +1,5 @@
 package io.sentry.android.gradle.integration
 
-import io.sentry.android.gradle.integration.BaseSentryNonAndroidPluginTest.Companion.appendArguments
 import io.sentry.android.gradle.util.GradleVersions
 import io.sentry.android.gradle.util.PrintBuildOutputOnFailureRule
 import io.sentry.android.gradle.util.SemVer


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Bumps AGP versions to the latest unstable ones
* Only run the build artifacts job for the `release/**` branches, we don't need other ones similar to sentry-java
* Add a check if pom can be found in the final zip archive

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #213 

