### PR TITLE
Add support for Kotlin K2 compiler plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add support for Kotlin K2 compiler plugin ([#716](https://github.com/getsentry/sentry-android-gradle-plugin/pull/716))
+
 ## 4.6.0
 
 ### Fixes

--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.0.0"
-    kotlin("kapt") version "2.0.0"
+    kotlin("jvm") version "1.9.24"
+    kotlin("kapt") version "1.9.24"
     id("distribution")
     id("com.vanniktech.maven.publish") version "0.17.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
@@ -67,6 +67,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.6.0")
     testImplementation("org.jetbrains.compose.desktop:desktop:1.6.10")
+}
+
+kapt {
+    correctErrorTypes = true
 }
 
 plugins.withId("com.vanniktech.maven.publish.base") {

--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
-    kotlin("kapt") version "1.8.20"
+    kotlin("jvm") version "2.0.0"
+    kotlin("kapt") version "2.0.0"
     id("distribution")
     id("com.vanniktech.maven.publish") version "0.17.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
@@ -65,8 +65,8 @@ dependencies {
 
     testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
-    testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.5.0")
-    testImplementation("org.jetbrains.compose.desktop:desktop:1.4.0")
+    testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.6.0")
+    testImplementation("org.jetbrains.compose.desktop:desktop:1.6.10")
 }
 
 plugins.withId("com.vanniktech.maven.publish.base") {

--- a/sentry-kotlin-compiler-plugin/gradle.properties
+++ b/sentry-kotlin-compiler-plugin/gradle.properties
@@ -16,3 +16,5 @@ POM_LICENCE_URL=https://github.com/getsentry/sentry-android-gradle-plugin/blob/m
 POM_DEVELOPER_ID=getsentry
 POM_DEVELOPER_NAME=Sentry Team and Contributors
 POM_DEVELOPER_URL=https://github.com/getsentry/
+
+kotlin.experimental.tryK2=true

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/SentryKotlinCompilerPlugin.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/SentryKotlinCompilerPlugin.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 class SentryKotlinCompilerPlugin : CompilerPluginRegistrar() {
 
     override val supportsK2: Boolean
-        get() = false
+        get() = true
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         val messageCollector = configuration.get(

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
@@ -56,7 +56,8 @@ class JetpackComposeTracingIrExtension(
             return
         }
 
-        val modifierThenRefs = pluginContext.referenceFunctions(modifierClassId.callableId("then"))
+        val modifierThenRefs = pluginContext
+            .referenceFunctions(modifierClassId.callableId("then"))
         if (modifierThenRefs.isEmpty()) {
             messageCollector.report(
                 CompilerMessageSeverity.WARNING,
@@ -137,7 +138,9 @@ class JetpackComposeTracingIrExtension(
             }
 
             override fun visitCall(expression: IrCall): IrExpression {
-                val composableName = visitingFunctionNames.lastOrNull() ?: return super.visitCall(expression)
+                val composableName = visitingFunctionNames.lastOrNull() ?: return super.visitCall(
+                    expression
+                )
 
                 // avoid infinite recursion by instrumenting ourselves
                 val dispatchReceiver = expression.dispatchReceiver
@@ -157,8 +160,8 @@ class JetpackComposeTracingIrExtension(
                 return super.visitCall(expression)
             }
 
-            private fun wrapExpression(expression: IrExpression?, composableName: String): IrExpression {
-
+            private fun wrapExpression(expression: IrExpression?, composableName: String):
+                IrExpression {
                 // Case A: modifier is not supplied
                 // -> simply set our modifier as param
                 // e.g. BasicText(text = "abc")
@@ -171,10 +174,11 @@ class JetpackComposeTracingIrExtension(
                 // see https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt;l=287-298;drc=f0b820e062ac34044b43144a87617e90d74657f3
 
                 val overwriteModifier = expression == null ||
-                    (expression is IrComposite &&
-                        expression.origin == IrStatementOrigin.DEFAULT_VALUE &&
-                        expression.type.classFqName == kotlinNothing)
-
+                    (
+                        expression is IrComposite &&
+                            expression.origin == IrStatementOrigin.DEFAULT_VALUE &&
+                            expression.type.classFqName == kotlinNothing
+                        )
 
                 if (overwriteModifier) {
                     val sentryTagCall = IrCallImpl(

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
@@ -20,8 +20,8 @@ import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -120,11 +120,10 @@ class JetpackComposeTracingIrExtension(
 
                 val isComposable = declaration.symbol.owner.hasAnnotation(composableAnnotation)
 
-                val isAndroidXPackage = declaration.getPackageFragment().packageFqName.asString()
-                    .startsWith("androidx")
+                val packageName = declaration.symbol.owner.parent.kotlinFqName.asString()
 
-                val isSentryPackage = declaration.getPackageFragment().packageFqName.asString()
-                    .startsWith("io.sentry.compose")
+                val isAndroidXPackage = packageName.startsWith("androidx")
+                val isSentryPackage = packageName.startsWith("io.sentry.compose")
 
                 if (isComposable && !isAndroidXPackage && !isSentryPackage) {
                     visitingFunctionNames.add(name)

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
@@ -133,10 +133,10 @@ class JetpackComposeTracingIrExtension(
 
                 val isComposable = declaration.symbol.owner.hasAnnotation(composableAnnotation)
 
-                val isAndroidXPackage = declaration.getPackageFragment().fqName.asString()
+                val isAndroidXPackage = declaration.getPackageFragment().packageFqName.asString()
                     .startsWith("androidx")
 
-                val isSentryPackage = declaration.getPackageFragment().fqName.asString()
+                val isSentryPackage = declaration.getPackageFragment().packageFqName.asString()
                     .startsWith("io.sentry.compose")
 
                 var modifierAdded = false

--- a/sentry-kotlin-compiler-plugin/src/test/kotlin/io/sentry/compose/JetpackComposeInstrumentationTest.kt
+++ b/sentry-kotlin-compiler-plugin/src/test/kotlin/io/sentry/compose/JetpackComposeInstrumentationTest.kt
@@ -151,8 +151,7 @@ class JetpackComposeInstrumentationTest {
                 @Composable
                 fun NoModifier() {
                     // expected:
-                    // val sentryModifier = Modifier.sentryTag("NoModifier")
-                    // ComposableFunction(modifier = sentryModifier, text = ..
+                    // ComposableFunction(modifier = Modifier.sentryTag("NoModifier"), text = ..
                     ComposableFunction(
                         text = "No Modifier Argument"
                     )
@@ -190,8 +189,7 @@ class JetpackComposeInstrumentationTest {
                 fun ExistingModifier() {
                     ComposableFunction(
                         // expected:
-                        // val sentryModifier = Modifier.sentryTag("ExistingModifier")
-                        // val modifier = sentryModifier.then(Modifier.fillMaxSize().padding(8.dp))
+                        // val modifier = Modifier.sentryTag("ExistingModifier").then(Modifier.fillMaxSize().padding(8.dp))
                         modifier = Modifier.fillMaxSize().padding(8.dp),
                         text = "Existing Modifier"
                     )
@@ -230,8 +228,7 @@ class JetpackComposeInstrumentationTest {
                 fun ModifierAsParam(modifier : Modifier = Modifier.Companion) {
                     ComposableFunction(
                         // expected:
-                        // val sentryModifier = Modifier.sentryTag("ModifierAsParam")
-                        // val modifier = sentryModifier.then(modifier.fillMaxSize().padding(8.dp))
+                        // val modifier = Modifier.sentryTag("ModifierAsParam").then(modifier.fillMaxSize().padding(8.dp))
                         modifier = modifier.fillMaxSize().padding(8.dp),
                         text = "ModifierAsParam"
                     )


### PR DESCRIPTION
## :scroll: Description

As of now:
 - [x] ~tests are broken, seems to be some configuration/version issue with the compiletesting library~
```
DEFAULT
java.lang.NoSuchFieldError: DEFAULT
	at com.tschuchort.compiletesting.KotlinCompilation.<init>(KotlinCompilation.kt:143)
	at io.sentry.compose.JetpackComposeInstrumentationTest$Fixture.compileFile(JetpackComposeInstrumentationTest.kt:83)
```
 - [x] ~when plugin is applied, it no-ops with the following error. This seems to stem from some compiler side API changes, it's probably best to peek into the JPC plugin source and align with their way of doing it.~
```
w: No definition of androidx.compose.ui.Modifier found, Sentry Kotlin Compiler plugin won't run. Please ensure you're applying to plugin to a compose-enabled project.
```


## :bulb: Motivation and Context
Support K2, fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/698


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
