### PR TITLE
fix(instrumentation): Make SentryGenerateIntegrationListTask configuration-cache compatible

### DIFF
--- a/.github/workflows/test-matrix-agp-gradle.yaml
+++ b/.github/workflows/test-matrix-agp-gradle.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   publish-dry-run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Kotlin Compiler Plugin: Fix API incompatibility with Kotlin 2.1.20 ([#857](https://github.com/getsentry/sentry-android-gradle-plugin/pull/857))
+- Make `SentryGenerateIntegrationListTask` configuration-cache compatible ([#866](https://github.com/getsentry/sentry-android-gradle-plugin/pull/866))
 
 ### Internal
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -29,7 +29,6 @@ import io.sentry.android.gradle.tasks.SentryUploadProguardMappingsTask
 import io.sentry.android.gradle.tasks.configureNativeSymbolsTask
 import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTaskFactory
 import io.sentry.android.gradle.telemetry.SentryTelemetryService
-import io.sentry.android.gradle.telemetry.withSentryTelemetry
 import io.sentry.android.gradle.transforms.MetaInfStripTransform
 import io.sentry.android.gradle.util.AgpVersions
 import io.sentry.android.gradle.util.AgpVersions.isAGP74
@@ -204,18 +203,13 @@ fun AndroidComponentsExtension<*, *, *>.configure(
         }
 
         val manifestUpdater =
-          project.tasks.register(
-            "${variant.name}SentryGenerateIntegrationListTask",
-            SentryGenerateIntegrationListTask::class.java,
-          ) {
-            it.integrations.set(
-              sentryModulesService.map { service ->
-                service.retrieveEnabledInstrumentationFeatures()
-              }
-            )
-            it.usesService(sentryModulesService)
-            it.withSentryTelemetry(extension, sentryTelemetryProvider)
-          }
+          SentryGenerateIntegrationListTask.register(
+            project,
+            extension,
+            sentryTelemetryProvider,
+            sentryModulesService,
+            variant.name,
+          )
 
         variant.artifacts
           .use(manifestUpdater)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
@@ -28,7 +28,7 @@ abstract class SentryModulesService :
   @set:Synchronized
   var externalModules: Map<ModuleIdentifier, SemVer> = emptyMap()
 
-  fun retrieveEnabledInstrumentationFeatures(): Set<String> {
+  fun retrieveEnabledInstrumentationFeatures(project: Project): Provider<Set<String>> {
     val features =
       parameters.features
         .get()
@@ -52,7 +52,7 @@ abstract class SentryModulesService :
       features.add("DexGuard")
     }
 
-    return features
+    return project.provider { features }
   }
 
   private fun isInstrumentationEnabled(feature: InstrumentationFeature): Boolean {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateIntegrationListTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateIntegrationListTask.kt
@@ -1,11 +1,17 @@
 package io.sentry.android.gradle.tasks
 
 import io.sentry.android.gradle.ManifestWriter
+import io.sentry.android.gradle.extensions.SentryPluginExtension
+import io.sentry.android.gradle.services.SentryModulesService
+import io.sentry.android.gradle.telemetry.SentryTelemetryService
+import io.sentry.android.gradle.telemetry.withSentryTelemetry
 import io.sentry.android.gradle.util.info
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -14,13 +20,10 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity.NONE
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
 
 @CacheableTask
 abstract class SentryGenerateIntegrationListTask : DefaultTask() {
-
-  companion object {
-    const val ATTR_INTEGRATIONS = "io.sentry.gradle-plugin-integrations"
-  }
 
   init {
     description = "Writes enabled integrations to AndroidManifest.xml"
@@ -56,6 +59,31 @@ abstract class SentryGenerateIntegrationListTask : DefaultTask() {
         updatedManifestFile.toPath(),
         StandardCopyOption.REPLACE_EXISTING,
       )
+    }
+  }
+
+  companion object {
+    const val ATTR_INTEGRATIONS = "io.sentry.gradle-plugin-integrations"
+
+    fun register(
+      project: Project,
+      extension: SentryPluginExtension,
+      sentryTelemetryProvider: Provider<SentryTelemetryService>?,
+      sentryModulesService: Provider<SentryModulesService>,
+      variantName: String,
+    ): TaskProvider<SentryGenerateIntegrationListTask> {
+      return project.tasks.register(
+        "${variantName}SentryGenerateIntegrationListTask",
+        SentryGenerateIntegrationListTask::class.java,
+      ) {
+        it.integrations.set(
+          sentryModulesService.flatMap { service ->
+            service.retrieveEnabledInstrumentationFeatures(project)
+          }
+        )
+        it.usesService(sentryModulesService)
+        it.withSentryTelemetry(extension, sentryTelemetryProvider)
+      }
     }
   }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -132,7 +132,7 @@ abstract class BaseSentryPluginTest(
         .withArguments("--stacktrace")
         .withPluginClasspath()
         .withGradleVersion(gradleVersion)
-        //            .withDebug(true)
+        .withDebug(true)
         .forwardStdOutput(writer)
         .forwardStdError(writer)
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -132,7 +132,7 @@ abstract class BaseSentryPluginTest(
         .withArguments("--stacktrace")
         .withPluginClasspath()
         .withGradleVersion(gradleVersion)
-        .withDebug(true)
+        //            .withDebug(true)
         .forwardStdOutput(writer)
         .forwardStdError(writer)
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The task inputs were not properly wired, so running with config-cache enabled resulted in inconsistent integrations list being written to the manifest + unnecessary task reruns. Using `flatMap` on the input + returning a Provider from `SentryModulesService` fixes the problem.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #846 

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
