### PR TITLE
Remove clean and no-daemon

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -45,7 +45,7 @@ jobs:
         if: always()
 
       - name: Build the Debug variant
-        run: ./gradlew assembleDebug --no-daemon
+        run: ./gradlew assembleDebug
 
       - name: Build the Release variant
-        run: ./gradlew assembleRelease --no-daemon
+        run: ./gradlew assembleRelease

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,9 @@
-.PHONY: format clean preMerge stop all
+.PHONY: format preMerge all
 
 format:
 	./gradlew spotlessApply
 
-clean:
-	./gradlew clean
-
 preMerge:
 	./gradlew preMerge --continue
 
-# We stop gradle at the end to make sure the cache folders
-# don't contain any lock files and are free to be cached.
-stop:
-	./gradlew --stop
-
-all: stop clean format preMerge
+all: format preMerge

--- a/plugin-build/Makefile
+++ b/plugin-build/Makefile
@@ -1,13 +1,10 @@
-.PHONY: clean compile all dist
-
-clean:
-	./gradlew clean
+.PHONY: compile all dist
 
 compile:
 	./gradlew assemble
 
 # build distribution artifacts
 dist:
-	./gradlew distZip --no-daemon --no-parallel
+	./gradlew distZip --no-parallel
 
-all: clean compile dist
+all: compile dist

--- a/sentry-kotlin-compiler-plugin/Makefile
+++ b/sentry-kotlin-compiler-plugin/Makefile
@@ -1,13 +1,10 @@
-.PHONY: clean compile all dist
-
-clean:
-	./gradlew clean
+.PHONY: compile all dist
 
 compile:
 	./gradlew assemble
 
 # build distribution artifacts
 dist:
-	./gradlew distZip --no-daemon --no-parallel
+	./gradlew distZip --no-parallel
 
-all: clean compile dist
+all: compile dist


### PR DESCRIPTION
## :scroll: Description
We start from a clean slate on CI so running clean only adds time to the
jobs.
Also it is always recommended to use the daemon especially when running
multiple jobs in order to speed up the build.

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
