### PR TITLE
Do not pollute build classpath

### DIFF
--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -38,11 +38,11 @@ jobs:
           - agp: "8.2.2"
             gradle: "8.2"
             java: "17"
-          - agp: "8.3.0-beta02"
+          - agp: "8.3.0-rc02"
             gradle: "8.4"
             java: "17"
-          - agp: "8.4.0-alpha06"
-            gradle: "8.6-rc-1"
+          - agp: "8.4.0-alpha11"
+            gradle: "8.6"
             java: "17"
 
     name: Test Matrix - AGP ${{ matrix.agp }} - Gradle ${{ matrix.gradle }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ## Unreleased
 
+### Fixes
+
+- Do not pollute build classpath with groovy dependencies ([#660](https://github.com/getsentry/sentry-android-gradle-plugin/pull/660))
+
 ### Dependencies
 
-  Bump CLI from v2.28.0 to v2.28.5 ([#655](https://github.com/getsentry/sentry-android-gradle-plugin/pull/655))
-    [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2285)
-    [diff](https://github.com/getsentry/sentry-cli/compare/2.28.0...2.28.5)
-  Bump CLI from v2.28.5 to v2.28.6 ([#657](https://github.com/getsentry/sentry-android-gradle-plugin/pull/657))
-    [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2286)
-    [diff](https://github.com/getsentry/sentry-cli/compare/2.28.5...2.28.6)
-  Bump Android SDK from v7.3.0 to v7.4.0 ([#659](https://github.com/getsentry/sentry-android-gradle-plugin/pull/659))
-    [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#740)
-    [diff](https://github.com/getsentry/sentry-java/compare/7.3.0...7.4.0)
+- Bump CLI from v2.28.0 to v2.28.5 ([#655](https://github.com/getsentry/sentry-android-gradle-plugin/pull/655))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2285)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.28.0...2.28.5)
+- Bump CLI from v2.28.5 to v2.28.6 ([#657](https://github.com/getsentry/sentry-android-gradle-plugin/pull/657))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2286)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.28.5...2.28.6)
+- Bump Android SDK from v7.3.0 to v7.4.0 ([#659](https://github.com/getsentry/sentry-android-gradle-plugin/pull/659))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#740)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.3.0...7.4.0)
 
 ## 4.3.0
 
@@ -33,8 +37,8 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2280)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.25.0...2.28.0)
   Bump Android SDK from v7.2.0 to v7.3.0 ([#646](https://github.com/getsentry/sentry-android-gradle-plugin/pull/646))
-    [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#730)
-    [diff](https://github.com/getsentry/sentry-java/compare/7.2.0...7.3.0)
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#730)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.2.0...7.3.0)
 
 ## 4.2.0
 

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -186,13 +186,6 @@ tasks.register<Test>("integrationTest").configure {
 }
 
 gradlePlugin {
-    compatibility {
-        // TODO: remove after dev.gradleplugins:gradle-api:8.6 is published
-        // TODO: just a workaround for our test matrix for now
-        if (GradleVersion.current().baseVersion.version == "8.6") {
-            gradleApiVersion.set("8.4")
-        }
-    }
     plugins {
         register("sentryPlugin") {
             id = "io.sentry.android.gradle"


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Seems like `dev.gradleplugins:gradle-api` was bundled with the plugin for compatibility reasons, removing the compatibility block fixes it

### Before
![image](https://github.com/getsentry/sentry-android-gradle-plugin/assets/4999776/5ec644d8-70e8-4b4a-9cda-abee8e6ba98d)


### After
![image](https://github.com/getsentry/sentry-android-gradle-plugin/assets/4999776/cb2ac309-578d-4af9-9a5b-4c4e5cdc83a3)




## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #656 

## :green_heart: How did you test it?
`./gradlew build --scan`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
