### PR TITLE
Add Google Truth for easier to debug assertions in tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8133)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.12.0...8.13.3)
 
+### Internal
+
+- Add Google Truth for easier to debug assertions in tests ([#920](https://github.com/getsentry/sentry-android-gradle-plugin/pull/920))
+
 ## 5.7.0
 
 ### Dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ autoService = { group = "com.google.auto.service", name = "auto-service", versio
 autoServiceAnnotatons = { group = "com.google.auto.service", name = "auto-service-annotations", version = "1.0.1" }
 kotlinJunit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.7.0" }
+truth = { module = "com.google.truth:truth", version = "1.4.4" }
 composeDesktop = { group = "org.jetbrains.compose.desktop", name = "desktop", version = "1.6.10" }
 
 # bytecode instrumentation

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
   testImplementation(libs.proguard)
   testImplementation(libs.junit)
   testImplementation(libs.mockitoKotlin)
+  testImplementation(libs.truth)
 
   testImplementation(libs.asm)
   testImplementation(libs.asmCommons)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/BundleSourcesTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/BundleSourcesTaskTest.kt
@@ -1,14 +1,11 @@
 package io.sentry.android.gradle.tasks
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.android.gradle.sourcecontext.BundleSourcesTask
 import io.sentry.android.gradle.sourcecontext.GenerateBundleIdTask.Companion.SENTRY_BUNDLE_ID_PROPERTY
 import java.io.File
 import java.util.Properties
 import java.util.UUID
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -40,15 +37,15 @@ class BundleSourcesTaskTest {
 
     val args = task.get().computeCommandLineArgs()
 
-    assertTrue("sentry-cli" in args)
-    assertTrue("debug-files" in args)
-    assertTrue("bundle-jvm" in args)
-    assertTrue(sourceDir.absolutePath in args)
-    assertTrue("--output=${outDir.absolutePath}" in args)
+    assertThat(args).contains("sentry-cli")
+    assertThat(args).contains("debug-files")
+    assertThat(args).contains("bundle-jvm")
+    assertThat(args).contains(sourceDir.absolutePath)
+    assertThat(args).contains("--output=${outDir.absolutePath}")
 
-    assertFalse("--org" in args)
-    assertFalse("--project" in args)
-    assertFalse("--log-level=debug" in args)
+    assertThat(args).doesNotContain("--org")
+    assertThat(args).doesNotContain("--project")
+    assertThat(args).doesNotContain("--log-level=debug")
   }
 
   @Test
@@ -69,7 +66,7 @@ class BundleSourcesTaskTest {
 
     val args = task.get().computeCommandLineArgs()
 
-    assertTrue("--log-level=debug" in args)
+    assertThat(args).contains("--log-level=debug")
   }
 
   @Test
@@ -91,10 +88,8 @@ class BundleSourcesTaskTest {
 
     task.get().setSentryPropertiesEnv()
 
-    assertEquals(
-      propertiesFile.absolutePath,
-      task.get().environment["SENTRY_PROPERTIES"].toString(),
-    )
+    assertThat(task.get().environment["SENTRY_PROPERTIES"].toString())
+      .isEqualTo(propertiesFile.toString())
   }
 
   @Test
@@ -115,7 +110,7 @@ class BundleSourcesTaskTest {
 
     task.get().setSentryAuthTokenEnv()
 
-    assertEquals("<token>", task.get().environment["SENTRY_AUTH_TOKEN"].toString())
+    assertThat(task.get().environment).containsEntry("SENTRY_AUTH_TOKEN", "<token>")
   }
 
   @Test
@@ -135,7 +130,7 @@ class BundleSourcesTaskTest {
 
     task.get().setSentryPropertiesEnv()
 
-    assertNull(task.get().environment["SENTRY_PROPERTIES"])
+    assertThat(task.get().environment).doesNotContainKey("SENTRY_PROPERTIES")
   }
 
   @Test
@@ -156,8 +151,8 @@ class BundleSourcesTaskTest {
 
     val args = task.get().computeCommandLineArgs()
 
-    assertTrue("--org" in args)
-    assertTrue("dummy-org" in args)
+    assertThat(args).contains("--org")
+    assertThat(args).contains("dummy-org")
   }
 
   @Test
@@ -178,8 +173,8 @@ class BundleSourcesTaskTest {
 
     val args = task.get().computeCommandLineArgs()
 
-    assertTrue("--project" in args)
-    assertTrue("dummy-proj" in args)
+    assertThat(args).contains("--project")
+    assertThat(args).contains("dummy-proj")
   }
 
   @Test
@@ -187,7 +182,7 @@ class BundleSourcesTaskTest {
     val expected = "8c776014-bb25-11eb-8529-0242ac130003"
     val input = tempDir.newFile().apply { writeText("$SENTRY_BUNDLE_ID_PROPERTY=$expected") }
     val actual = BundleSourcesTask.readBundleIdFromFile(input)
-    assertEquals(expected, actual)
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -195,7 +190,7 @@ class BundleSourcesTaskTest {
     val expected = "8c776014-bb25-11eb-8529-0242ac130003"
     val input = tempDir.newFile().apply { writeText(" $SENTRY_BUNDLE_ID_PROPERTY=$expected\n") }
     val actual = BundleSourcesTask.readBundleIdFromFile(input)
-    assertEquals(expected, actual)
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -238,8 +233,8 @@ class BundleSourcesTaskTest {
 
     val args = task.get().computeCommandLineArgs()
 
-    assertTrue("--url" in args)
-    assertTrue("https://some-host.sentry.io" in args)
+    assertThat(args).contains("--url")
+    assertThat(args).contains("https://some-host.sentry.io")
   }
 
   private fun createProject(): Project {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/CollectSourcesTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/CollectSourcesTaskTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.gradle.tasks
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.android.gradle.sourcecontext.SourceCollector
 import java.io.File
-import kotlin.test.assertEquals
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
@@ -35,7 +35,7 @@ class CollectSourcesTaskTest {
     SourceCollector().collectSources(outDir, sourceDirs)
 
     val outSources = outDir.walk().filter { it.isFile }.toList()
-    assertEquals(3, outSources.size)
+    assertThat(outSources).hasSize(3)
   }
 
   private fun createProject(): Project {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.gradle.tasks.dependencies
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTaskV2.Companion.SENTRY_DEPENDENCIES_REPORT_OUTPUT
 import java.io.File
-import kotlin.test.assertEquals
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
@@ -65,7 +65,7 @@ class SentryExternalDependenciesReportTaskTest {
     task.get().action()
 
     val outputFile = File(output, SENTRY_DEPENDENCIES_REPORT_OUTPUT)
-    assertEquals("", outputFile.readText())
+    assertThat(outputFile.readText()).isEqualTo("")
   }
 
   @Test
@@ -85,12 +85,13 @@ class SentryExternalDependenciesReportTaskTest {
     task.get().action()
 
     val outputFile = File(output, SENTRY_DEPENDENCIES_REPORT_OUTPUT)
-    assertEquals("", outputFile.readText())
+    assertThat(outputFile.readText()).isEqualTo("")
   }
 
   private fun File.verifyContents() {
-    assertEquals(
-      """
+    assertThat(File(this, SENTRY_DEPENDENCIES_REPORT_OUTPUT).readText())
+      .isEqualTo(
+        """
             androidx.annotation:annotation:1.1.0
             androidx.arch.core:core-common:2.1.0
             androidx.collection:collection:1.0.0
@@ -103,9 +104,8 @@ class SentryExternalDependenciesReportTaskTest {
             io.sentry:sentry-android-core:6.5.0
             io.sentry:sentry:6.5.0
             """
-        .trimIndent(),
-      File(this, SENTRY_DEPENDENCIES_REPORT_OUTPUT).readText(),
-    )
+          .trimIndent()
+      )
   }
 
   private fun createRegularProject(): Project {


### PR DESCRIPTION
## :scroll: Description

This adds Google Truth assertions for easier debugging in tests.
More information about Truth here: https://truth.dev/

## :bulb: Motivation and Context
Previous kotlin.test assertions give minimal information and a massive useless stacktrace.
![Screenshot 2025-06-12 at 14 28 32](https://github.com/user-attachments/assets/6084126f-d22a-4152-9d2f-1585d98bc2ce)

Google Truth assertions:
![Screenshot 2025-06-12 at 15 12 06](https://github.com/user-attachments/assets/f88afb34-06cd-45d6-a482-6a587c242322)

The Google Truth assertions give a lot more meaningful information to make it easier to debug failed tests.



## :green_heart: How did you test it?
By running the tests :)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
