### PR TITLE
Create `.git-blame-ignore-revs` and add #849 to it

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Integrate spotless and ktfmt (#849)
+8818afdfc6a705a8ab7df50dd8c988d5692239c7


### PR DESCRIPTION
#skip-changelog

#849 touched many lines and likely impacts the usefulness of `git blame`. With this change, that particular commit will be ignored by `git blame` (feature enabled by default in GitHub in the web view, can be set with `git config blame.ignoreRevsFile .git-blame-ignore-revs` locally).

https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view