### PR TITLE
Invalidate instrumentation cache when changing instrumentation features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Invalidate instrumentation cache when changing instrumentation features ([#753](https://github.com/getsentry/sentry-android-gradle-plugin/pull/753))
+
 ## 4.11.0
 
 ### Fixes

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -203,7 +203,11 @@ fun AndroidComponentsExtension<*, *, *>.configure(
                     params.logcatMinLevel.setDisallowChanges(
                         extension.tracingInstrumentation.logcat.minLevel
                     )
+
                     params.sentryModulesService.setDisallowChanges(sentryModulesService)
+                    params.features.setDisallowChanges(extension.tracingInstrumentation.features)
+                    params.logcatEnabled.setDisallowChanges(extension.tracingInstrumentation.logcat.enabled)
+                    params.appStartEnabled.setDisallowChanges(extension.tracingInstrumentation.appStart.enabled)
                     params.tmpDir.set(tmpDir)
                 }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -206,8 +206,12 @@ fun AndroidComponentsExtension<*, *, *>.configure(
 
                     params.sentryModulesService.setDisallowChanges(sentryModulesService)
                     params.features.setDisallowChanges(extension.tracingInstrumentation.features)
-                    params.logcatEnabled.setDisallowChanges(extension.tracingInstrumentation.logcat.enabled)
-                    params.appStartEnabled.setDisallowChanges(extension.tracingInstrumentation.appStart.enabled)
+                    params.logcatEnabled.setDisallowChanges(
+                        extension.tracingInstrumentation.logcat.enabled
+                    )
+                    params.appStartEnabled.setDisallowChanges(
+                        extension.tracingInstrumentation.appStart.enabled
+                    )
                     params.tmpDir.set(tmpDir)
                 }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -5,6 +5,7 @@ import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
 import io.sentry.android.gradle.SentryPlugin
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 import io.sentry.android.gradle.instrumentation.androidx.compose.ComposeNavigation
 import io.sentry.android.gradle.instrumentation.androidx.room.AndroidXRoomDao
 import io.sentry.android.gradle.instrumentation.androidx.sqlite.AndroidXSQLiteOpenHelper
@@ -29,6 +30,7 @@ import io.sentry.android.gradle.util.info
 import java.io.File
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -63,6 +65,18 @@ abstract class SpanAddingClassVisitorFactory :
 
         @get:Internal
         var _instrumentable: ClassInstrumentable?
+
+
+        // TODO test if this fixes the caching issue
+        //
+        @get:Input
+        val features: SetProperty<InstrumentationFeature>
+
+        @get:Input
+        val logcatEnabled: Property<Boolean>
+
+        @get:Input
+        val appStartEnabled: Property<Boolean>
     }
 
     private val instrumentable: ClassInstrumentable

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -65,7 +65,7 @@ abstract class SpanAddingClassVisitorFactory :
 
         @get:Internal
         var _instrumentable: ClassInstrumentable?
-        
+
         @get:Input
         val features: SetProperty<InstrumentationFeature>
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -65,10 +65,7 @@ abstract class SpanAddingClassVisitorFactory :
 
         @get:Internal
         var _instrumentable: ClassInstrumentable?
-
-
-        // TODO test if this fixes the caching issue
-        //
+        
         @get:Input
         val features: SetProperty<InstrumentationFeature>
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.instrumentation.fakes
 
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 import io.sentry.android.gradle.instrumentation.ClassInstrumentable
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
@@ -8,6 +9,7 @@ import java.io.File
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 class TestSpanAddingParameters(
     private val debugOutput: Boolean = true,
@@ -32,4 +34,13 @@ class TestSpanAddingParameters(
         get() = DefaultProperty<File>(PropertyHost.NO_OP, File::class.java).convention(inMemoryDir)
 
     override var _instrumentable: ClassInstrumentable? = null
+
+    override val features: SetProperty<InstrumentationFeature>
+        get() = TODO()
+
+    override val logcatEnabled: Property<Boolean>
+        get() = TODO()
+
+    override val appStartEnabled: Property<Boolean>
+        get() = TODO()
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -8,6 +8,7 @@ import io.sentry.android.gradle.verifyDependenciesReportAndroid
 import io.sentry.android.gradle.verifyIntegrationList
 import io.sentry.android.gradle.verifyProguardUuid
 import java.io.File
+import java.util.EnumSet
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
@@ -18,7 +19,6 @@ import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.assertThrows
 import org.junit.Assume.assumeThat
 import org.junit.Test
-import java.util.EnumSet
 
 class SentryPluginTest :
     BaseSentryPluginTest(BuildConfig.AgpVersion, GradleVersion.current().version) {
@@ -641,7 +641,8 @@ class SentryPluginTest :
     @Test
     fun `changing instrumentation features invalidates cache`() {
         val enumSetInitial = EnumSet.allOf(InstrumentationFeature::class.java)
-        val enumSetWithoutOkHttp = EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.OKHTTP
+        val enumSetWithoutOkHttp =
+            EnumSet.allOf(InstrumentationFeature::class.java) - InstrumentationFeature.OKHTTP
         val dependencies = setOf(
             "com.squareup.okhttp3:okhttp:3.14.9",
             "io.sentry:sentry-android-okhttp:6.6.0"
@@ -650,7 +651,12 @@ class SentryPluginTest :
         val secondBuildFile = File(appBuildFile.parentFile, "secondBuild")
         appBuildFile.copyTo(secondBuildFile)
 
-        applyTracingInstrumentation(dependencies = dependencies, features = enumSetInitial, debug = true, forceInstrumentDependencies = false)
+        applyTracingInstrumentation(
+            dependencies = dependencies,
+            features = enumSetInitial,
+            debug = true,
+            forceInstrumentDependencies = false
+        )
 
         runner
             .appendArguments("clean", ":app:assembleDebug", "--info")
@@ -664,7 +670,12 @@ class SentryPluginTest :
 
         appBuildFile.writeText(secondBuildFile.readText())
 
-        applyTracingInstrumentation(dependencies = dependencies, features = enumSetWithoutOkHttp, debug = true, forceInstrumentDependencies = false)
+        applyTracingInstrumentation(
+            dependencies = dependencies,
+            features = enumSetWithoutOkHttp,
+            debug = true,
+            forceInstrumentDependencies = false
+        )
 
         runner.build()
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -655,11 +655,11 @@ class SentryPluginTest :
             dependencies = dependencies,
             features = enumSetInitial,
             debug = true,
-            forceInstrumentDependencies = false
+            forceInstrumentDependencies = true
         )
 
         runner
-            .appendArguments("clean", ":app:assembleDebug", "--info")
+            .appendArguments("clean", ":app:assembleDebug")
             .build()
 
         // since it's an integration test, we just test that the log file was created for the class


### PR DESCRIPTION
## :scroll: Description
Add `features`, `logcatEnabled` and `appStartEnabled` params to `SpanAddingClassVisitorFactory` parameters to make sure that if these change, the instrumentation is run again and the cache is invalidated.


## :bulb: Motivation and Context
Currently, when instrumentation parameters `features`, `logcatEnabled` or `appStartEnabled` change, instrumentation is not run again and the cached instrumentation result is used. I.e. it is not possible to change the feature set without deleting the gradle cache in the home directory.

Fixes [#3595](https://github.com/getsentry/sentry-java/issues/3595)


## :green_heart: How did you test it?
Added automated test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
