### PR TITLE
fix: Include root project check in preMerge task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,7 @@ tasks.register("integrationTest") {
 tasks.register("preMerge") {
   description = "Runs all the tests/verification tasks on both top level and included build."
 
+  dependsOn(":check")
   dependsOn(gradle.includedBuild("sentry-kotlin-compiler-plugin").task(":check"))
   dependsOn(
     gradle


### PR DESCRIPTION
## Summary

Follow up from this comment: https://github.com/getsentry/sentry-android-gradle-plugin/pull/1001#discussion_r2419046337

- Add `dependsOn(":check")` to the `preMerge` task to ensure the root project's verification tasks are executed
- This fixes the issue where `spotlessCheck` was not running on the root project's `.kts` files during CI workflows

## Context

The `preMerge` task was calling `:check` on subprojects and included builds, but not on the root project itself. Since `spotlessCheck` is automatically added as a dependency of the `check` task, this meant the root project's Kotlin Gradle files (`.kts`) were not being checked for formatting issues in CI.

This change follows the existing pattern in the `preMerge` task and ensures all verification tasks run consistently across all projects.

#skip-changelog (internal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)