### PR TITLE
Bump upload action to v4

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew preMerge --continue
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.os }}
           path: plugin-build/build/reports/tests/

--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -110,7 +110,7 @@ jobs:
           arguments: integrationTest
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-AGP${{ matrix.agp }}-Gradle${{ matrix.gradle }}
           path: plugin-build/build/reports/tests/


### PR DESCRIPTION
_#skip-changelog_

should fix failing CI