### PR TITLE
Do not run sentry-cli commands if telemetry is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - This should fix the `java.lang.AssertionError: Class with incorrect id found` exception when using `kotlinx.serialization`
 - Fall back to `findTask` if `assembleProvider` of AndroidVariant is null when hooking source bundle and native symbols upload tasks ([#639](https://github.com/getsentry/sentry-android-gradle-plugin/pull/639))
 - Hook source context tasks to also run after `install{Variant}` tasks ([#643](https://github.com/getsentry/sentry-android-gradle-plugin/pull/643))
+- Do not run sentry-cli commands if telemetry is disabled ([#648](https://github.com/getsentry/sentry-android-gradle-plugin/pull/648))
 
 ### Dependencies
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
@@ -97,6 +97,7 @@ abstract class BaseSentryNonAndroidPluginTest(
                 // unlock transforms because we're running tests in parallel therefore they may conflict
                 print(providers.exec {
                   commandLine 'find', project.gradle.gradleUserHomeDir, '-type', 'f', '-name', 'transforms-3.lock', '-delete'
+                  ignoreExitValue true
                 }.standardOutput.asText.get())
             } else {
               tasks.register('unlockTransforms', Exec) {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -115,6 +115,7 @@ abstract class BaseSentryPluginTest(
                 // unlock transforms because we're running tests in parallel therefore they may conflict
                 print(providers.exec {
                   commandLine 'find', project.gradle.gradleUserHomeDir, '-type', 'f', '-name', 'transforms-3.lock', '-delete'
+                  ignoreExitValue true
                 }.standardOutput.asText.get())
             } else {
               tasks.register('unlockTransforms', Exec) {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -150,7 +150,7 @@ class SentryPluginConfigurationCacheTest :
               autoUploadProguardMapping = false
               autoInstallation.enabled = false
               includeDependenciesReport = false
-              telemetry = false
+              telemetry = true
             }
             """.trimIndent()
         )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginNonAndroidTest.kt
@@ -1,71 +1,73 @@
 package io.sentry.android.gradle.integration
 
-// import kotlin.test.Test
-// import kotlin.test.assertTrue
-// import org.gradle.util.GradleVersion
-//
-// class SentryPluginNonAndroidTest :
-//    BaseSentryNonAndroidPluginTest(GradleVersion.current().version) {
-//
-//    @Test
-//    fun `telemetry can be disabled`() {
-//        appBuildFile.writeText(
-//            // language=Groovy
-//            """
-//            plugins {
-//              id "java"
-//              id "io.sentry.jvm.gradle"
-//            }
-//
-//            dependencies {
-//              implementation 'org.springframework.boot:spring-boot-starter:3.0.0'
-//              implementation 'ch.qos.logback:logback-classic:1.0.0'
-//              implementation 'org.apache.logging.log4j:log4j-api:2.0'
-//              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
-//              implementation 'org.postgresql:postgresql:42.6.0'
-//              implementation 'com.graphql-java:graphql-java:17.3'
-//            }
-//
-//            sentry {
-//                telemetry = false
-//            }
-//            """.trimIndent()
-//        )
-//
-//        val result = runner
-//            .appendArguments("app:assemble", "--debug")
-//            .build()
-//
-//        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
-//        assertTrue(result.output) { "Sentry telemetry has been disabled." in result.output }
-//    }
-//
-//    @Test
-//    fun `telemetry is enabled by default`() {
-//        appBuildFile.writeText(
-//            // language=Groovy
-//            """
-//            plugins {
-//              id "java"
-//              id "io.sentry.jvm.gradle"
-//            }
-//
-//            dependencies {
-//              implementation 'org.springframework.boot:spring-boot-starter:3.0.0'
-//              implementation 'ch.qos.logback:logback-classic:1.0.0'
-//              implementation 'org.apache.logging.log4j:log4j-api:2.0'
-//              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
-//              implementation 'org.postgresql:postgresql:42.6.0'
-//              implementation 'com.graphql-java:graphql-java:17.3'
-//            }
-//            """.trimIndent()
-//        )
-//
-//        val result = runner
-//            .appendArguments("app:assemble", "--info")
-//            .build()
-//
-//        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
-//        assertTrue(result.output) { "Sentry telemetry is enabled." in result.output }
-//    }
-// }
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.util.GradleVersion
+
+class SentryPluginNonAndroidTest :
+    BaseSentryNonAndroidPluginTest(GradleVersion.current().version) {
+
+    @Test
+    fun `telemetry can be disabled`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "java"
+              id "io.sentry.jvm.gradle"
+            }
+
+            dependencies {
+              implementation 'org.springframework.boot:spring-boot-starter:3.0.0'
+              implementation 'ch.qos.logback:logback-classic:1.0.0'
+              implementation 'org.apache.logging.log4j:log4j-api:2.0'
+              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
+              implementation 'org.postgresql:postgresql:42.6.0'
+              implementation 'com.graphql-java:graphql-java:17.3'
+            }
+
+            sentry {
+                telemetry = false
+            }
+            """.trimIndent()
+        )
+
+        val result = runner
+            .appendArguments("app:assemble", "--info")
+            .build()
+
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Sentry telemetry has been disabled." in result.output }
+        assertFalse(result.output) { "sentry-cli" in result.output }
+    }
+
+    @Test
+    fun `telemetry is enabled by default`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "java"
+              id "io.sentry.jvm.gradle"
+            }
+
+            dependencies {
+              implementation 'org.springframework.boot:spring-boot-starter:3.0.0'
+              implementation 'ch.qos.logback:logback-classic:1.0.0'
+              implementation 'org.apache.logging.log4j:log4j-api:2.0'
+              implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
+              implementation 'org.postgresql:postgresql:42.6.0'
+              implementation 'com.graphql-java:graphql-java:17.3'
+            }
+            """.trimIndent()
+        )
+
+        val result = runner
+            .appendArguments("app:assemble", "--info")
+            .build()
+
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Sentry telemetry is enabled." in result.output }
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTelemetryTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTelemetryTest.kt
@@ -1,40 +1,54 @@
 package io.sentry.android.gradle.integration
 
-// import io.sentry.BuildConfig
-// import kotlin.test.Ignore
-// import kotlin.test.Test
-// import kotlin.test.assertTrue
-// import org.gradle.util.GradleVersion
-//
-// class SentryPluginTelemetryTest :
-//    BaseSentryPluginTest(BuildConfig.AgpVersion, GradleVersion.current().version) {
-//
-//    @Test
-//    fun `telemetry can be disabled`() {
-//        appBuildFile.appendText(
-//            // language=Groovy
-//            """
-//                sentry {
-//                  telemetry = false
-//                }
-//            """.trimIndent()
-//        )
-//
-//        val result = runner
-//            .appendArguments("app:assembleDebug", "--debug")
-//            .build()
-//
-//        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
-//        assertTrue(result.output) { "Sentry telemetry has been disabled." in result.output }
-//    }
-//
-//    @Test
-//    fun `telemetry is enabled by default`() {
-//        val result = runner
-//            .appendArguments("app:assembleDebug", "--info")
-//            .build()
-//
-//        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
-//        assertTrue(result.output) { "Sentry telemetry is enabled." in result.output }
-//    }
-// }
+import io.sentry.BuildConfig
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.util.GradleVersion
+
+class SentryPluginTelemetryTest :
+    BaseSentryPluginTest(BuildConfig.AgpVersion, GradleVersion.current().version) {
+
+    @Test
+    fun `telemetry can be disabled`() {
+        appBuildFile.appendText(
+            // language=Groovy
+            """
+            sentry {
+              telemetry = false
+            }
+            """.trimIndent()
+        )
+
+        val result = runner
+            .appendArguments("app:assembleDebug", "--info")
+            .build()
+
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Sentry telemetry has been disabled." in result.output }
+        assertFalse(result.output) { "sentry-cli" in result.output }
+    }
+
+    @Test
+    fun `telemetry is enabled by default`() {
+        appBuildFile.writeText(
+            // language=Groovy
+            """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            android {
+              namespace 'com.example'
+            }
+            """.trimIndent()
+        )
+        val result = runner
+            .appendArguments("app:assembleDebug", "--info")
+            .build()
+
+        assertTrue(result.output) { "BUILD SUCCESSFUL" in result.output }
+        assertTrue(result.output) { "Sentry telemetry is enabled." in result.output }
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Do not run sentry-cli commands if telemetry is disabled
* Add `--log-level=error` for the `sentry-cli info` command to prevent printing this message
```
INFO    2024-01-08 10:16:18.758013 +01:00 Loaded file referenced by SENTRY_PROPERTIES (<redacted>)
```
* Uncomment telemetry tests as they should be working now
* ignoreExitValue for deleting lock files, this should fix failures on AGP 8.4.0-alpha06 on `main`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #626 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes
