### PR TITLE
refactor(distribution): Rename orgAuthToken to distributionAuthToken

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateDistributionPropertiesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateDistributionPropertiesTask.kt
@@ -52,7 +52,9 @@ abstract class GenerateDistributionPropertiesTask : PropertiesFileOutputTask() {
     outputFile.get().asFile.writer().use { writer ->
       orgSlug.orNull?.let { writer.appendLine("$ORG_SLUG_PROPERTY=$it") }
       projectSlug.orNull?.let { writer.appendLine("$PROJECT_SLUG_PROPERTY=$it") }
-      distributionAuthToken.orNull?.let { writer.appendLine("$DISTRIBUTION_AUTH_TOKEN_PROPERTY=$it") }
+      distributionAuthToken.orNull?.let {
+        writer.appendLine("$DISTRIBUTION_AUTH_TOKEN_PROPERTY=$it")
+      }
       writer.appendLine("$BUILD_CONFIGURATION_PROPERTY=${buildConfiguration.get()}")
     }
   }


### PR DESCRIPTION
## Summary

Renamed the `orgAuthToken` property in `GenerateDistributionPropertiesTask` to `distributionAuthToken` for better clarity and consistency.

The property specifically holds the distribution auth token (sourced from `extension.distribution.authToken`), not a general org token, so the new name more accurately reflects its purpose and aligns with the constant it writes to (`DISTRIBUTION_AUTH_TOKEN_PROPERTY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)