### PR TITLE
build: Bump `sentry-cli` to `2.39.0`

### DIFF
--- a/plugin-build/sentry-cli.properties
+++ b/plugin-build/sentry-cli.properties
@@ -1,2 +1,2 @@
-version = 2.38.2
+version = 2.39.0
 repo = https://github.com/getsentry/sentry-cli


### PR DESCRIPTION


## :scroll: Description
Bump `sentry-cli` to `2.39.0`. This version includes an experimental chunk uploading feature for Proguard files: https://github.com/getsentry/sentry-cli/pull/2264.

## :bulb: Motivation and Context
Adds chunk uploading for Proguard files.


## :green_heart: How did you test it?
I tested the CLI changes manually. Did not perform any tests against the Gradle plugin, since I am not sure how to do that.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
