### PR TITLE
feat(sizeAnalysis): Add enabledVariants property to bypass global ignore rules

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtension.kt
@@ -5,6 +5,7 @@ import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
 import org.jetbrains.annotations.ApiStatus.Experimental
 
 @Experimental
@@ -16,6 +17,31 @@ constructor(objects: ObjectFactory, providerFactory: ProviderFactory) {
     objects
       .property(Boolean::class.java)
       .convention(providerFactory.isCi() && false) // set to false for now otherwise upload fails CI
+
+  /**
+   * Set of Android build variants that should have size analysis enabled.
+   *
+   * When empty (default), size analysis runs on all variants (subject to the enabled flag).
+   * When populated, only the specified variants will have size analysis enabled.
+   *
+   * Note: This property BYPASSES the global ignore settings (ignoredVariants, ignoredBuildTypes,
+   * ignoredFlavors). This allows size analysis to run on specific variants even if they are
+   * globally ignored. This is different from most other Sentry features which respect the global
+   * ignore settings.
+   *
+   * Example:
+   * ```
+   * sentry {
+   *   ignoredVariants.set(["debug"]) // Most features ignore debug
+   *   sizeAnalysis {
+   *     enabled = true
+   *     enabledVariants.set(["debug", "release"]) // Size analysis runs on both
+   *   }
+   * }
+   * ```
+   */
+  val enabledVariants: SetProperty<String> =
+    objects.setProperty(String::class.java).convention(emptySet())
 
   /**
    * The build configuration to use for the upload. This allows comparison between builds with the

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtensionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtensionTest.kt
@@ -1,0 +1,99 @@
+package io.sentry.android.gradle.extensions
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+class SizeAnalysisExtensionTest {
+
+  @Test
+  fun `enabledVariants is empty by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension =
+      project.objects.newInstance(
+        SizeAnalysisExtension::class.java,
+        project.objects,
+        project.providers,
+      )
+
+    assertTrue(extension.enabledVariants.get().isEmpty())
+  }
+
+  @Test
+  fun `enabledVariants can be configured with variant names`() {
+    val project = ProjectBuilder.builder().build()
+    val extension =
+      project.objects.newInstance(
+        SizeAnalysisExtension::class.java,
+        project.objects,
+        project.providers,
+      )
+
+    extension.enabledVariants.set(setOf("release", "staging", "debug"))
+
+    assertEquals(setOf("release", "staging", "debug"), extension.enabledVariants.get())
+  }
+
+  @Test
+  fun `enabledVariants can be updated multiple times`() {
+    val project = ProjectBuilder.builder().build()
+    val extension =
+      project.objects.newInstance(
+        SizeAnalysisExtension::class.java,
+        project.objects,
+        project.providers,
+      )
+
+    extension.enabledVariants.set(setOf("release"))
+    assertEquals(setOf("release"), extension.enabledVariants.get())
+
+    extension.enabledVariants.set(setOf("debug", "staging"))
+    assertEquals(setOf("debug", "staging"), extension.enabledVariants.get())
+  }
+
+  @Test
+  fun `enabled is false by default in non-CI environment`() {
+    val project = ProjectBuilder.builder().build()
+    val extension =
+      project.objects.newInstance(
+        SizeAnalysisExtension::class.java,
+        project.objects,
+        project.providers,
+      )
+
+    // In test environment, CI is typically not set
+    assertFalse(extension.enabled.get())
+  }
+
+  @Test
+  fun `enabled can be configured`() {
+    val project = ProjectBuilder.builder().build()
+    val extension =
+      project.objects.newInstance(
+        SizeAnalysisExtension::class.java,
+        project.objects,
+        project.providers,
+      )
+
+    extension.enabled.set(true)
+
+    assertTrue(extension.enabled.get())
+  }
+
+  @Test
+  fun `buildConfiguration can be configured`() {
+    val project = ProjectBuilder.builder().build()
+    val extension =
+      project.objects.newInstance(
+        SizeAnalysisExtension::class.java,
+        project.objects,
+        project.providers,
+      )
+
+    extension.buildConfiguration.set("custom-config")
+
+    assertEquals("custom-config", extension.buildConfiguration.get())
+  }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginVariantTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginVariantTest.kt
@@ -83,6 +83,118 @@ class SentryPluginVariantTest :
     assertTrue(":app:uploadSentryProguardMappingsDemoRelease" in build.output)
   }
 
+  @Test
+  fun `size analysis bypasses ignoredVariants when enabledVariants is set`() {
+    appBuildFile.appendText(
+      // language=Groovy
+      """
+                sentry {
+                  autoUploadProguardMapping = false
+                  ignoredVariants = ["fullRelease"]
+                  sizeAnalysis {
+                    enabled = true
+                    enabledVariants = ["fullRelease"]
+                  }
+                  tracingInstrumentation {
+                    enabled = false
+                  }
+                }
+            """
+        .trimIndent()
+    )
+
+    val build = runner.appendArguments(":app:assembleFullRelease", "--dry-run").build()
+
+    // Size analysis upload task should be present despite variant being ignored
+    assertTrue(":app:uploadSentryBundleFullRelease" in build.output)
+    assertTrue(":app:uploadSentryApkFullRelease" in build.output)
+    // Proguard mapping task should still be skipped (respects ignoredVariants)
+    assertFalse(":app:uploadSentryProguardMappingsFullRelease" in build.output)
+  }
+
+  @Test
+  fun `size analysis respects enabled flag even when variant is in enabledVariants`() {
+    appBuildFile.appendText(
+      // language=Groovy
+      """
+                sentry {
+                  autoUploadProguardMapping = false
+                  sizeAnalysis {
+                    enabled = false
+                    enabledVariants = ["fullRelease"]
+                  }
+                  tracingInstrumentation {
+                    enabled = false
+                  }
+                }
+            """
+        .trimIndent()
+    )
+
+    val build = runner.appendArguments(":app:assembleFullRelease", "--dry-run").build()
+
+    // Size analysis should be disabled
+    assertFalse(":app:uploadSentryBundleFullRelease" in build.output)
+    assertFalse(":app:uploadSentryApkFullRelease" in build.output)
+  }
+
+  @Test
+  fun `size analysis runs on all variants when enabledVariants is empty and enabled is true`() {
+    appBuildFile.appendText(
+      // language=Groovy
+      """
+                sentry {
+                  autoUploadProguardMapping = false
+                  sizeAnalysis {
+                    enabled = true
+                  }
+                  tracingInstrumentation {
+                    enabled = false
+                  }
+                }
+            """
+        .trimIndent()
+    )
+
+    val buildRelease = runner.appendArguments(":app:assembleFullRelease", "--dry-run").build()
+    val buildDebug = runner.appendArguments(":app:assembleFullDebug", "--dry-run").build()
+
+    // Both variants should have size analysis tasks
+    assertTrue(":app:uploadSentryBundleFullRelease" in buildRelease.output)
+    assertTrue(":app:uploadSentryApkFullRelease" in buildRelease.output)
+    assertTrue(":app:uploadSentryBundleFullDebug" in buildDebug.output)
+    assertTrue(":app:uploadSentryApkFullDebug" in buildDebug.output)
+  }
+
+  @Test
+  fun `size analysis only runs on specified variants when enabledVariants is not empty`() {
+    appBuildFile.appendText(
+      // language=Groovy
+      """
+                sentry {
+                  autoUploadProguardMapping = false
+                  sizeAnalysis {
+                    enabled = true
+                    enabledVariants = ["fullRelease"]
+                  }
+                  tracingInstrumentation {
+                    enabled = false
+                  }
+                }
+            """
+        .trimIndent()
+    )
+
+    val buildRelease = runner.appendArguments(":app:assembleFullRelease", "--dry-run").build()
+    val buildDebug = runner.appendArguments(":app:assembleFullDebug", "--dry-run").build()
+
+    // Only fullRelease should have size analysis tasks
+    assertTrue(":app:uploadSentryBundleFullRelease" in buildRelease.output)
+    assertTrue(":app:uploadSentryApkFullRelease" in buildRelease.output)
+    assertFalse(":app:uploadSentryBundleFullDebug" in buildDebug.output)
+    assertFalse(":app:uploadSentryApkFullDebug" in buildDebug.output)
+  }
+
   private fun applyIgnores(
     ignoredVariants: Set<String> = setOf(),
     ignoredBuildTypes: Set<String> = setOf(),


### PR DESCRIPTION
## Summary

Adds a new `enabledVariants` property to `SizeAnalysisExtension` that allows size analysis to run on specific variants, bypassing the global ignore settings (`ignoredVariants`, `ignoredBuildTypes`, `ignoredFlavors`).

This provides fine-grained control over which variants have size analysis enabled, similar to how `distribution.enabledVariants` works.

## Changes

- **Added `enabledVariants` property** to `SizeAnalysisExtension` with detailed documentation about bypassing behavior
- **Added `calculateSizeAnalysisEnabled()` helper function** that handles variant filtering independently from `isVariantAllowed`
- **Refactored `AndroidComponentsConfig`** to handle size analysis and distribution filtering independently
- **Added unit tests** for the new `enabledVariants` property
- **Added integration tests** for the bypass behavior (some tests failing, need investigation)

## Behavior

### Empty `enabledVariants` (default)
```gradle
sizeAnalysis {
  enabled = true
  // enabledVariants is empty - runs on all variants
}
```
Size analysis runs on all variants (backward compatible).

### Specified variants
```gradle
sizeAnalysis {
  enabled = true
  enabledVariants = ["release", "staging"]
}
```
Size analysis runs only on specified variants.

### Bypassing global ignores
```gradle
sentry {
  ignoredVariants = ["debug"]  // Most features ignore debug
  sizeAnalysis {
    enabled = true
    enabledVariants = ["debug", "release"]  // Size analysis runs on both
  }
}
```
Size analysis can run on variants that are globally ignored.

### Master kill-switch
```gradle
sizeAnalysis {
  enabled = false  // Master switch
  enabledVariants = ["release"]  // Ignored when enabled is false
}
```
The `enabled` flag still acts as a master kill-switch.

## Known Issues

⚠️ Some integration tests are failing - need to investigate:
- `size analysis runs on all variants when enabledVariants is empty and enabled is true`
- `size analysis only runs on specified variants when enabledVariants is not empty`
- `size analysis bypasses ignoredVariants when enabledVariants is set`

These will be fixed before marking the PR as ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)