### PR TITLE
feat(multi-module): Introduce SentryRootPlugin with App and Lib subplugins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.androidApplication) version BuildPluginsVersion.AGP apply false
   alias(libs.plugins.androidLibrary) version BuildPluginsVersion.AGP apply false
   alias(libs.plugins.spotless)
+  id("io.sentry.gradle")
 }
 
 allprojects {

--- a/examples/android-gradle-kts/build.gradle.kts
+++ b/examples/android-gradle-kts/build.gradle.kts
@@ -1,7 +1,4 @@
-plugins {
-  alias(libs.plugins.androidApplication) version BuildPluginsVersion.AGP
-  id("io.sentry.android.gradle")
-}
+plugins { alias(libs.plugins.androidApplication) version BuildPluginsVersion.AGP }
 
 android {
   compileSdk = LibsVersion.SDK_VERSION

--- a/examples/android-gradle/build.gradle
+++ b/examples/android-gradle/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.sentry.android.gradle'
 
 android {
     compileSdk = LibsVersion.SDK_VERSION

--- a/examples/android-guardsquare-proguard/build.gradle
+++ b/examples/android-guardsquare-proguard/build.gradle
@@ -12,7 +12,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.sentry.android.gradle'
 if (BuildPluginsVersion.INSTANCE.isProguardApplicable()) {
     apply plugin: 'com.guardsquare.proguard'
 }

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
   alias(libs.plugins.androidApplication) version BuildPluginsVersion.AGP
   alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.kapt)
-  id("io.sentry.android.gradle")
 }
 
 // useful for local debugging of the androidx.sqlite lib
@@ -105,6 +104,7 @@ sentry {
 
   org.set("sentry-sdks")
   projectName.set("sentry-android")
+  telemetry.set(false)
   telemetryDsn.set(CI.SENTRY_SDKS_DSN)
 
   tracingInstrumentation { forceInstrumentDependencies.set(true) }

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -104,7 +104,6 @@ sentry {
 
   org.set("sentry-sdks")
   projectName.set("sentry-android")
-  telemetry.set(false)
   telemetryDsn.set(CI.SENTRY_SDKS_DSN)
 
   tracingInstrumentation { forceInstrumentDependencies.set(true) }

--- a/examples/android-ndk/build.gradle
+++ b/examples/android-ndk/build.gradle
@@ -11,7 +11,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.sentry.android.gradle'
 
 android {
     compileSdk = LibsVersion.SDK_VERSION
@@ -37,7 +36,6 @@ android {
 }
 
 if (System.getenv("AUTO_UPLOAD")) {
-    apply plugin: 'io.sentry.android.gradle'
     sentry {
         autoUploadProguardMapping = false
         uploadNativeSymbols = true

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -183,6 +183,10 @@ tasks.register<Test>("integrationTest").configure {
 
 gradlePlugin {
   plugins {
+    register("sentryRootPlugin") {
+      id = "io.sentry.gradle"
+      implementationClass = "io.sentry.gradle.SentryRootPlugin"
+    }
     register("sentryPlugin") {
       id = "io.sentry.android.gradle"
       implementationClass = "io.sentry.android.gradle.SentryPlugin"

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -11,7 +11,6 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.internal.utils.setDisallowChanges
-import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
 import io.sentry.android.gradle.SentryTasksProvider.getMappingFileProvider
@@ -41,6 +40,7 @@ import io.sentry.android.gradle.util.collectModules
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.info
+import io.sentry.gradle.sep
 import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.file.Directory

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AppConfig.kt
@@ -3,7 +3,6 @@ package io.sentry.android.gradle
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
-import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
 import io.sentry.android.gradle.SentryTasksProvider.getLintVitalAnalyzeProvider
@@ -30,6 +29,7 @@ import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.hookWithMinifyTasks
 import io.sentry.android.gradle.util.hookWithPackageTasks
 import io.sentry.android.gradle.util.info
+import io.sentry.gradle.sep
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -1,12 +1,10 @@
 package io.sentry.android.gradle
 
-import com.android.build.api.variant.AndroidComponentsExtension
-import com.android.build.gradle.AppExtension
-import io.sentry.BuildConfig
-import io.sentry.android.gradle.autoinstall.installDependencies
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.util.AgpVersions
-import java.io.File
+import io.sentry.gradle.SENTRY_ORG_PARAMETER
+import io.sentry.gradle.SENTRY_PROJECT_PARAMETER
+import io.sentry.gradle.subplugin.AndroidAppSubplugin
 import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -21,74 +19,55 @@ abstract class SentryPlugin
 constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugin<Project> {
 
   override fun apply(project: Project) {
+    project.logger.warn(
+      """
+      WARNING: Using 'io.sentry.android.gradle' is deprecated and this plugin will be removed in the future.
+      Consider migrating to 'io.sentry.gradle' (root project gradle plugin) instead.
+      """
+        .trimIndent()
+    )
+    project.checkAgpApplied()
+    project.checkAgpVersion()
+
+    val extraProperties = project.extensions.getByName("ext") as ExtraPropertiesExtension
+    val sentryOrgParameter =
+      runCatching { extraProperties.get(SENTRY_ORG_PARAMETER).toString() }.getOrNull()
+    val sentryProjectParameter =
+      runCatching { extraProperties.get(SENTRY_PROJECT_PARAMETER).toString() }.getOrNull()
+
+    val extension = SentryPluginExtension.of(project)
+    AndroidAppSubplugin(project, extension)
+      .apply(buildEvents, sentryOrgParameter, sentryProjectParameter)
+  }
+
+  private fun Project.checkAgpApplied() {
+    if (!plugins.hasPlugin("com.android.application")) {
+      logger.warn(
+        """
+        WARNING: Using 'io.sentry.android.gradle' is only supported for the app module.
+        Please make sure that you apply the Sentry gradle plugin alongside 'com.android.application' on the _module_ level, and not on the root project level.
+        https://docs.sentry.io/platforms/android/configuration/gradle/
+        """
+          .trimIndent()
+      )
+    }
+  }
+
+  private fun Project.checkAgpVersion() {
     if (AgpVersions.CURRENT < AgpVersions.VERSION_7_0_0) {
       throw StopExecutionException(
         """
-                Using io.sentry.android.gradle:3+ with Android Gradle Plugin < 7 is not supported.
-                Either upgrade the AGP version to 7+, or use an earlier version of the Sentry
-                Android Gradle Plugin. For more information check our migration guide
-                https://docs.sentry.io/platforms/android/migration/#migrating-from-iosentrysentry-android-gradle-plugin-2x-to-iosentrysentry-android-gradle-plugin-300
-                """
-          .trimIndent()
-      )
-    }
-    if (!project.plugins.hasPlugin("com.android.application")) {
-      project.logger.warn(
+        Using io.sentry.android.gradle:3+ with Android Gradle Plugin < 7 is not supported.
+        Either upgrade the AGP version to 7+, or use an earlier version of the Sentry
+        Android Gradle Plugin. For more information check our migration guide
+        https://docs.sentry.io/platforms/android/migration/#migrating-from-iosentrysentry-android-gradle-plugin-2x-to-iosentrysentry-android-gradle-plugin-300
         """
-                WARNING: Using 'io.sentry.android.gradle' is only supported for the app module.
-                Please make sure that you apply the Sentry gradle plugin alongside 'com.android.application' on the _module_ level, and not on the root project level.
-                https://docs.sentry.io/platforms/android/configuration/gradle/
-                """
           .trimIndent()
       )
-    }
-
-    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java, project)
-
-    project.pluginManager.withPlugin("com.android.application") {
-      val oldAGPExtension = project.extensions.getByType(AppExtension::class.java)
-      val androidComponentsExt =
-        project.extensions.getByType(AndroidComponentsExtension::class.java)
-      val cliExecutable = project.cliExecutableProvider()
-
-      val extraProperties = project.extensions.getByName("ext") as ExtraPropertiesExtension
-
-      val sentryOrgParameter =
-        runCatching { extraProperties.get(SENTRY_ORG_PARAMETER).toString() }.getOrNull()
-      val sentryProjectParameter =
-        runCatching { extraProperties.get(SENTRY_PROJECT_PARAMETER).toString() }.getOrNull()
-
-      // new API configuration
-      androidComponentsExt.configure(
-        project,
-        extension,
-        buildEvents,
-        cliExecutable,
-        sentryOrgParameter,
-        sentryProjectParameter,
-      )
-
-      // old API configuration
-      oldAGPExtension.configure(
-        project,
-        extension,
-        cliExecutable,
-        sentryOrgParameter,
-        sentryProjectParameter,
-        buildEvents,
-      )
-
-      project.installDependencies(extension, true)
     }
   }
 
   companion object {
-    const val SENTRY_ORG_PARAMETER = "sentryOrg"
-    const val SENTRY_PROJECT_PARAMETER = "sentryProject"
-    internal const val SENTRY_SDK_VERSION = BuildConfig.SdkVersion
-
-    internal val sep = File.separator
-
     // a single unified logger used by instrumentation
     internal val logger by lazy { LoggerFactory.getLogger(SentryPlugin::class.java) }
   }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -36,8 +36,10 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
       runCatching { extraProperties.get(SENTRY_PROJECT_PARAMETER).toString() }.getOrNull()
 
     val extension = SentryPluginExtension.of(project)
-    AndroidAppSubplugin(project, extension)
-      .apply(buildEvents, sentryOrgParameter, sentryProjectParameter)
+    project.pluginManager.withPlugin("com.android.application") {
+      AndroidAppSubplugin(project, extension)
+        .apply(buildEvents, sentryOrgParameter, sentryProjectParameter)
+    }
   }
 
   private fun Project.checkAgpApplied() {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstallState.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstallState.kt
@@ -1,6 +1,6 @@
 package io.sentry.android.gradle.autoinstall
 
-import io.sentry.android.gradle.SentryPlugin.Companion.SENTRY_SDK_VERSION
+import io.sentry.gradle.SENTRY_SDK_VERSION
 import java.io.Serializable
 import org.gradle.api.invocation.Gradle
 import org.jetbrains.annotations.TestOnly

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/AutoInstallExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/AutoInstallExtension.kt
@@ -1,6 +1,6 @@
 package io.sentry.android.gradle.extensions
 
-import io.sentry.android.gradle.SentryPlugin.Companion.SENTRY_SDK_VERSION
+import io.sentry.gradle.SENTRY_SDK_VERSION
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -194,4 +194,9 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
    */
   val telemetryDsn: Property<String> =
     objects.property(String::class.java).convention(SENTRY_SAAS_DSN)
+
+  internal companion object {
+    fun of(project: Project): SentryPluginExtension =
+      project.extensions.create("sentry", SentryPluginExtension::class.java, project)
+  }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/GenerateBundleIdTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/GenerateBundleIdTask.kt
@@ -27,7 +27,7 @@ abstract class GenerateBundleIdTask : PropertiesFileOutputTask() {
 
   init {
     description =
-      "Generates a unique build ID to be used " + "when bundling sources for upload to Sentry"
+      "Generates a unique build ID to be used when bundling sources for upload to Sentry"
 
     @Suppress("LeakingThis") onlyIf { includeSourceContext.getOrElse(false) }
   }

--- a/plugin-build/src/main/kotlin/io/sentry/gradle/SentryRootPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/gradle/SentryRootPlugin.kt
@@ -1,0 +1,27 @@
+package io.sentry.gradle
+
+import io.sentry.gradle.subplugin.RootPlugin
+import javax.inject.Inject
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
+import org.slf4j.LoggerFactory
+
+internal abstract class SentryRootPlugin
+@Inject
+constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugin<Project> {
+
+  override fun apply(project: Project) {
+    if (project == project.rootProject) {
+      RootPlugin(project).apply(buildEvents)
+    } else {
+      throw StopExecutionException("io.sentry.gradle must be applied only to the root project.")
+    }
+  }
+
+  companion object {
+    // a single unified logger used by instrumentation
+    internal val logger by lazy { LoggerFactory.getLogger(SentryRootPlugin::class.java) }
+  }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/gradle/Shared.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/gradle/Shared.kt
@@ -1,0 +1,11 @@
+package io.sentry.gradle
+
+import io.sentry.BuildConfig
+import java.io.File
+
+internal const val SENTRY_ORG_PARAMETER = "sentryOrg"
+internal const val SENTRY_PROJECT_PARAMETER = "sentryProject"
+
+internal const val SENTRY_SDK_VERSION = BuildConfig.SdkVersion
+
+internal val sep = File.separator

--- a/plugin-build/src/main/kotlin/io/sentry/gradle/subplugin/AndroidAppSubplugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/gradle/subplugin/AndroidAppSubplugin.kt
@@ -1,0 +1,66 @@
+package io.sentry.gradle.subplugin
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.gradle.AppExtension
+import io.sentry.android.gradle.autoinstall.installDependencies
+import io.sentry.android.gradle.cliExecutableProvider
+import io.sentry.android.gradle.configure
+import io.sentry.android.gradle.extensions.SentryPluginExtension
+import io.sentry.android.gradle.util.AgpVersions
+import org.gradle.api.Project
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
+
+class AndroidAppSubplugin(
+  private val project: Project,
+  private val extension: SentryPluginExtension,
+) {
+  fun apply(
+    buildEvents: BuildEventListenerRegistryInternal,
+    sentryOrgParameter: String?,
+    sentryProjectParameter: String?,
+  ) =
+    project.run {
+      checkAgpVersion()
+
+      val oldAGPExtension = extensions.getByType(AppExtension::class.java)
+      val androidComponentsExt = extensions.getByType(AndroidComponentsExtension::class.java)
+      val cliExecutable = cliExecutableProvider()
+
+      // new API configuration
+      androidComponentsExt.configure(
+        this,
+        extension,
+        buildEvents,
+        cliExecutable,
+        sentryOrgParameter,
+        sentryProjectParameter,
+      )
+
+      // old API configuration
+      oldAGPExtension.configure(
+        this,
+        extension,
+        cliExecutable,
+        sentryOrgParameter,
+        sentryProjectParameter,
+        buildEvents,
+      )
+
+      installDependencies(extension, true)
+    }
+
+  private fun Project.checkAgpVersion() {
+    if (AgpVersions.CURRENT < AgpVersions.VERSION_7_0_0) {
+      throw StopExecutionException(
+        """
+        Using io.sentry.android.gradle:3+ with Android Gradle Plugin < 7 is not supported.
+        Either upgrade the AGP version to 7+, or use an earlier version of the Sentry
+        Android Gradle Plugin. For more information check our migration guide
+        https://docs.sentry.io/platforms/android/migration/#migrating-from-iosentrysentry-android-gradle-plugin-2x-to-iosentrysentry-android-gradle-plugin-300
+        """
+          .trimIndent()
+      )
+    }
+  }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/gradle/subplugin/AndroidLibSubplugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/gradle/subplugin/AndroidLibSubplugin.kt
@@ -1,0 +1,9 @@
+package io.sentry.gradle.subplugin
+
+import org.gradle.api.Project
+
+class AndroidLibSubplugin(private val project: Project) {
+  fun apply() {
+    // TODO: add logic to upload source contexts here
+  }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/gradle/subplugin/RootPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/gradle/subplugin/RootPlugin.kt
@@ -1,0 +1,50 @@
+package io.sentry.gradle.subplugin
+
+import io.sentry.android.gradle.extensions.SentryPluginExtension
+import io.sentry.gradle.SENTRY_ORG_PARAMETER
+import io.sentry.gradle.SENTRY_PROJECT_PARAMETER
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
+
+internal class RootPlugin(private val project: Project) {
+  init {
+    check(project == project.rootProject) {
+      "This plugin must only be applied to the root project. Was ${project.path}."
+    }
+  }
+
+  fun apply(buildEvents: BuildEventListenerRegistryInternal) =
+    project.run {
+      subprojects { p ->
+        val extraProperties = p.extensions.getByName("ext") as ExtraPropertiesExtension
+        val sentryOrgParameter =
+          runCatching { extraProperties.get(SENTRY_ORG_PARAMETER).toString() }.getOrNull()
+        val sentryProjectParameter =
+          runCatching { extraProperties.get(SENTRY_PROJECT_PARAMETER).toString() }.getOrNull()
+
+        p.pluginManager.withPlugin("com.android.library") {
+          val sentryExtension = SentryPluginExtension.of(p)
+          AndroidLibSubplugin(p).apply()
+        }
+        p.pluginManager.withPlugin("com.android.application") {
+          val sentryExtension = SentryPluginExtension.of(p)
+          AndroidAppSubplugin(p, sentryExtension)
+            .apply(buildEvents, sentryOrgParameter, sentryProjectParameter)
+        }
+
+        // this has to be in afterEvaluate, else it might be too early to detect the deprecated
+        // plugin
+        p.afterEvaluate {
+          p.pluginManager.withPlugin("com.android.application") {
+            if (p.plugins.hasPlugin("io.sentry.android.gradle")) {
+              throw StopExecutionException(
+                "Using 'io.sentry.gradle' and 'io.sentry.android.gradle' plugins together is not supported."
+              )
+            }
+          }
+        }
+      }
+    }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
@@ -13,8 +13,10 @@ import io.sentry.android.gradle.telemetry.SentryTelemetryService
 import io.sentry.android.gradle.util.SentryPluginUtils
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.info
+import io.sentry.gradle.SENTRY_ORG_PARAMETER
+import io.sentry.gradle.SENTRY_PROJECT_PARAMETER
 import io.sentry.gradle.common.JavaVariant
-import java.io.File
+import io.sentry.gradle.sep
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -35,7 +37,7 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
   private val configuredForJavaProject = AtomicBoolean(false)
 
   override fun apply(project: Project) {
-    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java, project)
+    val extension = SentryPluginExtension.of(project)
 
     project.pluginManager.withPlugin("org.gradle.java") {
       if (configuredForJavaProject.getAndSet(true)) {
@@ -54,11 +56,9 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
       val extraProperties = project.extensions.getByName("ext") as ExtraPropertiesExtension
 
       val sentryOrgParameter =
-        runCatching { extraProperties.get(SentryPlugin.SENTRY_ORG_PARAMETER).toString() }
-          .getOrNull()
+        runCatching { extraProperties.get(SENTRY_ORG_PARAMETER).toString() }.getOrNull()
       val sentryProjectParameter =
-        runCatching { extraProperties.get(SentryPlugin.SENTRY_PROJECT_PARAMETER).toString() }
-          .getOrNull()
+        runCatching { extraProperties.get(SENTRY_PROJECT_PARAMETER).toString() }.getOrNull()
 
       val sentryTelemetryProvider = SentryTelemetryService.register(project)
       project.gradle.taskGraph.whenReady {
@@ -134,9 +134,5 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
 
       project.installDependencies(extension, false)
     }
-  }
-
-  companion object {
-    internal val sep = File.separator
   }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallNonAndroidTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.android.gradle.integration
 
-import io.sentry.android.gradle.SentryPlugin.Companion.SENTRY_SDK_VERSION
+import io.sentry.gradle.SENTRY_SDK_VERSION
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.gradle.util.GradleVersion

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.android.gradle.integration
 
 import io.sentry.BuildConfig
-import io.sentry.android.gradle.SentryPlugin.Companion.SENTRY_SDK_VERSION
+import io.sentry.gradle.SENTRY_SDK_VERSION
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.gradle.util.GradleVersion

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,9 @@ pluginManagement {
       if (requested.id.id == "io.sentry.jvm.gradle") {
         useModule("io.sentry:sentry-android-gradle-plugin:${requested.version}")
       }
+      if (requested.id.id == "io.sentry.gradle") {
+        useModule("io.sentry:sentry-android-gradle-plugin:${requested.version}")
+      }
     }
   }
   repositories {
@@ -28,7 +31,7 @@ include(":examples:android-gradle")
 
 include(":examples:android-gradle-kts")
 
-include(":examples:android-guardsquare-proguard")
+// include(":examples:android-guardsquare-proguard")
 
 include(":examples:android-ndk")
 


### PR DESCRIPTION
_#skip-changelog_ 

## :scroll: Description
<!--- Describe your changes in detail -->
- Introduce a new `io.sentry.gradle` plugin that has to be applied on the root project level. The plugin then:
	- Goes over `subprojects` and applies the respective subplugins depending on what plugins are currently applied to the gradle project
	- AppSubplugin implementation remained untouched and just works, however I will refactor and extract some things later on
	- LibSubplugin implementation to follow
	- Checks if the `io.sentry.android.gradle` plugin is in place and throws as they are incompatible and can't be used together
- Deprecate `io.sentry.android.gradle` and print a message to switch over to the new root plugin
	- It also delegates to the same AppSubplugin that is used by the new root plugin
- Factor out common things into a separate file that we share among the plugins

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #800 

## :green_heart: How did you test it?
So far just manually, will add/convert existing tests later

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
- Make LibSubplugin do the actual work
  - also investigate if we can reuse the same one for all kinds of libs, not only android 
- Make RootPlugin collect sources from all modules into a single bundle and upload it
- Introduce new SentryRootExtension and SentryProjectExtension to allow configuration per-project or globally on a root project level
- Convert tests to use the root plugin and add a single test that tests the deprecated one 