### PR TITLE
fix(kotlin-compiler): Fix Modifier.sentryTag() not found warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix `Modifier.sentryTag()` not found warning ([#997](https://github.com/getsentry/sentry-android-gradle-plugin/pull/997))
+
 ## 6.0.0-alpha.4
 
 ### Dependencies

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.ksp)
   id("io.sentry.android.gradle")
+  id("io.sentry.kotlin.compiler.gradle")
 }
 
 if (getKotlinPluginVersion() >= "2.0.0") {

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
@@ -11,14 +11,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import io.sentry.samples.instrumentation.ui.ComposeActivity.Destination
 
 class ComposeActivity : ComponentActivity() {
 
@@ -36,14 +39,7 @@ class ComposeActivity : ComponentActivity() {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
           ) {
-            BasicText(
-              modifier =
-                Modifier.border(2.dp, Color.Gray, pillShape)
-                  .clip(pillShape)
-                  .clickable { navController.navigate(Destination.Details.route) }
-                  .padding(24.dp),
-              text = "Home. Tap to go to Details.",
-            )
+            HomeText(navController, pillShape)
           }
         }
         composable(Destination.Details.route) {
@@ -52,14 +48,7 @@ class ComposeActivity : ComponentActivity() {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
           ) {
-            BasicText(
-              modifier =
-                Modifier.border(2.dp, Color.Gray, pillShape)
-                  .clip(pillShape)
-                  .clickable { navController.popBackStack() }
-                  .padding(24.dp),
-              text = "Details. Tap or press back to return.",
-            )
+            DetailsText(navController, pillShape)
           }
         }
       }
@@ -71,4 +60,29 @@ class ComposeActivity : ComponentActivity() {
 
     object Details : Destination("details")
   }
+}
+
+@Composable
+fun HomeText(navController: NavController, pillShape: RoundedCornerShape) {
+  BasicText(
+    modifier =
+      Modifier.border(2.dp, Color.Gray, pillShape)
+        .clip(pillShape)
+        .clickable { navController.navigate(Destination.Details.route) }
+        .padding(24.dp),
+    text = "Home. Tap to go to Details.",
+  )
+}
+
+@Composable
+fun DetailsText(navController: NavController, pillShape: RoundedCornerShape) {
+  BasicText(
+    modifier =
+      Modifier
+        .border(2.dp, Color.Gray, pillShape)
+        .clip(pillShape)
+        .clickable { navController.popBackStack() }
+        .padding(24.dp),
+    text = "Details. Tap or press back to return.",
+  )
 }

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
@@ -78,8 +78,7 @@ fun HomeText(navController: NavController, pillShape: RoundedCornerShape) {
 fun DetailsText(navController: NavController, pillShape: RoundedCornerShape) {
   BasicText(
     modifier =
-      Modifier
-        .border(2.dp, Color.Gray, pillShape)
+      Modifier.border(2.dp, Color.Gray, pillShape)
         .clip(pillShape)
         .clickable { navController.popBackStack() }
         .padding(24.dp),

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/MainActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/MainActivity.kt
@@ -12,12 +12,8 @@ import io.sentry.SpanStatus
 import io.sentry.TransactionOptions
 import io.sentry.samples.instrumentation.R
 import io.sentry.samples.instrumentation.SampleApp
-import io.sentry.samples.instrumentation.network.TrackService
 import io.sentry.samples.instrumentation.ui.list.TrackAdapter
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,13 +36,13 @@ class MainActivity : ComponentActivity() {
         .tracksDao()
         .all()
         // TODO: this service doesn't work anymore, need to find a replacement
-//        .map {
-//          val remote =
-//            withContext(Dispatchers.IO) {
-//              TrackService.instance.tracks("6188aa82-3102-436a-9a68-513e6ad9efcb")
-//            }
-//          remote + it
-//        }
+        //        .map {
+        //          val remote =
+        //            withContext(Dispatchers.IO) {
+        //              TrackService.instance.tracks("6188aa82-3102-436a-9a68-513e6ad9efcb")
+        //            }
+        //          remote + it
+        //        }
         .collect {
           (list.adapter as TrackAdapter).populate(it)
           transaction.finish(SpanStatus.OK)

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/MainActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/MainActivity.kt
@@ -39,13 +39,14 @@ class MainActivity : ComponentActivity() {
       SampleApp.database
         .tracksDao()
         .all()
-        .map {
-          val remote =
-            withContext(Dispatchers.IO) {
-              TrackService.instance.tracks("6188aa82-3102-436a-9a68-513e6ad9efcb")
-            }
-          remote + it
-        }
+        // TODO: this service doesn't work anymore, need to find a replacement
+//        .map {
+//          val remote =
+//            withContext(Dispatchers.IO) {
+//              TrackService.instance.tracks("6188aa82-3102-436a-9a68-513e6ad9efcb")
+//            }
+//          remote + it
+//        }
         .collect {
           (list.adapter as TrackAdapter).populate(it)
           transaction.finish(SpanStatus.OK)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,11 +67,11 @@ sample-androidx-recyclerView = "androidx.recyclerview:recyclerview:1.2.0"
 sample-androidx-lifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
 sample-androidx-appcompat = "androidx.appcompat:appcompat:1.2.0"
 
-sample-androidx-composeRuntime = "androidx.compose.runtime:runtime:1.1.1"
+sample-androidx-composeRuntime = "androidx.compose.runtime:runtime:1.5.4"
 sample-androidx-composeNavigation = "androidx.navigation:navigation-compose:2.5.2"
 sample-androidx-composeActivity = "androidx.activity:activity-compose:1.4.0"
-sample-androidx-composeFoundation = "androidx.compose.foundation:foundation:1.2.1"
-sample-androidx-composeFoundationLayout = "androidx.compose.foundation:foundation-layout:1.2.1"
+sample-androidx-composeFoundation = "androidx.compose.foundation:foundation:1.5.4"
+sample-androidx-composeFoundationLayout = "androidx.compose.foundation:foundation-layout:1.5.4"
 
 sample-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "sampleCoroutines" }
 sample-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "sampleCoroutines" }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
@@ -88,7 +88,7 @@ class JetpackComposeTracingIrExtension22(private val messageCollector: MessageCo
     val sentryModifierClassId = FqName("io.sentry.compose").classId("SentryModifier")
 
     val sentryModifierCompanionClass =
-      pluginContext.referenceClass(sentryModifierClassId)?.owner?.companionObject()
+      pluginContext.referenceClass(sentryModifierClassId)?.owner
 
     val sentryModifierTagFunction = sentryModifierClassId.callableId("sentryTag")
 

--- a/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
@@ -87,8 +87,7 @@ class JetpackComposeTracingIrExtension22(private val messageCollector: MessageCo
 
     val sentryModifierClassId = FqName("io.sentry.compose").classId("SentryModifier")
 
-    val sentryModifierCompanionClass =
-      pluginContext.referenceClass(sentryModifierClassId)?.owner
+    val sentryModifierCompanionClass = pluginContext.referenceClass(sentryModifierClassId)?.owner
 
     val sentryModifierTagFunction = sentryModifierClassId.callableId("sentryTag")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,6 @@ includeBuild("plugin-build")
 // this is needed so we can use kotlin-compiler-plugin directly in the sample app without publishing
 includeBuild("sentry-kotlin-compiler-plugin") {
   dependencySubstitution {
-    substitute(module("io.sentry:sentry-kotlin-compiler-plugin"))
-      .using(project(":"))
+    substitute(module("io.sentry:sentry-kotlin-compiler-plugin")).using(project(":"))
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,4 +42,10 @@ include(":examples:multi-module-sample:spring-boot-in-multi-module-sample2")
 
 includeBuild("plugin-build")
 
-includeBuild("sentry-kotlin-compiler-plugin")
+// this is needed so we can use kotlin-compiler-plugin directly in the sample app without publishing
+includeBuild("sentry-kotlin-compiler-plugin") {
+  dependencySubstitution {
+    substitute(module("io.sentry:sentry-kotlin-compiler-plugin"))
+      .using(project(":"))
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- There's no `companion` object in `SentryModifier` because it's an object itself, so we just have to use the instance of the class
- Also updated the sample app so we can use the compiler plugin directly in it without the need to publish it first

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #941

## :green_heart: How did you test it?
Manually verified that composables are tagged and breadcrumbs are created for them + existing tests should cover it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
