### PR TITLE
chore(gh): Update GH issue templates for Linear compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way we (probably) intend.
-labels: ["Platform: Android", "bug"]
-type: Bug
+labels: ["Android", "Bug"]
 body:
   - type: input
     id: gradle_version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: 💡 Feature Request
 description: Tell us about a problem our Gradle plugin could solve but doesn't.
-labels: ["Platform: Android", "enhancement"]
-type: Feature
+labels: ["Android", "Feature"]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,6 +1,6 @@
 name: Blank Issue
 description: Blank Issue. Reserved for maintainers.
-labels: ["Platform: Android"]
+labels: ["Android"]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
replaces usage of GH issue type and platform label to Linear-compatible labels

GH issue types will be deprecated internally by August 14

#skip-changelog