### PR TITLE
Centralize dependency management

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,6 @@ plugins {
 }
 
 allprojects {
-  repositories {
-    google()
-    mavenCentral()
-  }
   apply { plugin("com.diffplug.spotless") }
 
   if (name != "examples") {

--- a/examples/multi-module-sample/spring-boot-in-multi-module-sample/build.gradle.kts
+++ b/examples/multi-module-sample/spring-boot-in-multi-module-sample/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
-repositories { mavenCentral() }
-
 dependencies {
   implementation(libs.sample.springBoot.starterSecurity)
   implementation(libs.sample.springBoot.starterWeb)

--- a/examples/multi-module-sample/spring-boot-in-multi-module-sample2/build.gradle.kts
+++ b/examples/multi-module-sample/spring-boot-in-multi-module-sample2/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
-repositories { mavenCentral() }
-
 dependencies {
   implementation(libs.sample.springBoot.starterSecurity)
   implementation(libs.sample.springBoot.starterWeb)

--- a/examples/spring-boot-sample/build.gradle.kts
+++ b/examples/spring-boot-sample/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
-repositories { mavenCentral() }
-
 dependencies {
   implementation(libs.sample.springBoot.starterSecurity)
   implementation(libs.sample.springBoot.starterWeb)

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -23,14 +23,6 @@ plugins {
   alias(libs.plugins.buildConfig)
 }
 
-allprojects {
-  repositories {
-    mavenLocal()
-    mavenCentral()
-    google()
-  }
-}
-
 BootstrapAndroidSdk.locateAndroidSdk(project, extra)
 
 val androidSdkPath: String? by extra

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -1,3 +1,13 @@
 rootProject.name = ("sentry-android-gradle-plugin")
 
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+    google()
+    mavenLocal()
+  }
+
+  repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+}
+
 include(":common")

--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -12,13 +12,6 @@ plugins {
 val kotlin1920: SourceSet by sourceSets.creating
 val kotlin2120: SourceSet by sourceSets.creating
 
-allprojects {
-  repositories {
-    google()
-    mavenCentral()
-  }
-}
-
 spotless {
   kotlin {
     ktfmt(libs.versions.ktfmt.get()).googleStyle()
@@ -51,11 +44,6 @@ publish.releaseSigningEnabled = false
 tasks.named("distZip") {
   dependsOn("publishToMavenLocal")
   onlyIf { inputs.sourceFiles.isEmpty.not().also { require(it) { "No distribution to zip." } } }
-}
-
-repositories {
-  google()
-  maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
 }
 
 dependencies {

--- a/sentry-kotlin-compiler-plugin/settings.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/settings.gradle.kts
@@ -1,1 +1,10 @@
 rootProject.name = ("sentry-kotlin-compiler-plugin")
+
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+  }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,14 @@ pluginManagement {
   }
 }
 
+dependencyResolutionManagement {
+  repositories {
+    mavenCentral()
+    google()
+  }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+}
+
 rootProject.name = ("sentry-android-gradle-plugin-composite-build")
 
 include(":examples:android-gradle")


### PR DESCRIPTION
## :scroll: Description

This removes some uses of the allprojects block in favor of centralized
dependency management.

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
