### PR TITLE
Fix source context with configuration cache on AGP 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix source bundles with configuration cache on AGP 8+ ([#725](https://github.com/getsentry/sentry-android-gradle-plugin/pull/725)) 
+
 ## 4.8.0
 
 ### Fixes

--- a/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/JavaVariant.kt
+++ b/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/JavaVariant.kt
@@ -38,7 +38,7 @@ data class JavaVariant(
                     projectDir.dir(javaDir.absolutePath)
                 }
             }
-            javaDirs.filterBuildConfig().toSet()
-        }.zip(additionalSources) { javaKotlin, other -> javaKotlin + other }
+            (javaDirs + additionalSources.get()).filterBuildConfig().toSet()
+        }
     }
 }

--- a/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/SentryVariant.kt
+++ b/plugin-build/common/src/main/kotlin/io/sentry/gradle/common/SentryVariant.kt
@@ -28,7 +28,7 @@ interface SentryVariant {
     ): Provider<out Collection<Directory>>
 }
 
-fun List<Directory>.filterBuildConfig(): List<Directory> =
+fun Collection<Directory>.filterBuildConfig(): Collection<Directory> =
     filterNot {
         // consider also AGP buildConfig folder as well as community plugins:
         // https://github.com/yshrsmz/BuildKonfig/blob/727f4f9e79e6726ab9489499ec6d92b6f6d56266/buildkonfig-gradle-plugin/src/main/kotlin/com/codingfeline/buildkonfig/gradle/BuildKonfigPlugin.kt#L47

--- a/plugin-build/src/agp70/kotlin/io/sentry/android/gradle/AGP70Compat.kt
+++ b/plugin-build/src/agp70/kotlin/io/sentry/android/gradle/AGP70Compat.kt
@@ -44,8 +44,8 @@ data class AndroidVariant70(
             val kotlinDirs = variant.sourceSets.flatMap {
                 it.kotlinDirectories.map { kotlinDir -> projectDir.dir(kotlinDir.absolutePath) }
             }
-            (kotlinDirs + javaDirs).filterBuildConfig().toSet()
-        }.zip(additionalSources) { javaKotlin, other -> javaKotlin + other }
+            (kotlinDirs + javaDirs + additionalSources.get()).filterBuildConfig().toSet()
+        }
     }
 }
 

--- a/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
+++ b/plugin-build/src/agp74/kotlin/io/sentry/android/gradle/AGP74Compat.kt
@@ -64,11 +64,11 @@ data class AndroidVariant74(
                 (java + additionalSources.get()).filterBuildConfig().toSet()
             }
             else ->
-               javaProvider.map { java ->
-                   (java + kotlinProvider.get() + additionalSources.get())
-                       .filterBuildConfig()
-                       .toSet()
-               }
+                javaProvider.map { java ->
+                    (java + kotlinProvider.get() + additionalSources.get())
+                        .filterBuildConfig()
+                        .toSet()
+                }
         }
     }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -266,7 +266,7 @@ class SentryPluginSourceContextTest :
               namespace 'com.example'
 
               buildFeatures {
-                buildConfig false
+                buildConfig true
               }
             }
 
@@ -297,6 +297,12 @@ class SentryPluginSourceContextTest :
             testProjectDir.root,
             "files/_/_/com/example/Example.jvm",
             ktContents
+        )
+        // do not bundle build config
+        verifySourceBundleContents(
+            testProjectDir.root,
+            "files/_/_/com/example/BuildConfig.jvm",
+            ""
         )
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Looks like Gradle has a bug where it queries values of providers using `.zip` or `.flatMap` too early, but using `.map` works, so we just use that + `.get()` for other providers (which will be still evaluated lazily  since it's inside `.map` I believe)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #683 

## :green_heart: How did you test it?
See updated integration test in the diff 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
