### PR TITLE
Fix API incompatibility with Kotlin 2.1.20 for Kotlin Compose Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Kotlin Compiler Plugin: Fix API incompatibility with Kotlin 2.1.20 ([#857](https://github.com/getsentry/sentry-android-gradle-plugin/pull/857))
+
 ### Internal
 
 - Migrate Dependencies to Gradle version catalog ([#712](https://github.com/getsentry/sentry-android-gradle-plugin/pull/712))

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension.kt
@@ -213,7 +213,7 @@ class JetpackComposeTracingIrExtension(private val messageCollector: MessageColl
             val sentryTagCall = generateSentryTagCall(builder, composableName)
 
             // Modifier.then()
-            val thenCall = builder.irCall(modifierThen, modifierType, 1, 0, null)
+            val thenCall = builder.irCall(modifierThen, modifierType)
             thenCall.putValueArgument(0, expression)
             thenCall.dispatchReceiver = sentryTagCall
 
@@ -226,7 +226,7 @@ class JetpackComposeTracingIrExtension(private val messageCollector: MessageColl
           composableName: String,
         ): IrCall {
           val sentryTagCall =
-            builder.irCall(sentryModifierTagFunctionRef, modifierType, 1, 0, null).also {
+            builder.irCall(sentryModifierTagFunctionRef, modifierType).also {
               it.extensionReceiver =
                 builder.irGetObjectValue(
                   type = modifierCompanionClassRef.createType(false, emptyList()),


### PR DESCRIPTION
…ount` parameter

Incompatible with Kotlin 2.1.20, See also:
https://github.com/JetBrains/kotlin/commit/dd508452c414a0ee8082aa6f76d664271cb38f2f

## :scroll: Description
Fix building failed with Kotlin 2.1.20 + Sentry Compose Trace

## :bulb: Motivation and Context
https://github.com/getsentry/sentry-android-gradle-plugin/issues/856

## :green_heart: How did you test it?
Build with action

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
