### PR TITLE
refactor(distribution): Remove validation requiring distribution.enabled for updateSdkVariants

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -76,15 +76,6 @@ fun ApplicationAndroidComponentsExtension.configure(
             "You cannot use the auto-update SDK in variants where the Sentry SDK is disabled."
         )
       }
-
-      // Check if updateSdkVariants is set but distribution uploads are disabled
-      val distributionEnabled = extension.distribution.enabled.get()
-      if (!distributionEnabled) {
-        throw IllegalArgumentException(
-          "Invalid configuration: updateSdkVariants contains variant '$variantName' but buildDistribution.enabled is false. " +
-            "It doesn't make sense to embed the auto-update SDK without uploading the build."
-        )
-      }
     }
 
     if (isVariantAllowed(extension, variant.name, variant.flavorName, variant.buildType)) {


### PR DESCRIPTION
## Summary
- Removes the validation check that prevented using `updateSdkVariants` when `distribution.enabled` is false
- Allows users to embed the auto-update SDK in specific variants without requiring distribution uploads to be globally enabled

This change provides more flexibility in configuration, allowing the SDK installation to be controlled independently from the upload behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)