### PR TITLE
Fix circular dependency for minify/dexguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 - Do not pollute build classpath with groovy dependencies ([#677](https://github.com/getsentry/sentry-android-gradle-plugin/pull/677))
 - Ensure sentry-cli works well with configuration cache ([#675](https://github.com/getsentry/sentry-android-gradle-plugin/pull/675))
+- Fix circular task dependency in combination with DexGuard plugin ([#678](https://github.com/getsentry/sentry-android-gradle-plugin/pull/678))
 
 ### Dependencies
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -38,7 +38,6 @@ import io.sentry.android.gradle.util.ReleaseInfo
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.collectModules
-import io.sentry.android.gradle.util.finalizeByPreBuildTask
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.info
@@ -398,11 +397,16 @@ private fun Variant.configureProguardMappingsTasks(
                 taskSuffix = name.capitalized,
                 releaseInfo = releaseInfo
             )
-            generateUuidTask.finalizeByPreBuildTask(project, name)
-            uploadMappingsTask.hookWithMinifyTasks(
+
+            generateUuidTask.hookWithMinifyTasks(
                 project,
                 name,
                 dexguardEnabled && GroovyCompat.isDexguardEnabledForVariant(project, name)
+            )
+
+            uploadMappingsTask.hookWithAssembleTasks(
+                project,
+                variant
             )
 
             return generateUuidTask

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -33,10 +33,12 @@ import io.sentry.android.gradle.telemetry.withSentryTelemetry
 import io.sentry.android.gradle.transforms.MetaInfStripTransform
 import io.sentry.android.gradle.util.AgpVersions
 import io.sentry.android.gradle.util.AgpVersions.isAGP74
+import io.sentry.android.gradle.util.GroovyCompat
 import io.sentry.android.gradle.util.ReleaseInfo
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.collectModules
+import io.sentry.android.gradle.util.finalizeByPreBuildTask
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.info
@@ -396,8 +398,12 @@ private fun Variant.configureProguardMappingsTasks(
                 taskSuffix = name.capitalized,
                 releaseInfo = releaseInfo
             )
-            generateUuidTask.hookWithMinifyTasks(project, name, dexguardEnabled)
-            uploadMappingsTask.hookWithMinifyTasks(project, name, dexguardEnabled)
+            generateUuidTask.finalizeByPreBuildTask(project, name)
+            uploadMappingsTask.hookWithMinifyTasks(
+                project,
+                name,
+                dexguardEnabled && GroovyCompat.isDexguardEnabledForVariant(project, name)
+            )
 
             return generateUuidTask
         } else {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -21,10 +21,12 @@ import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesRep
 import io.sentry.android.gradle.telemetry.SentryTelemetryService
 import io.sentry.android.gradle.util.AgpVersions
 import io.sentry.android.gradle.util.AgpVersions.isAGP74
+import io.sentry.android.gradle.util.GroovyCompat
 import io.sentry.android.gradle.util.ReleaseInfo
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.SentryPluginUtils.withLogging
+import io.sentry.android.gradle.util.finalizeByPreBuildTask
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.hookWithPackageTasks
@@ -339,8 +341,12 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                 releaseInfo = releaseInfo,
                 sentryUrl = extension.url
             )
-            generateUuidTask.hookWithMinifyTasks(project, name, dexguardEnabled)
-            uploadMappingsTask.hookWithMinifyTasks(project, name, dexguardEnabled)
+            generateUuidTask.finalizeByPreBuildTask(project, name)
+            uploadMappingsTask.hookWithMinifyTasks(
+                project,
+                name,
+                dexguardEnabled && GroovyCompat.isDexguardEnabledForVariant(project, name)
+            )
 
             return generateUuidTask
         } else {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -26,7 +26,6 @@ import io.sentry.android.gradle.util.ReleaseInfo
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.SentryPluginUtils.withLogging
-import io.sentry.android.gradle.util.finalizeByPreBuildTask
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.hookWithPackageTasks
@@ -341,11 +340,15 @@ private fun ApplicationVariant.configureProguardMappingsTasks(
                 releaseInfo = releaseInfo,
                 sentryUrl = extension.url
             )
-            generateUuidTask.finalizeByPreBuildTask(project, name)
-            uploadMappingsTask.hookWithMinifyTasks(
+            generateUuidTask.hookWithMinifyTasks(
                 project,
                 name,
                 dexguardEnabled && GroovyCompat.isDexguardEnabledForVariant(project, name)
+            )
+
+            uploadMappingsTask.hookWithAssembleTasks(
+                project,
+                variant
             )
 
             return generateUuidTask

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/tasks.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/tasks.kt
@@ -3,10 +3,9 @@ package io.sentry.android.gradle.util
 import io.sentry.android.gradle.SentryTasksProvider.getAssembleTaskProvider
 import io.sentry.android.gradle.SentryTasksProvider.getBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getInstallTaskProvider
-import io.sentry.android.gradle.SentryTasksProvider.getMinifyTasks
+import io.sentry.android.gradle.SentryTasksProvider.getMinifyTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageProvider
-import io.sentry.android.gradle.SentryTasksProvider.getPreBuildTask
 import io.sentry.android.gradle.SentryTasksProvider.getPreBundleTask
 import io.sentry.android.gradle.util.SentryPluginUtils.withLogging
 import io.sentry.gradle.common.SentryVariant
@@ -22,27 +21,16 @@ fun TaskProvider<out Task>.hookWithMinifyTasks(
     // we need to wait for project evaluation to have all tasks available, otherwise the new
     // AndroidComponentsExtension is configured too early to look up for the tasks
     project.afterEvaluate {
-        val minifyTasks = getMinifyTasks(
+        val minifyTask = getMinifyTask(
             project,
             variantName,
             dexguardEnabled
         )
 
         // we just hack ourselves into the Proguard/R8/DexGuard task's doLast.
-        for (task in minifyTasks) {
-            task.configure {
-                it.finalizedBy(this)
-            }
+        minifyTask?.configure {
+            it.finalizedBy(this)
         }
-    }
-}
-
-fun TaskProvider<out Task>.finalizeByPreBuildTask(
-    project: Project,
-    variantName: String
-) {
-    configure {
-        it.finalizedBy(getPreBuildTask(project, variantName))
     }
 }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -7,14 +7,15 @@ import io.sentry.android.gradle.SentryTasksProvider.getInstallTaskProvider
 import io.sentry.android.gradle.SentryTasksProvider.getLintVitalAnalyzeProvider
 import io.sentry.android.gradle.SentryTasksProvider.getLintVitalReportProvider
 import io.sentry.android.gradle.SentryTasksProvider.getMergeAssetsProvider
+import io.sentry.android.gradle.SentryTasksProvider.getMinifyTasks
 import io.sentry.android.gradle.SentryTasksProvider.getPackageBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageProvider
 import io.sentry.android.gradle.SentryTasksProvider.getPreBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getProcessResourcesProvider
-import io.sentry.android.gradle.SentryTasksProvider.getTransformerTask
 import io.sentry.gradle.common.SentryVariant
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
@@ -32,7 +33,7 @@ class SentryTaskProviderTest {
     fun `getTransformerTask returns null for missing task`() {
         val project = ProjectBuilder.builder().build()
 
-        assertNull(getTransformerTask(project, "debug")?.get())
+        assertTrue(getMinifyTasks(project, "debug").isEmpty())
     }
 
     @Test
@@ -43,11 +44,11 @@ class SentryTaskProviderTest {
 
         assertEquals(
             task,
-            getTransformerTask(
+            getMinifyTasks(
                 project,
                 "debug",
                 dexguardEnabled = true
-            )?.get()
+            ).first().get()
         )
     }
 
@@ -57,12 +58,12 @@ class SentryTaskProviderTest {
             "transformClassesAndResourcesWithProguardTransformForDebug"
         )
 
-        assertNull(
-            getTransformerTask(
+        assertTrue(
+            getMinifyTasks(
                 project,
                 "debug",
                 dexguardEnabled = false
-            )
+            ).isEmpty()
         )
     }
 
@@ -70,14 +71,14 @@ class SentryTaskProviderTest {
     fun `getTransformerTask returns minify for R8`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithR8")
 
-        assertEquals(task, getTransformerTask(project, "debug")?.get())
+        assertEquals(task, getMinifyTasks(project, "debug").first().get())
     }
 
     @Test
     fun `getTransformerTask returns minify for embedded Proguard`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithProguard")
 
-        assertEquals(task, getTransformerTask(project, "debug")?.get())
+        assertEquals(task, getMinifyTasks(project, "debug").first().get())
     }
 
     @Test
@@ -87,11 +88,11 @@ class SentryTaskProviderTest {
 
         assertEquals(
             "transformClassesAndResourcesWithProguardTransformForDebug",
-            getTransformerTask(
+            getMinifyTasks(
                 project,
                 "debug",
                 dexguardEnabled = true
-            )?.get()?.name
+            ).first().name
         )
     }
 
@@ -102,11 +103,11 @@ class SentryTaskProviderTest {
 
         assertEquals(
             r8task,
-            getTransformerTask(
+            getMinifyTasks(
                 project,
                 "debug",
                 dexguardEnabled = false
-            )?.get()
+            ).first().get()
         )
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryTaskProviderTest.kt
@@ -7,7 +7,7 @@ import io.sentry.android.gradle.SentryTasksProvider.getInstallTaskProvider
 import io.sentry.android.gradle.SentryTasksProvider.getLintVitalAnalyzeProvider
 import io.sentry.android.gradle.SentryTasksProvider.getLintVitalReportProvider
 import io.sentry.android.gradle.SentryTasksProvider.getMergeAssetsProvider
-import io.sentry.android.gradle.SentryTasksProvider.getMinifyTasks
+import io.sentry.android.gradle.SentryTasksProvider.getMinifyTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageBundleTask
 import io.sentry.android.gradle.SentryTasksProvider.getPackageProvider
 import io.sentry.android.gradle.SentryTasksProvider.getPreBundleTask
@@ -15,7 +15,6 @@ import io.sentry.android.gradle.SentryTasksProvider.getProcessResourcesProvider
 import io.sentry.gradle.common.SentryVariant
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
@@ -33,7 +32,7 @@ class SentryTaskProviderTest {
     fun `getTransformerTask returns null for missing task`() {
         val project = ProjectBuilder.builder().build()
 
-        assertTrue(getMinifyTasks(project, "debug").isEmpty())
+        assertNull(getMinifyTask(project, "debug"))
     }
 
     @Test
@@ -44,11 +43,11 @@ class SentryTaskProviderTest {
 
         assertEquals(
             task,
-            getMinifyTasks(
+            getMinifyTask(
                 project,
                 "debug",
                 dexguardEnabled = true
-            ).first().get()
+            )!!.get()
         )
     }
 
@@ -58,12 +57,12 @@ class SentryTaskProviderTest {
             "transformClassesAndResourcesWithProguardTransformForDebug"
         )
 
-        assertTrue(
-            getMinifyTasks(
+        assertNull(
+            getMinifyTask(
                 project,
                 "debug",
                 dexguardEnabled = false
-            ).isEmpty()
+            )
         )
     }
 
@@ -71,14 +70,14 @@ class SentryTaskProviderTest {
     fun `getTransformerTask returns minify for R8`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithR8")
 
-        assertEquals(task, getMinifyTasks(project, "debug").first().get())
+        assertEquals(task, getMinifyTask(project, "debug")!!.get())
     }
 
     @Test
     fun `getTransformerTask returns minify for embedded Proguard`() {
         val (project, task) = getTestProjectWithTask("minifyDebugWithProguard")
 
-        assertEquals(task, getMinifyTasks(project, "debug").first().get())
+        assertEquals(task, getMinifyTask(project, "debug")!!.get())
     }
 
     @Test
@@ -88,11 +87,11 @@ class SentryTaskProviderTest {
 
         assertEquals(
             "transformClassesAndResourcesWithProguardTransformForDebug",
-            getMinifyTasks(
+            getMinifyTask(
                 project,
                 "debug",
                 dexguardEnabled = true
-            ).first().name
+            )!!.name
         )
     }
 
@@ -103,11 +102,11 @@ class SentryTaskProviderTest {
 
         assertEquals(
             r8task,
-            getMinifyTasks(
+            getMinifyTask(
                 project,
                 "debug",
                 dexguardEnabled = false
-            ).first().get()
+            )!!.get()
         )
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -202,8 +202,9 @@ class SentryPluginTest :
         val uuid2 = verifyProguardUuid(testProjectDir.root)
 
         assertEquals(
+            TaskOutcome.UP_TO_DATE,
             build.task(":app:generateSentryProguardUuidRelease")?.outcome,
-            TaskOutcome.UP_TO_DATE
+            build.output
         )
 
         assertEquals(uuid1, uuid2)


### PR DESCRIPTION
## :scroll: Description

Based on the task graph for R8/DG, `mergeDex<Variant>` is the closest to `minify<Variant>WithR8`. 
1) hooked ProGuard UUID gen task to the minify/mergeDex tasks
2) hooked UUID upload to assemble task (same as source context)

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/679

Not sure if we still need `transformClassesAndResourcesWithProguardTransformFor*`!?

## :green_heart: How did you test it?
Manual testing with example app.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
