### PR TITLE
Exclude BuildConfig sources from source bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Do not include `BuildConfig` into source bundles ([#705](https://github.com/getsentry/sentry-android-gradle-plugin/pull/705))
+
 ### Dependencies
 
 - Bump CLI from v2.31.1 to v2.31.2 ([#702](https://github.com/getsentry/sentry-android-gradle-plugin/pull/702))

--- a/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/JavaVariant.kt
+++ b/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/JavaVariant.kt
@@ -38,7 +38,7 @@ data class JavaVariant(
                     projectDir.dir(javaDir.absolutePath)
                 }
             }
-            (javaDirs).toSet()
+            javaDirs.filterBuildConfig().toSet()
         }.zip(additionalSources) { javaKotlin, other -> javaKotlin + other }
     }
 }

--- a/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/SentryVariant.kt
+++ b/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/SentryVariant.kt
@@ -27,3 +27,12 @@ interface SentryVariant {
         additionalSources: Provider<out Collection<Directory>>
     ): Provider<out Collection<Directory>>
 }
+
+fun List<Directory>.filterBuildConfig(): List<Directory> =
+    filterNot {
+        // consider also AGP buildConfig folder as well as community plugins:
+        // https://github.com/yshrsmz/BuildKonfig/blob/727f4f9e79e6726ab9489499ec6d92b6f6d56266/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt#L47
+        // https://github.com/gmazzo/gradle-buildconfig-plugin/blob/9fe73852fe5d545f7825826d288d7b2f4e336060/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigPlugin.kt#L119
+        // https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/variant/VariantPathHelper.kt;l=274-275?q=buildConfigSourceOutputDir
+        it.asFile.path.contains("buildConfig") || it.asFile.path.contains("buildkonfig")
+    }

--- a/plugin-build/src/agp70/kotlin/io/sentry/android/gradle/AGP70Compat.kt
+++ b/plugin-build/src/agp70/kotlin/io/sentry/android/gradle/AGP70Compat.kt
@@ -10,6 +10,7 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.api.ApplicationVariant
 import io.sentry.gradle.common.SentryVariant
+import io.sentry.gradle.common.filterBuildConfig
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
@@ -43,7 +44,7 @@ data class AndroidVariant70(
             val kotlinDirs = variant.sourceSets.flatMap {
                 it.kotlinDirectories.map { kotlinDir -> projectDir.dir(kotlinDir.absolutePath) }
             }
-            (kotlinDirs + javaDirs).toSet()
+            (kotlinDirs + javaDirs).filterBuildConfig().toSet()
         }.zip(additionalSources) { javaKotlin, other -> javaKotlin + other }
     }
 }

--- a/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
+++ b/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
@@ -13,6 +13,7 @@ import com.android.build.api.variant.Variant
 import com.android.build.api.variant.impl.ApplicationVariantImpl
 import com.android.build.api.variant.impl.VariantImpl
 import io.sentry.gradle.common.SentryVariant
+import io.sentry.gradle.common.filterBuildConfig
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
@@ -60,8 +61,11 @@ data class AndroidVariant74(
             }
             else ->
                 javaProvider
-                    .zip(kotlinProvider) { java, kotlin -> (java + kotlin).toSet() }
+                    .zip(kotlinProvider) { java, kotlin ->
+                        (java + kotlin).filterBuildConfig().toSet()
+                    }
                     .zip(additionalSources) { javaKotlin, other -> (javaKotlin + other).toSet() }
+
         }
     }
 

--- a/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
+++ b/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
@@ -65,7 +65,6 @@ data class AndroidVariant74(
                         (java + kotlin).filterBuildConfig().toSet()
                     }
                     .zip(additionalSources) { javaKotlin, other -> (javaKotlin + other).toSet() }
-
         }
     }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -487,7 +487,7 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
                 args.add(url)
             }
 
-            args.add("--log-level=debug")
+            args.add("--log-level=error")
             args.add("info")
 
             parameters.propertiesFilePath.orNull?.let { path ->
@@ -531,7 +531,7 @@ abstract class SentryCliVersionValueSource : ValueSource<String, VersionParams> 
 
             val args = mutableListOf(parameters.cliExecutable.get())
 
-            args.add("--log-level=debug")
+            args.add("--log-level=error")
             args.add("--version")
 
             it.commandLine(args)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -487,7 +487,7 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
                 args.add(url)
             }
 
-            args.add("--log-level=error")
+            args.add("--log-level=debug")
             args.add("info")
 
             parameters.propertiesFilePath.orNull?.let { path ->
@@ -531,7 +531,7 @@ abstract class SentryCliVersionValueSource : ValueSource<String, VersionParams> 
 
             val args = mutableListOf(parameters.cliExecutable.get())
 
-            args.add("--log-level=error")
+            args.add("--log-level=debug")
             args.add("--version")
 
             it.commandLine(args)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -189,7 +189,7 @@ class SentryPluginSourceContextTest :
               namespace 'com.example'
 
               buildFeatures {
-                buildConfig false
+                buildConfig true
               }
             }
 
@@ -235,6 +235,12 @@ class SentryPluginSourceContextTest :
             testProjectDir.root,
             "files/_/_/io/other/TestCustom.jvm",
             customContents
+        )
+        // do not bundle build config
+        verifySourceBundleContents(
+            testProjectDir.root,
+            "files/_/_/com/example/BuildConfig.jvm",
+            ""
         )
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Exclude sources that contain build config in their path (considering well-known community plugins for buildConfig generation as well)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #692 
Closes #683 

## :green_heart: How did you test it?
Manually verified with the sample from #692 + also automated test 


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes

