### PR TITLE
Support K2 alongside 1.8.x / 1.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix support for Kotlin K2 compiler plugin ([#720](https://github.com/getsentry/sentry-android-gradle-plugin/pull/720))
+
 ## 4.7.0
 
 ### Features


### PR DESCRIPTION
## :scroll: Description

Replace all `impl` usages with either `DeclarationIrBuilder` or other extension functions, which are both available in 1.x and 2.0.0.

## :bulb: Motivation and Context
Support K2

Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/698


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
