### PR TITLE
feat(distribution): Enable build uploads when distribution is enabled

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -229,7 +229,9 @@ fun ApplicationAndroidComponentsExtension.configure(
           )
           .toTransform(SingleArtifact.MERGED_MANIFEST)
       }
-      if (extension.sizeAnalysis.enabled.get() == true) {
+      val sizeAnalysisEnabled = extension.sizeAnalysis.enabled.get() == true
+      val distributionEnabled = extension.distribution.enabledVariants.get().contains(variant.name)
+      if (sizeAnalysisEnabled || distributionEnabled) {
         variant.configureUploadAppTasks(
           project,
           extension,


### PR DESCRIPTION
## Summary

Enables build uploads when distribution is configured, decoupling it from size analysis.

Previously, build uploads only occurred when `sizeAnalysis.enabled` was `true`. This change allows builds to be uploaded when either:
- Size analysis is globally enabled, OR
- The variant is in `distribution.enabledVariants`

This allows users to use build distribution independently of size analysis features, while still supporting both features working together.

## Changes

- Updated `AndroidComponentsConfig.kt` to check both `sizeAnalysis.enabled` and `distribution.enabledVariants` when deciding whether to configure upload tasks
- The `buildConfiguration` parameter continues to be used for both features to organize builds

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)