### PR TITLE
Manually wire up copyFlutterAssets task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add missing copyFlutterAssets task dependency for Flutter ([#723](https://github.com/getsentry/sentry-android-gradle-plugin/pull/723))
+
 ## 4.7.1
 
 ### Fixes

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -901,7 +901,14 @@ class SentryPluginTest :
 
     @Test
     fun `copyFlutterAssetsDebug is wired up`() {
-        // first build it so it gets cached
+        assumeThat(
+            "We only wire up the copyFlutterAssets task " +
+                "if the transform API (AGP >= 7.4.0) is used",
+            SemVer.parse(androidGradlePluginVersion) >= AgpVersions.VERSION_7_4_0,
+            `is`(true)
+        )
+
+        // when a flutter project is detected
         appBuildFile.appendText(
             // language=Groovy
             """
@@ -913,6 +920,8 @@ class SentryPluginTest :
             """.trimIndent()
         )
 
+        // then InjectSentryMetaPropertiesIntoAssetsTask should depend on it
+        // and thus copyFlutterAssetsDebug should be executed as part of assembleDebug
         val build = runner.withArguments(":app:assembleDebug").build()
 
         assertEquals(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -899,6 +899,29 @@ class SentryPluginTest :
         assertEquals(uuid1, uuid2)
     }
 
+    @Test
+    fun `copyFlutterAssetsDebug is wired up`() {
+        // first build it so it gets cached
+        appBuildFile.appendText(
+            // language=Groovy
+            """
+            tasks.register("copyFlutterAssetsDebug") {
+                doFirst {
+                    println("Hello World")
+                }
+            }
+            """.trimIndent()
+        )
+
+        val build = runner.withArguments(":app:assembleDebug").build()
+
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            build.task(":app:copyFlutterAssetsDebug")?.outcome,
+            build.output
+        )
+    }
+
     private fun applyUploadNativeSymbols() {
         appBuildFile.appendText(
             // language=Groovy


### PR DESCRIPTION
## :scroll: Description

Flutter isn't using the transform API to add generated sources, and thus breaks our Android transform API approach.
Simply wire up the task manually until flutter will eventually switch to the transform API as well.

More details on the overall problem: https://www.notion.so/sentry/ProGuard-Mapping-File-upload-sentry-vs-the-rest-e90c1fd768a94bfdb4e0a9ad0ac80503?pvs=4#42b4620bf43349ae9fd091b7c36dda0a

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/701


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
