### PR TITLE
feat(distribution): Include distribution properties for all enabled variants

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateDistributionPropertiesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateDistributionPropertiesTask.kt
@@ -43,7 +43,7 @@ abstract class GenerateDistributionPropertiesTask : PropertiesFileOutputTask() {
 
   @get:Input abstract val projectSlug: Property<String>
 
-  @get:Input abstract val orgAuthToken: Property<String>
+  @get:Input abstract val authToken: Property<String>
 
   @get:Input abstract val buildConfiguration: Property<String>
 
@@ -52,7 +52,7 @@ abstract class GenerateDistributionPropertiesTask : PropertiesFileOutputTask() {
     outputFile.get().asFile.writer().use { writer ->
       orgSlug.orNull?.let { writer.appendLine("$ORG_SLUG_PROPERTY=$it") }
       projectSlug.orNull?.let { writer.appendLine("$PROJECT_SLUG_PROPERTY=$it") }
-      orgAuthToken.orNull?.let { writer.appendLine("$DISTRIBUTION_AUTH_TOKEN_PROPERTY=$it") }
+      authToken.orNull?.let { writer.appendLine("$DISTRIBUTION_AUTH_TOKEN_PROPERTY=$it") }
       writer.appendLine("$BUILD_CONFIGURATION_PROPERTY=${buildConfiguration.get()}")
     }
   }
@@ -117,7 +117,7 @@ abstract class GenerateDistributionPropertiesTask : PropertiesFileOutputTask() {
           }
         task.projectSlug.set(projectProvider)
 
-        task.orgAuthToken.set(extension.distribution.authToken)
+        task.authToken.set(extension.distribution.authToken)
 
         task.buildConfiguration.set(buildConfiguration)
       }


### PR DESCRIPTION
## Summary
Theoretically, a customer might have a variant disabled for Sentry but they might want to use it for Distribution.

Example “debug” is “ignoredVariants” but they still want to use that variant for distribution.

The question to ask is:

> Why would someone want to distribute a build that has sentry disabled?

**If we think this situation will never happen** then please say no to this PR since I think it makes this code more complicated!!!

This PR ensures that distribution properties are included in the APK/bundle for all variants configured in `extension.distribution.enabledVariants`, regardless of whether they are "allowed" variants (filtered by `includeProguardMapping`, variant filters, etc.).

Previously, distribution properties were only included for variants that passed the `isVariantAllowed` check because the properties were added through the `InjectSentryMetaPropertiesIntoAssetsTask`, which only runs for allowed variants.

In addition, it writes the distribution properties to a separate file `sentry-distribution.properties` instead of `sentry-debug-meta.properties`.

See code for more comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>