### PR TITLE
Add stricter plugin validation and fix issues.

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -319,3 +319,10 @@ buildConfig {
 }
 
 tasks.register<ASMifyTask>("asmify")
+
+tasks.named("check").configure { dependsOn(tasks.named("validatePlugins")) }
+
+tasks.withType<ValidatePlugins>().configureEach {
+  failOnWarning.set(true)
+  enableStricterValidation.set(true)
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/BundleSourcesTask.kt
@@ -17,6 +17,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -25,6 +26,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
 
+@CacheableTask
 abstract class BundleSourcesTask : SentryCliExecTask() {
 
   init {
@@ -41,7 +43,9 @@ abstract class BundleSourcesTask : SentryCliExecTask() {
   @get:InputDirectory
   abstract val sourceDir: DirectoryProperty
 
-  @get:InputFile abstract val bundleIdFile: RegularFileProperty
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val bundleIdFile: RegularFileProperty
 
   @get:OutputDirectory abstract val output: DirectoryProperty
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/UploadSourceBundleTask.kt
@@ -15,8 +15,12 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Uploads should not be cached")
 abstract class UploadSourceBundleTask : SentryCliExecTask() {
 
   init {
@@ -38,7 +42,9 @@ abstract class UploadSourceBundleTask : SentryCliExecTask() {
 
   @get:Input abstract val includeSourceContext: Property<Boolean>
 
-  @get:InputDirectory abstract val sourceBundleDir: DirectoryProperty
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val sourceBundleDir: DirectoryProperty
 
   @get:Input abstract val autoUploadSourceContext: Property<Boolean>
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/DirectoryOutputTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/DirectoryOutputTask.kt
@@ -3,7 +3,9 @@ package io.sentry.android.gradle.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "abstract task, should not be used directly")
 abstract class DirectoryOutputTask : DefaultTask() {
 
   @get:OutputDirectory abstract val output: DirectoryProperty

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/PropertiesFileOutputTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/PropertiesFileOutputTask.kt
@@ -3,7 +3,9 @@ package io.sentry.android.gradle.tasks
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "abstract task, should not be used directly")
 abstract class PropertiesFileOutputTask : DirectoryOutputTask() {
   @get:Internal abstract val outputFile: Provider<RegularFile>
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt
@@ -13,14 +13,21 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "abstract task, should not be used directly")
 abstract class SentryCliExecTask : Exec() {
 
   @get:Input @get:Optional abstract val debug: Property<Boolean>
 
   @get:Input abstract val cliExecutable: Property<String>
 
-  @get:InputFile @get:Optional abstract val sentryProperties: RegularFileProperty
+  @get:InputFile
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val sentryProperties: RegularFileProperty
 
   @get:Input @get:Optional abstract val sentryOrganization: Property<String>
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -16,7 +16,9 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Uploads should not be cached")
 abstract class SentryUploadNativeSymbolsTask : SentryCliExecTask() {
 
   init {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt
@@ -16,8 +16,12 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Uploads should not be cached")
 abstract class SentryUploadProguardMappingsTask : SentryCliExecTask() {
 
   init {
@@ -33,9 +37,13 @@ abstract class SentryUploadProguardMappingsTask : SentryCliExecTask() {
     outputs.upToDateWhen { true }
   }
 
-  @get:InputFile abstract val uuidFile: RegularFileProperty
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val uuidFile: RegularFileProperty
 
-  @get:InputFiles abstract var mappingsFiles: Provider<FileCollection>
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract var mappingsFiles: Provider<FileCollection>
 
   @get:Input abstract val autoUploadProguardMapping: Property<Boolean>
 


### PR DESCRIPTION
## :scroll: Description

This adds stricter plugin validation to check that all tasks are
declared cacheable or not and all properties are correctly marked.

This also fixes issues that the task discovered and adds it as a
dependency to the check task.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
