### PR TITLE
docs(changelog): Use ### format for Breaking Changes sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,10 @@ This version introduces sentry-cli 3.0.0. Sentry-cli 3.0.0 and above only offici
 
 ### Features
 
-- Add upload functionality for size analysis ([#915](https://github.com/getsentry/sentry-android-gradle-plugin/pull/915))
+- Add upload functionality for [Size Analysis](https://docs.sentry.io/platforms/android/size-analysis/) ([#915](https://github.com/getsentry/sentry-android-gradle-plugin/pull/915))
+- Add upload functionality for [Build Distribution](https://docs.sentry.io/platforms/android/build-distribution/) ([#986](https://github.com/getsentry/sentry-android-gradle-plugin/pull/986))
+- Auto-install for [Auto-Update Build Distribution](https://docs.sentry.io/platforms/android/build-distribution/auto-update/) SDK when enabled for variant ([#1001](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1001))
 - Add VCS info extension for build uploads with customizable version control metadata ([#969](https://github.com/getsentry/sentry-android-gradle-plugin/pull/969))
-- Add buildConfiguration to SizeAnalysisExtension ([#976](https://github.com/getsentry/sentry-android-gradle-plugin/pull/976))
-- Add Distribution API to Sentry Android Gradle Plugin ([#986](https://github.com/getsentry/sentry-android-gradle-plugin/pull/986))
-- Add GenerateDistributionPropertiesTask for distribution options ([#999](https://github.com/getsentry/sentry-android-gradle-plugin/pull/999), [#1000](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1000))
-- Auto-install distribution dependency when enabled for variant ([#1001](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1001))
-- Add dedicated distribution auth token property ([#1007](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1007))
-- Enable build uploads when distribution is enabled ([#1011](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1011))
-- Separate upload and SDK installation controls for distribution ([#1017](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1017))
-- Remove validation requiring distribution.enabled for updateSdkVariants ([#1019](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1019))
-- Mark sizeAnalysis APIs as experimental ([#985](https://github.com/getsentry/sentry-android-gradle-plugin/pull/985))
 - Include version in logs if auto install refuses to install a dependency ([#979](https://github.com/getsentry/sentry-android-gradle-plugin/pull/979))
 - Auto install Spring Boot 4 (`sentry-spring-boot-4`) and Spring 7 (`sentry-spring-7`) modules ([#980](https://github.com/getsentry/sentry-android-gradle-plugin/pull/980))
 


### PR DESCRIPTION
## Summary

Improve the Unreleased section of CHANGELOG.md with the following changes:

- Standardize Breaking Changes sections to use `### Breaking Changes` heading format instead of `**Breaking Changes**:` for consistency with other section headings like Features, Fixes, Dependencies, and Internal
- Link Size Analysis and Build Distribution features to their respective documentation pages
- Simplify and consolidate feature descriptions to focus on user-facing functionality
- Remove implementation details in favor of high-level feature descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)