### PR TITLE
chore: Add action to warn about potentially risky PR changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,4 @@
+# This is used by the action https://github.com/dorny/paths-filter
+
+high_risk_code: &high_risk_code
+  - ".github/file-filters.yml"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,4 +1,17 @@
 # This is used by the action https://github.com/dorny/paths-filter
 
 high_risk_code: &high_risk_code
-  - ".github/file-filters.yml"
+  # Visitor classes (bytecode manipulation)
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/AbstractSpanAddingMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/compose/visitor/RememberNavControllerMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/room/visitor/AndroidXRoomDaoVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/room/visitor/InstrumentableMethodsCollectingVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/database/visitor/ExecSqlMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/database/visitor/QueryMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/statement/visitor/ExecuteStatementMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/androidx/sqlite/visitor/SQLiteOpenHelperMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/appstart/ApplicationMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/appstart/ContentProviderMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/logcat/LogcatClassVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/okhttp/visitor/OkHttpEventListenerMethodVisitor.kt"
+  - "plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/wrap/visitor/WrappingVisitor.kt"

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -1,0 +1,49 @@
+name: Changes In High Risk Code
+on:
+  pull_request:
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  files-changed:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      high_risk_code: ${{ steps.changes.outputs.high_risk_code }}
+      high_risk_code_files: ${{ steps.changes.outputs.high_risk_code_files }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+          # Enable listing of files matching each filter.
+          # Paths to files will be available in `${FILTER_NAME}_files` output variable.
+          list-files: csv
+
+  validate-high-risk-code:
+    if: needs.files-changed.outputs.high_risk_code == 'true'
+    needs: files-changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR to notify of changes in high risk files
+        uses: actions/github-script@v7
+        env:
+          high_risk_code: ${{ needs.files-changed.outputs.high_risk_code_files }}
+        with:
+          script: |
+            const highRiskFiles = process.env.high_risk_code;
+            const fileList = highRiskFiles.split(',').map(file => `- [ ] ${file}`).join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 🚨 Detected changes in high risk code 🚨 \n High-risk code has higher potential to break the SDK and may be hard to test. To prevent severe bugs, apply the rollout process for releasing such changes and be extra careful when changing and reviewing these files:\n ${fileList}`
+            })


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Implement a mechanism that automatically adds an "alert" comment to PRs if they include changes to files we think have higher potential to break things than others.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
same as https://github.com/getsentry/sentry-java/pull/3726

## :green_heart: How did you test it?
✅ by adding the file-filter.yml introduced in this PR to the list of potentially risky changes and ensuring that an alert is shown
![Screenshot 2024-09-30 at 17 29 51](https://github.com/user-attachments/assets/9d80a47e-4273-48c4-b0ae-fe47a103bda3)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] ~I added tests to verify the changes~
- [ ] ~I updated the docs if needed~
- [ ] ~No breaking changes~


## :crystal_ball: Next steps


#skip-changelog