### PR TITLE
Fix misleading auth-token error message in case "sentry-cli info" fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix misleading auth-token error message in case "sentry-cli info" fails ([#708](https://github.com/getsentry/sentry-android-gradle-plugin/pull/708))
+
 ## 4.5.1
 
 ### Fixes

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -263,7 +263,7 @@ abstract class SentryTelemetryService :
 
             // if telemetry is disabled we don't even need to exec sentry-cli as telemetry service
             // will be no-op
-            if (isExecAvailable() && isTelemetryEnabled) {
+            if (isExecAvailable() && isTelemetryEnabled && extension.authToken.orNull != null) {
                 return paramsWithExecAvailable(
                     project,
                     cliExecutable,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -13,6 +13,7 @@ import io.sentry.SentryLevel
 import io.sentry.SpanStatus
 import io.sentry.android.gradle.SentryCliProvider
 import io.sentry.android.gradle.SentryPlugin
+import io.sentry.android.gradle.SentryPlugin.Companion.logger
 import io.sentry.android.gradle.SentryPropertiesFileProvider
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.telemetry.SentryCliInfoValueSource.InfoParams
@@ -263,8 +264,8 @@ abstract class SentryTelemetryService :
 
             // if telemetry is disabled we don't even need to exec sentry-cli as telemetry service
             // will be no-op
-            if (isExecAvailable() && isTelemetryEnabled && extension.authToken.orNull != null) {
-                return paramsWithExecAvailable(
+            if (isExecAvailable() && isTelemetryEnabled) {
+                paramsWithExecAvailable(
                     project,
                     cliExecutable,
                     extension,
@@ -272,19 +273,21 @@ abstract class SentryTelemetryService :
                     org,
                     buildType,
                     tags
-                )
-            } else {
-                return SentryTelemetryServiceParams(
-                    isTelemetryEnabled,
-                    extension.telemetryDsn.get(),
-                    org,
-                    buildType,
-                    tags,
-                    extension.debug.get(),
-                    saas = extension.url.orNull == null,
-                    cliVersion = BuildConfig.CliVersion
-                )
+                )?.let {
+                    return it
+                }
             }
+            // fallback: sentry-cli is not available or e.g. auth token is not configured
+            return SentryTelemetryServiceParams(
+                isTelemetryEnabled,
+                extension.telemetryDsn.get(),
+                org,
+                buildType,
+                tags,
+                extension.debug.get(),
+                saas = extension.url.orNull == null,
+                cliVersion = BuildConfig.CliVersion
+            )
         }
 
         private fun paramsWithExecAvailable(
@@ -295,7 +298,7 @@ abstract class SentryTelemetryService :
             sentryOrg: String?,
             buildType: String,
             tags: Map<String, String>
-        ): SentryTelemetryServiceParams {
+        ): SentryTelemetryServiceParams? {
             var cliVersion: String? = BuildConfig.CliVersion
             var defaultSentryOrganization: String? = null
             val infoOutput = project.providers.of(SentryCliInfoValueSource::class.java) { cliVS ->
@@ -309,6 +312,10 @@ abstract class SentryTelemetryService :
                     )
                 }
             }.get()
+
+            if (infoOutput.isEmpty()) {
+                return null
+            }
             val isSaas = infoOutput.contains("(?m)Sentry Server: .*sentry.io$".toRegex())
 
             orgRegex.find(infoOutput)?.let { matchResult ->
@@ -471,9 +478,11 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
     @get:Inject
     abstract val execOperations: ExecOperations
 
-    override fun obtain(): String {
-        val output = ByteArrayOutputStream()
-        execOperations.exec {
+    override fun obtain(): String? {
+        val stdOutput = ByteArrayOutputStream()
+        val errOutput = ByteArrayOutputStream()
+
+        val execResult = execOperations.exec {
             it.isIgnoreExitValue = true
             SentryCliProvider.maybeExtractFromResources(
                 parameters.buildDirectory.get(),
@@ -499,9 +508,19 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
             }
 
             it.commandLine(args)
-            it.standardOutput = output
+            it.standardOutput = stdOutput
+            it.errorOutput = errOutput
         }
-        return String(output.toByteArray(), Charset.defaultCharset())
+
+        if (execResult.exitValue == 0) {
+            return String(stdOutput.toByteArray(), Charset.defaultCharset())
+        } else {
+            logger.info {
+                "Failed to execute sentry-cli info. Error Output: " +
+                    String(errOutput.toByteArray(), Charset.defaultCharset())
+            }
+            return ""
+        }
     }
 }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
@@ -14,7 +14,7 @@ class SentryTelemetryServiceTest {
 
     @Suppress("UnstableApiUsage")
     @Test
-    fun `when no auth token is present, SentryCliInfoValueSource sentry-cli info returns an empty string`() {
+    fun `SentryCliInfoValueSource returns empty string when no auth token is present`() {
         val project = ProjectBuilder
             .builder()
             .withProjectDir(testProjectDir.root)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
@@ -26,8 +26,8 @@ class SentryTelemetryServiceTest {
         val infoOutput = project.providers.of(SentryCliInfoValueSource::class.java) { cliVS ->
             cliVS.parameters.buildDirectory.set(project.buildDir)
             cliVS.parameters.cliExecutable.set(cliPath.absolutePath)
-            // notice the absence of the auth token
-            // cliVS.parameters.authToken.set("")
+            // sets an empty/invalid auth token
+            cliVS.parameters.authToken.set("")
         }.get()
 
         assertEquals("", infoOutput)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
@@ -1,0 +1,35 @@
+package io.sentry.android.gradle.telemetry
+
+import io.sentry.android.gradle.SentryCliProvider
+import kotlin.test.assertEquals
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SentryTelemetryServiceTest {
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    @Suppress("UnstableApiUsage")
+    @Test
+    fun `when no auth token is present, SentryCliInfoValueSource sentry-cli info returns an empty string`() {
+        val project = ProjectBuilder
+            .builder()
+            .withProjectDir(testProjectDir.root)
+            .build()
+
+        val cliPath = SentryCliProvider
+            .getCliResourcesExtractionPath(project.layout.buildDirectory.asFile.get())
+
+        val infoOutput = project.providers.of(SentryCliInfoValueSource::class.java) { cliVS ->
+            cliVS.parameters.buildDirectory.set(project.buildDir)
+            cliVS.parameters.cliExecutable.set(cliPath.absolutePath)
+            // notice the absence of the auth token
+            // cliVS.parameters.authToken.set("")
+        }.get()
+
+        assertEquals("", infoOutput)
+    }
+}


### PR DESCRIPTION
## :scroll: Description

Telemetry uses `sentry-cli info` to gather some env setup information. However, if no auth token is present the stderr is printed and shown as an error in IDEs like Android Studio.

As it can be fine for `sentry-cli info` to fail, simply swallow and re-print the std err and fallback to a default config.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
