### PR TITLE
Update Maven Publish Plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Verify artifact contents
         shell: bash
         run: |
-          zipfile=$(ls -1 plugin-build/build/distributions | grep -v "PluginMarker")
+          zipfile=$(ls -1 plugin-build/build/distributions | grep -v "PluginMarker" | grep -v ".tar")
           filename=${zipfile/\.zip/}
           unzip plugin-build/build/distributions/$filename.zip -d /tmp
           find /tmp/$filename | grep "pom-default.xml"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ groovyGradlePlugin = { id = "dev.gradleplugins.groovy-gradle-plugin", version = 
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 # do not upgrade `mavenPublish` to 0.18.0, it does not generate the pom-default.xml and module.json under
 # build/publications/maven
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.21.0" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "4.2.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,8 +21,6 @@ dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.0" }
 groovyGradlePlugin = { id = "dev.gradleplugins.groovy-gradle-plugin", version = "1.2" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
-# do not upgrade `mavenPublish` to 0.18.0, it does not generate the pom-default.xml and module.json under
-# build/publications/maven
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ groovyGradlePlugin = { id = "dev.gradleplugins.groovy-gradle-plugin", version = 
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 # do not upgrade `mavenPublish` to 0.18.0, it does not generate the pom-default.xml and module.json under
 # build/publications/maven
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.17.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "4.2.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ groovyGradlePlugin = { id = "dev.gradleplugins.groovy-gradle-plugin", version = 
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 # do not upgrade `mavenPublish` to 0.18.0, it does not generate the pom-default.xml and module.json under
 # build/publications/maven
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.21.0" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version = "4.2.0" }

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
   id("distribution")
   alias(libs.plugins.dokka)
   id("java-gradle-plugin")
-  alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.spotless)
   // we need this plugin in order to include .aar dependencies into a pure java project, which the
   // gradle plugin is
@@ -238,6 +238,8 @@ distributions {
     contents { from("build${sep}publications${sep}sentryJvmPluginPluginMarkerMaven") }
   }
 }
+
+apply { plugin("com.vanniktech.maven.publish") }
 
 tasks.named("distZip") {
   dependsOn("publishToMavenLocal")

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.vanniktech.maven.publish.MavenPublishPluginExtension
 import io.sentry.android.gradle.internal.ASMifyTask
 import io.sentry.android.gradle.internal.BootstrapAndroidSdk
 import java.io.FileInputStream
@@ -14,7 +13,7 @@ plugins {
   id("distribution")
   alias(libs.plugins.dokka)
   id("java-gradle-plugin")
-  alias(libs.plugins.mavenPublish) apply false
+  alias(libs.plugins.mavenPublish)
   alias(libs.plugins.spotless)
   // we need this plugin in order to include .aar dependencies into a pure java project, which the
   // gradle plugin is
@@ -239,14 +238,6 @@ distributions {
     contents { from("build${sep}publications${sep}sentryJvmPluginPluginMarkerMaven") }
   }
 }
-
-apply { plugin("com.vanniktech.maven.publish") }
-
-val publish = extensions.getByType(MavenPublishPluginExtension::class.java)
-
-// signing is done when uploading files to MC
-// via gpg:sign-and-deploy-file (release.kts)
-publish.releaseSigningEnabled = false
 
 tasks.named("distZip") {
   dependsOn("publishToMavenLocal")

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
   id("distribution")
   alias(libs.plugins.dokka)
   id("java-gradle-plugin")
-  alias(libs.plugins.mavenPublish) apply false
+  alias(libs.plugins.mavenPublish)
   alias(libs.plugins.spotless)
   // we need this plugin in order to include .aar dependencies into a pure java project, which the
   // gradle plugin is
@@ -225,7 +225,7 @@ distributions {
   main {
     contents {
       from("build${sep}libs")
-      from("build${sep}publications${sep}maven")
+      from("build${sep}publications${sep}pluginMaven")
     }
   }
   create("sentryPluginMarker") {
@@ -238,8 +238,6 @@ distributions {
     contents { from("build${sep}publications${sep}sentryJvmPluginPluginMarkerMaven") }
   }
 }
-
-apply { plugin("com.vanniktech.maven.publish") }
 
 tasks.named("distZip") {
   dependsOn("publishToMavenLocal")

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -25,3 +25,5 @@ POM_LICENCE_URL=https://github.com/getsentry/sentry-android-gradle-plugin/blob/m
 POM_DEVELOPER_ID=getsentry
 POM_DEVELOPER_NAME=Sentry Team and Contributors
 POM_DEVELOPER_URL=https://github.com/getsentry/
+
+RELEASE_SIGNING_ENABLED=false

--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -34,13 +34,6 @@ distributions {
   }
 }
 
-val publish =
-  extensions.getByType(com.vanniktech.maven.publish.MavenPublishPluginExtension::class.java)
-
-// signing is done when uploading files to MC
-// via gpg:sign-and-deploy-file (release.kts)
-publish.releaseSigningEnabled = false
-
 tasks.named("distZip") {
   dependsOn("publishToMavenLocal")
   onlyIf { inputs.sourceFiles.isEmpty.not().also { require(it) { "No distribution to zip." } } }

--- a/sentry-kotlin-compiler-plugin/gradle.properties
+++ b/sentry-kotlin-compiler-plugin/gradle.properties
@@ -16,3 +16,5 @@ POM_LICENCE_URL=https://github.com/getsentry/sentry-android-gradle-plugin/blob/m
 POM_DEVELOPER_ID=getsentry
 POM_DEVELOPER_NAME=Sentry Team and Contributors
 POM_DEVELOPER_URL=https://github.com/getsentry/
+
+RELEASE_SIGNING_ENABLED=false


### PR DESCRIPTION
## :scroll: Description
This updates the Maven Publish Plugin which should unblock enabling the
configuration cache and also help with updating to Gradle 8.x in this
repo.

The changelog for all the versions is here: https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md#version-0180-2021-09-13

Note, we cannot update to a higher version until the build itself is
build with Gradle 8.x or higher.

The api to configure signing was changed in 0.20.0 this is why the
gradle property was adjusted.

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
