### PR TITLE
Reduce number of cores/threads.

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -133,9 +133,8 @@ tasks.named("pluginUnderTestMetadata").configure {
   (this as PluginUnderTestMetadata).pluginClasspath.from(fixtureClasspath)
 }
 
-tasks.named("test").configure {
-  require(this is Test)
-  maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+tasks.withType<Test>().named("test").configure {
+  maxParallelForks = 2
 
   // Cap JVM args per test
   minHeapSize = "128m"
@@ -150,9 +149,9 @@ tasks.register<Test>("integrationTest").configure {
   // for some reason Gradle > 8.10 doesn't pick up the pluginUnderTestMetadata classpath, so we
   // need to add it manually
   classpath +=
-    layout.files(project.layout.buildDirectory.get().toString() + "/pluginUnderTestMetadata")
+    layout.files(project.layout.buildDirectory.dir("pluginUnderTestMetadata"))
 
-  maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+  maxParallelForks = 2
 
   // Cap JVM args per test
   minHeapSize = "128m"
@@ -196,7 +195,7 @@ tasks.withType<Jar>().configureEach {
 
 tasks.withType<ShadowJar>().configureEach {
   archiveClassifier.set("")
-  configurations = listOf(project.configurations.getByName("shade"))
+  configurations = listOf(shade)
 
   exclude("/kotlin/**")
   exclude("/groovy**")

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -148,8 +148,7 @@ tasks.register<Test>("integrationTest").configure {
   description = "Runs the integration tests"
   // for some reason Gradle > 8.10 doesn't pick up the pluginUnderTestMetadata classpath, so we
   // need to add it manually
-  classpath +=
-    layout.files(project.layout.buildDirectory.dir("pluginUnderTestMetadata"))
+  classpath += layout.files(project.layout.buildDirectory.dir("pluginUnderTestMetadata"))
 
   maxParallelForks = 2
 


### PR DESCRIPTION
On a modern mac machine with 10+ cores this demands too many workers.
Gradle integration tests are disk bound no I/O bound so this doesn't
speed up the build but significantly increases memory consumption.
CI has only 4 cores anyways so this should have the same effect on CI as before.
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
