### PR TITLE
make cli cache path predictable

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -2,6 +2,7 @@
 
 package io.sentry.android.gradle
 
+import io.sentry.BuildConfig
 import io.sentry.android.gradle.SentryCliValueSource.Params
 import io.sentry.android.gradle.SentryPlugin.Companion.logger
 import io.sentry.android.gradle.util.GradleVersions
@@ -10,7 +11,6 @@ import io.sentry.android.gradle.util.info
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
-import java.nio.file.Files
 import java.util.Locale
 import java.util.Properties
 import org.gradle.api.Project
@@ -32,7 +32,7 @@ internal object SentryCliProvider {
      */
     @JvmStatic
     @Synchronized
-    fun getSentryCliPath(projectDir: File, rootDir: File): String {
+    fun getSentryCliPath(projectDir: File, projectBuildFile: File, rootDir: File): String {
         val cliPath = memoizedCliPath
         if (!cliPath.isNullOrEmpty() && File(cliPath).exists()) {
             logger.info { "Using memoized cli path: $cliPath" }
@@ -66,7 +66,7 @@ internal object SentryCliProvider {
             // otherwise we need to unpack into a file
             logger.info { "Trying to load cli from $resourcePath in a temp file..." }
 
-            loadCliFromResourcesToTemp(resourcePath)?.let {
+            loadCliFromResources(projectBuildFile, resourcePath)?.let {
                 logger.info { "cli extracted from resources into: $it" }
                 memoizedCliPath = it
                 return@getSentryCliPath it
@@ -103,32 +103,41 @@ internal object SentryCliProvider {
         }
     }
 
-    internal fun loadCliFromResourcesToTemp(resourcePath: String): String? {
+    internal fun loadCliFromResources(projectBuildFile: File, resourcePath: String): String? {
         val resourceStream = javaClass.getResourceAsStream(resourcePath)
-        val tmpDirPrefix = try {
-            // only specific for some tests for deterministic behavior when executing in parallel
-            System.getProperty("sentryCliTempFolder")
-        } catch (e: Throwable) {
-            null
-        }
-        val tempFile = File.createTempFile(
-            ".sentry-cli",
-            ".exe",
-            tmpDirPrefix?.let { Files.createTempDirectory(it).toFile() }
-        ).apply {
-            deleteOnExit()
-            setExecutable(true)
-        }
-
         return if (resourceStream != null) {
-            FileOutputStream(tempFile).use { output ->
+            val baseFolder = try {
+                // only specific for some tests for deterministic behavior when executing in parallel
+                val folder = System.getProperty("sentryCliTempFolder")
+                if (folder != null) {
+                    File(folder)
+                } else {
+                    null
+                }
+            } catch (e: Throwable) {
+                null
+            } ?: File(projectBuildFile, "tmp")
+
+            logger.error { "sentry-cli base folder: ${baseFolder.absolutePath}" }
+
+            if (!baseFolder.exists() && !baseFolder.mkdirs()) {
+                logger.error { "Failed to create sentry-cli base folder" }
+                return null
+            }
+
+            val cliFilePath =
+                File(baseFolder, ".sentry-cli-${BuildConfig.Version}-${BuildConfig.CliVersion}.exe")
+            FileOutputStream(cliFilePath).use { output ->
                 resourceStream.use { input ->
                     input.copyTo(output)
                 }
             }
-            tempFile.absolutePath
+            cliFilePath.setExecutable(true)
+            cliFilePath.deleteOnExit()
+
+            cliFilePath.absolutePath
         } else {
-            null
+            return null
         }
     }
 
@@ -151,12 +160,16 @@ abstract class SentryCliValueSource : ValueSource<String, Params> {
         val projectDir: Property<File>
 
         @get:Input
+        val projectBuildDir: Property<File>
+
+        @get:Input
         val rootProjDir: Property<File>
     }
 
     override fun obtain(): String? {
         return SentryCliProvider.getSentryCliPath(
             parameters.projectDir.get(),
+            parameters.projectBuildDir.get(),
             parameters.rootProjDir.get()
         )
     }
@@ -168,12 +181,14 @@ fun Project.cliExecutableProvider(): Provider<String> {
         // e.g. switching branches
         providers.of(SentryCliValueSource::class.java) {
             it.parameters.projectDir.set(project.projectDir)
+            it.parameters.projectBuildDir.set(project.layout.buildDirectory.asFile.get())
             it.parameters.rootProjDir.set(project.rootDir)
         }
     } else {
         return provider {
             SentryCliProvider.getSentryCliPath(
                 project.projectDir,
+                project.layout.buildDirectory.asFile.get(),
                 project.rootDir
             )
         }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -2,7 +2,7 @@ package io.sentry.android.gradle
 
 import io.sentry.android.gradle.SentryCliProvider.getCliSuffix
 import io.sentry.android.gradle.SentryCliProvider.getSentryPropertiesPath
-import io.sentry.android.gradle.SentryCliProvider.loadCliFromResourcesToTemp
+import io.sentry.android.gradle.SentryCliProvider.loadCliFromResources
 import io.sentry.android.gradle.SentryCliProvider.searchCliInPropertiesFile
 import io.sentry.android.gradle.SentryCliProvider.searchCliInResources
 import io.sentry.android.gradle.util.SystemPropertyRule
@@ -157,7 +157,7 @@ class SentryCliProviderTest {
                 writeText("echo \"This is just a dummy script\"")
             }
 
-        val loadedPath = loadCliFromResourcesToTemp(resourcePath)
+        val loadedPath = loadCliFromResources(File("."), resourcePath)
         assertNotNull(loadedPath)
 
         val binContent = File(loadedPath).readText()
@@ -170,7 +170,7 @@ class SentryCliProviderTest {
     fun `loadCliFromResourcesToTemp returns null if file does not exist`() {
         val resourcePath = "./dummy-bin/i-dont-exist"
 
-        assertNull(loadCliFromResourcesToTemp(resourcePath))
+        assertNull(loadCliFromResources(File("."), resourcePath))
     }
 
     @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.gradle
 
+import io.sentry.android.gradle.SentryCliProvider.extractCliFromResources
 import io.sentry.android.gradle.SentryCliProvider.getCliSuffix
 import io.sentry.android.gradle.SentryCliProvider.getSentryPropertiesPath
-import io.sentry.android.gradle.SentryCliProvider.loadCliFromResources
 import io.sentry.android.gradle.SentryCliProvider.searchCliInPropertiesFile
 import io.sentry.android.gradle.SentryCliProvider.searchCliInResources
 import io.sentry.android.gradle.util.SystemPropertyRule
@@ -157,7 +157,7 @@ class SentryCliProviderTest {
                 writeText("echo \"This is just a dummy script\"")
             }
 
-        val loadedPath = loadCliFromResources(File("."), resourcePath)
+        val loadedPath = extractCliFromResources(File("."), resourcePath)
         assertNotNull(loadedPath)
 
         val binContent = File(loadedPath).readText()
@@ -170,7 +170,7 @@ class SentryCliProviderTest {
     fun `loadCliFromResourcesToTemp returns null if file does not exist`() {
         val resourcePath = "./dummy-bin/i-dont-exist"
 
-        assertNull(loadCliFromResources(File("."), resourcePath))
+        assertNull(extractCliFromResources(File("."), resourcePath))
     }
 
     @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -296,7 +296,11 @@ class SentryPluginSourceContextTest :
 
     @Test
     fun `uploadSourceBundle task is up-to-date on subsequent builds`() {
-        val sentryCli = SentryCliProvider.getSentryCliPath(File(""), File(""))
+        val sentryCli = SentryCliProvider.getSentryCliPath(
+            File(""),
+            File("build"),
+            File("")
+        )
         sentryPropertiesFile.writeText("cli.executable=$sentryCli")
 
         runner.appendArguments("app:assembleRelease")
@@ -346,7 +350,11 @@ class SentryPluginSourceContextTest :
 
     @Test
     fun `uploadSourceBundle task is not up-to-date on subsequent builds if cli path changes`() {
-        val sentryCli = SentryCliProvider.getSentryCliPath(File(""), File(""))
+        val sentryCli = SentryCliProvider.getSentryCliPath(
+            File(""),
+            File("build"),
+            File("")
+        )
         sentryPropertiesFile.writeText("cli.executable=$sentryCli")
 
         runner.appendArguments("app:assembleRelease")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -884,6 +884,15 @@ class SentryPluginTest :
         assertEquals(uuid1, uuid2)
     }
 
+    @Test
+    fun `works well with configuration cache`() {
+        val run0 = runner.withArguments("--configuration-cache", ":app:assembleRelease").build()
+        assertFalse("Reusing configuration cache." in run0.output, run0.output)
+
+        val run1 = runner.withArguments("--configuration-cache", ":app:assembleRelease").build()
+        assertTrue("Reusing configuration cache." in run1.output, run1.output)
+    }
+
     private fun applyUploadNativeSymbols() {
         appBuildFile.appendText(
             // language=Groovy


### PR DESCRIPTION
## :scroll: Description

Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/651

Going from
```shell
./gradlew :app:assembleRelease --configuration-cache
Configuration cache is an incubating feature.
Calculating task graph as configuration cache cannot be reused because a build logic input of type 'SentryCliValueSource' has changed.
```

to 

```shell
./gradlew :app:assembleRelease --configuration-cache
Configuration cache is an incubating feature.
Reusing configuration cache.
```

## :bulb: Motivation and Context

Our Gradle plugin should be cache-friendly.

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
