### PR TITLE
feat: allow `sentry-opentelemetry-agentless` and `sentry-opentelemetry-agentless-spring` to determine SDK version to install

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
@@ -124,7 +124,9 @@ private fun DependencySet.findSentryVersion(isAndroid: Boolean): String? =
                     it.name == SentryModules.SENTRY.name ||
                         it.name == SentryModules.SENTRY_SPRING_BOOT2.name ||
                         it.name == SentryModules.SENTRY_SPRING_BOOT3.name ||
-                        it.name == SentryModules.SENTRY_BOM.name
+                        it.name == SentryModules.SENTRY_BOM.name ||
+                        it.name == SentryModules.SENTRY_OPENTELEMETRY_AGENTLESS.name ||
+                        it.name == SentryModules.SENTRY_OPENTELEMETRY_AGENTLESS_SPRING.name
                     ) && it.version != null
         }?.version
     }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -122,4 +122,12 @@ internal object SentryModules {
         "io.sentry",
         "sentry-bom"
     )
+    internal val SENTRY_OPENTELEMETRY_AGENTLESS = DefaultModuleIdentifier.newId(
+        "io.sentry",
+        "sentry-opentelemetry-agentless"
+    )
+    internal val SENTRY_OPENTELEMETRY_AGENTLESS_SPRING = DefaultModuleIdentifier.newId(
+        "io.sentry",
+        "sentry-opentelemetry-agentless-spring"
+    )
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`sentry-opentelemetry-agentless` and `sentry-opentelemetry-agentless-spring` are likely to be added manually by customers that use the Java SDK but don't want to use OTEL.
With this change, we allow the versions specified for those dependencies (if present) to override the default SDK version to be installed by the plugin.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-android-gradle-plugin/issues/834

## :green_heart: How did you test it?
Integration tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [X] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
