### PR TITLE
Only apply Jetpack Compose instrumentation if Modifier class is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Only apply Jetpack Compose instrumentation if `Modifier` class is available ([#727](https://github.com/getsentry/sentry-android-gradle-plugin/pull/727))
+
 ## 4.9.0
 
 ### Fixes

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
@@ -39,8 +39,18 @@ class JetpackComposeTracingIrExtension(
         val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
 
         val modifierClassId = FqName("androidx.compose.ui").classId("Modifier")
-        val modifierType = pluginContext.referenceClass(modifierClassId)!!.owner.defaultType
+        val modifierClassSymbol = pluginContext.referenceClass(modifierClassId)
+        if (modifierClassSymbol == null) {
+            messageCollector.report(
+                CompilerMessageSeverity.WARNING,
+                "No class definition of androidx.compose.ui.Modifier found, " +
+                    "Sentry Kotlin Compiler plugin won't run. " +
+                    "Please ensure you're applying to plugin to a compose-enabled project."
+            )
+            return
+        }
 
+        val modifierType = modifierClassSymbol.owner.defaultType
         val modifierCompanionClass =
             pluginContext.referenceClass(modifierClassId)?.owner?.companionObject()
         val modifierCompanionClassRef = modifierCompanionClass?.symbol
@@ -48,7 +58,7 @@ class JetpackComposeTracingIrExtension(
         if (modifierCompanionClass == null || modifierCompanionClassRef == null) {
             messageCollector.report(
                 CompilerMessageSeverity.WARNING,
-                "No definition of androidx.compose.ui.Modifier found, " +
+                "No type definition of androidx.compose.ui.Modifier found, " +
                     "Sentry Kotlin Compiler plugin won't run. " +
                     "Please ensure you're applying to plugin to a compose-enabled project."
             )

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
@@ -45,7 +45,7 @@ class JetpackComposeTracingIrExtension(
                 CompilerMessageSeverity.WARNING,
                 "No class definition of androidx.compose.ui.Modifier found, " +
                     "Sentry Kotlin Compiler plugin won't run. " +
-                    "Please ensure you're applying to plugin to a compose-enabled project."
+                    "Please ensure you're applying the plugin to a compose-enabled project."
             )
             return
         }


### PR DESCRIPTION
## :scroll: Description
If the Kotlin Compiler Plugin is applied for non Compose enabled modules, it will cause a crash during app compilation.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/687

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
