### PR TITLE
Include version in dependency auto install messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add upload functionality for size analysis ([#915](https://github.com/getsentry/sentry-android-gradle-plugin/pull/915))
 - Add VCS info extension for build uploads with customizable version control metadata ([#969](https://github.com/getsentry/sentry-android-gradle-plugin/pull/969))
+- Include version in logs if auto install refuses to install a dependency ([#979](https://github.com/getsentry/sentry-android-gradle-plugin/pull/979))
 
 ### Fixes
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AbstractInstallStrategy.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AbstractInstallStrategy.kt
@@ -32,7 +32,7 @@ abstract class AbstractInstallStrategy : ComponentMetadataRule {
       parseVersion(context.details.id.version)?.let { thirdPartySemVersion ->
         if (thirdPartySemVersion < it) {
           logger.info {
-            "$sentryModuleId won't be installed because the current version is " +
+            "$sentryModuleId won't be installed because the current version ($thirdPartySemVersion) is " +
               "lower than the minimum supported version ($it)"
           }
           return
@@ -43,8 +43,8 @@ abstract class AbstractInstallStrategy : ComponentMetadataRule {
       parseVersion(context.details.id.version)?.let { thirdPartySemVersion ->
         if (thirdPartySemVersion > it) {
           logger.info {
-            "$sentryModuleId won't be installed because the current version is " +
-              "higher than the maximum supported version ($it)"
+            "$sentryModuleId won't be installed because the current version ($thirdPartySemVersion) " +
+              "is higher than the maximum supported version ($it)"
           }
           return
         }
@@ -57,7 +57,7 @@ abstract class AbstractInstallStrategy : ComponentMetadataRule {
         if (sentrySemVersion < minSupportedSentryVersion) {
           logger.warn {
             "$sentryModuleId won't be installed because the current sentry version " +
-              "is lower than the minimum supported sentry version " +
+              "($sentrySemVersion) is lower than the minimum supported sentry version " +
               "($minSupportedSentryVersion)"
           }
           return
@@ -78,7 +78,7 @@ abstract class AbstractInstallStrategy : ComponentMetadataRule {
         if (sentrySemVersion > maxSupportedSentryVersion) {
           logger.debug {
             "$sentryModuleId won't be installed because the current sentry version " +
-              "is higher than the maximum supported sentry version " +
+              "($sentrySemVersion) is higher than the maximum supported sentry version " +
               "($maxSupportedSentryVersion)"
           }
           return

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/compose/ComposeInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/compose/ComposeInstallStrategyTest.kt
@@ -64,7 +64,7 @@ class ComposeInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-compose-android won't be installed because the current " +
-          "version is lower than the minimum supported version (1.0.0)"
+          "version (0.9.0) is lower than the minimum supported version (1.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/Graphql22InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/Graphql22InstallStrategyTest.kt
@@ -80,7 +80,7 @@ class Graphql22InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-graphql-22 won't be installed because the current " +
-          "version is lower than the minimum supported version (22.0.0)"
+          "version (21.9.0) is lower than the minimum supported version (22.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/GraphqlInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/GraphqlInstallStrategyTest.kt
@@ -80,7 +80,7 @@ class GraphqlInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-graphql won't be installed because the current " +
-          "version is higher than the maximum supported version (21.9999.9999)"
+          "version (22.1.0) is higher than the maximum supported version (21.9999.9999)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/kotlin/KotlinExtensionsInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/kotlin/KotlinExtensionsInstallStrategyTest.kt
@@ -64,7 +64,7 @@ class KotlinExtensionsInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-kotlin-extensions won't be installed because the current " +
-          "version is lower than the minimum supported version (1.6.1)"
+          "version (1.6.0) is lower than the minimum supported version (1.6.1)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/log4j2/Log4j2InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/log4j2/Log4j2InstallStrategyTest.kt
@@ -63,7 +63,7 @@ class Log4j2InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-log4j2 won't be installed because the current " +
-          "version is lower than the minimum supported version (2.0.0)"
+          "version (1.0.0) is lower than the minimum supported version (2.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/logback/LogbackInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/logback/LogbackInstallStrategyTest.kt
@@ -63,7 +63,7 @@ class LogbackInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-logback won't be installed because the current " +
-          "version is lower than the minimum supported version (1.0.0)"
+          "version (0.0.1) is lower than the minimum supported version (1.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/AndroidOkHttpInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/AndroidOkHttpInstallStrategyTest.kt
@@ -67,7 +67,7 @@ class AndroidOkHttpInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-android-okhttp won't be installed because the current " +
-          "version is lower than the minimum supported version (3.13.0)"
+          "version (3.11.0) is lower than the minimum supported version (3.13.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }
@@ -80,7 +80,7 @@ class AndroidOkHttpInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-android-okhttp won't be installed because the current " +
-          "sentry version is higher than the maximum supported sentry version (6.9999.9999)"
+          "sentry version (7.0.0) is higher than the maximum supported sentry version (6.9999.9999)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/OkHttpInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/OkHttpInstallStrategyTest.kt
@@ -67,7 +67,7 @@ class OkHttpInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-okhttp won't be installed because the current " +
-          "version is lower than the minimum supported version (3.13.0)"
+          "version (3.11.0) is lower than the minimum supported version (3.13.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }
@@ -80,7 +80,7 @@ class OkHttpInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-okhttp won't be installed because the current sentry " +
-          "version is lower than the minimum supported sentry version (7.0.0)"
+          "version (6.33.0) is lower than the minimum supported sentry version (7.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring5InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring5InstallStrategyTest.kt
@@ -63,7 +63,7 @@ class Spring5InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-spring won't be installed because the current " +
-          "version is lower than the minimum supported version (5.1.2)"
+          "version (5.1.1) is lower than the minimum supported version (5.1.2)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }
@@ -76,7 +76,7 @@ class Spring5InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-spring won't be installed because the current " +
-          "version is higher than the maximum supported version (5.9999.9999)"
+          "version (6.0.0) is higher than the maximum supported version (5.9999.9999)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring6InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring6InstallStrategyTest.kt
@@ -63,7 +63,7 @@ class Spring6InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-spring-jakarta won't be installed because the current " +
-          "version is lower than the minimum supported version (6.0.0)"
+          "version (5.7.4) is lower than the minimum supported version (6.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategyTest.kt
@@ -63,7 +63,7 @@ class SpringBoot2InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-spring-boot won't be installed because the current " +
-          "version is lower than the minimum supported version (2.1.0)"
+          "version (2.0.0) is lower than the minimum supported version (2.1.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }
@@ -76,7 +76,7 @@ class SpringBoot2InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-spring-boot won't be installed because the current " +
-          "version is higher than the maximum supported version (2.9999.9999)"
+          "version (3.0.0) is higher than the maximum supported version (2.9999.9999)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategyTest.kt
@@ -63,7 +63,7 @@ class SpringBoot3InstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-spring-boot-jakarta won't be installed because the " +
-          "current version is lower than the minimum supported version (3.0.0)"
+          "current version (2.7.13) is lower than the minimum supported version (3.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/sqlite/SqliteInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/sqlite/SqliteInstallStrategyTest.kt
@@ -63,7 +63,7 @@ class SqliteInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-android-sqlite won't be installed because the current " +
-          "version is lower than the minimum supported version (2.0.0)"
+          "version (1.0.0) is lower than the minimum supported version (2.0.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/timber/TimberInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/timber/TimberInstallStrategyTest.kt
@@ -64,7 +64,7 @@ class TimberInstallStrategyTest {
     assertTrue {
       fixture.logger.capturedMessage ==
         "[sentry] sentry-android-timber won't be installed because the current " +
-          "version is lower than the minimum supported version (4.6.0)"
+          "version (4.5.0) is lower than the minimum supported version (4.6.0)"
     }
     verify(fixture.metadataDetails, never()).allVariants(any())
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Log the version that caused the Sentry Gradle plugin to not auto install a dependency.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without the version in the message, customers (and us) are left wondering what version it tried and whether the plugin used the correct version. This change avoids having to go through the list of dependencies.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
