### PR TITLE
Enable daemon re-use

### DIFF
--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+CrashOnOutOfMemoryError
-org.gradle.daemon=false
 org.gradle.caching=true
 org.gradle.parallel=true
 

--- a/sentry-kotlin-compiler-plugin/gradle.properties
+++ b/sentry-kotlin-compiler-plugin/gradle.properties
@@ -1,3 +1,7 @@
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:+CrashOnOutOfMemoryError
+org.gradle.caching=true
+org.gradle.parallel=true
+
 GROUP = io.sentry
 POM_ARTIFACT_ID = sentry-kotlin-compiler-plugin
 VERSION_NAME = 5.7.0


### PR DESCRIPTION
## :scroll: Description

This enables the Gradle daemon for the plugin build and also adds the
same gradle properties to the kotlin compiler build in order to allow
daemon re-use between all the builds.

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
