### PR TITLE
fix(scripts): Consider previous major pre-release for AGP in generate-compat-matrix script

### DIFF
--- a/scripts/generate-compat-matrix.main.kts
+++ b/scripts/generate-compat-matrix.main.kts
@@ -248,7 +248,11 @@ class GenerateMatrix : CliktCommand() {
 
     // AGP usually has two pre-releases at the same time
     val latestPreRelease = semvers.last { it.isPreRelease }
-    val secondToLatestPreRelease = semvers.last { it.isPreRelease && it.minor == (latestPreRelease.minor - 1) }
+    var secondToLatestPreRelease = semvers.lastOrNull { it.isPreRelease && it.minor == (latestPreRelease.minor - 1) }
+    if (secondToLatestPreRelease == null) {
+      // this means the previous pre-release is actually in the previous major
+      secondToLatestPreRelease = semvers.last { it.isPreRelease && it.major == (latestPreRelease.major - 1) }
+    }
     val latest = semvers.last { it.isStable }
     val previousMajorLatest = semvers.last { it.isStable && it.major == (latest.major - 1)}
     return listOf(latestPreRelease, secondToLatestPreRelease, latest, previousMajorLatest)


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
We were not considering if the previous pre-release is in the previous major (e.g. current - 9.0.0-alpha02, previous - 8.13.0-rc01)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
