### PR TITLE
Fix plugin for spring-dependency-management 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix plugin for spring-dependency-management 1.1.6 ([#741](https://github.com/getsentry/sentry-android-gradle-plugin/pull/741))
+
 ## 4.10.0
 
 ### Features

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,7 +16,7 @@ object BuildPluginsVersion {
     const val BUILDCONFIG = "3.1.0"
 
     const val SPRING_BOOT = "2.7.4"
-    const val SPRING_DEP_MANAGEMENT = "1.0.11.RELEASE"
+    const val SPRING_DEP_MANAGEMENT = "1.1.6"
 
 	// proguard does not support AGP 8 yet
     fun isProguardApplicable(): Boolean = VersionNumber.parse(AGP).major < 8

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
@@ -48,6 +48,11 @@ private val strategies = listOf(
 fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boolean) {
     configurations.named("implementation").configure { configuration ->
         configuration.withDependencies { dependencies ->
+
+            project.dependencies.components { component ->
+                strategies.forEach { it.register(component) }
+            }
+
             // if autoInstallation is disabled, the autoInstallState will contain initial values
             // which all default to false, hence, the integrations won't be installed as well
             if (extension.autoInstallation.enabled.get()) {
@@ -68,9 +73,6 @@ fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boo
                 }
             }
         }
-    }
-    project.dependencies.components { component ->
-        strategies.forEach { it.register(component) }
     }
 }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
@@ -32,10 +32,6 @@ private val strategies = listOf(
     TimberInstallStrategy.Registrar,
     FragmentInstallStrategy.Registrar,
     ComposeInstallStrategy.Registrar,
-    Spring5InstallStrategy.Registrar,
-    Spring6InstallStrategy.Registrar,
-    SpringBoot2InstallStrategy.Registrar,
-    SpringBoot3InstallStrategy.Registrar,
     LogbackInstallStrategy.Registrar,
     Log4j2InstallStrategy.Registrar,
     JdbcInstallStrategy.Registrar,
@@ -45,12 +41,19 @@ private val strategies = listOf(
     WarnOnOverrideStrategy.Registrar
 )
 
+private val delayedStrategies = listOf(
+    Spring5InstallStrategy.Registrar,
+    Spring6InstallStrategy.Registrar,
+    SpringBoot2InstallStrategy.Registrar,
+    SpringBoot3InstallStrategy.Registrar,
+)
+
 fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boolean) {
     configurations.named("implementation").configure { configuration ->
         configuration.withDependencies { dependencies ->
 
             project.dependencies.components { component ->
-                strategies.forEach { it.register(component) }
+                delayedStrategies.forEach { it.register(component) }
             }
 
             // if autoInstallation is disabled, the autoInstallState will contain initial values
@@ -73,6 +76,9 @@ fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boo
                 }
             }
         }
+    }
+    project.dependencies.components { component ->
+        strategies.forEach { it.register(component) }
     }
 }
 


### PR DESCRIPTION
## :scroll: Description
Fix plugin for spring-dependency-management 1.1.6.

In the new version of spring-depenency-management some of their action are now executed earlier, causing our install strategies to be executed before the AutoInstallState is correctly initialized.


## :bulb: Motivation and Context
Fixes #735


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
