### PR TITLE
Mark sizeAnalysis APIs as experimental

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -107,6 +107,7 @@ abstract class SentryPluginExtension @Inject constructor(project: Project) {
 
   val sizeAnalysis: SizeAnalysisExtension = objects.newInstance(SizeAnalysisExtension::class.java)
 
+  @org.jetbrains.annotations.ApiStatus.Experimental
   fun sizeAnalysis(sizeAnalysisAction: Action<SizeAnalysisExtension>) {
     sizeAnalysisAction.execute(sizeAnalysis)
   }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtension.kt
@@ -5,7 +5,9 @@ import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.annotations.ApiStatus
 
+@ApiStatus.Experimental
 open class SizeAnalysisExtension
 @Inject
 constructor(objects: ObjectFactory, providerFactory: ProviderFactory) {


### PR DESCRIPTION
## Summary
- Add `@ApiStatus.Experimental` annotation to `SizeAnalysisExtension` class
- Add `@ApiStatus.Experimental` annotation to `sizeAnalysis` configuration function

## Details
This marks the new size analysis APIs as experimental and subject to change, providing appropriate warnings to users who use these APIs.

The annotations will help communicate that these APIs are still evolving and may change in future releases.

Closes EME-280

🤖 Generated with [Claude Code](https://claude.ai/code)