### PR TITLE
fix(android): Wire dependencies report through asset transform task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - (Experimental) Wire VCS info extension to snapshot uploads for git metadata support ([#1102](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1102))
 
+### Fixes
+
+- Fix `includeDependenciesReport` failing with `MissingValueException` due to unset output directory ([#1115](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1115))
+
 ### Dependencies
 
 - Bump CLI from v3.3.2 to v3.3.3 ([#1101](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1101))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -83,7 +83,8 @@ fun ApplicationAndroidComponentsExtension.configure(
       val sentryTelemetryProvider =
         variant.configureTelemetry(project, extension, cliExecutable, sentryOrg, buildEvents)
 
-      variant.configureDependenciesTask(project, extension, sentryTelemetryProvider)
+      val reportDependenciesTask =
+        variant.configureDependenciesTask(project, extension, sentryTelemetryProvider)
 
       // TODO: do this only once, and all other tasks should be SentryVariant.configureSomething
       val sentryVariant = AndroidVariant74(variant)
@@ -164,6 +165,7 @@ fun ApplicationAndroidComponentsExtension.configure(
             sentryTelemetryProvider,
             tasksGeneratingProperties,
             variant.name.capitalized,
+            reportDependenciesTask,
           )
 
         assetsWiredWithDirectories(
@@ -338,7 +340,7 @@ private fun Variant.configureDependenciesTask(
   project: Project,
   extension: SentryPluginExtension,
   sentryTelemetryProvider: Provider<SentryTelemetryService>,
-) {
+): TaskProvider<SentryExternalDependenciesReportTaskV2>? {
   if (extension.includeDependenciesReport.get()) {
     val reportDependenciesTask =
       SentryExternalDependenciesReportTaskV2.register(
@@ -350,8 +352,9 @@ private fun Variant.configureDependenciesTask(
         includeReport = extension.includeDependenciesReport,
         taskSuffix = name.capitalized,
       )
-    sources.assets?.addGeneratedSourceDirectory(reportDependenciesTask) { task -> task.output }
+    return reportDependenciesTask
   }
+  return null
 }
 
 private fun ApplicationVariant.configureProguardMappingsTasks(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/InjectSentryMetaPropertiesIntoAssetsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/InjectSentryMetaPropertiesIntoAssetsTask.kt
@@ -20,6 +20,7 @@ package io.sentry.android.gradle.tasks
 
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.sourcecontext.getAndDelete
+import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTaskV2
 import io.sentry.android.gradle.telemetry.SentryTelemetryService
 import io.sentry.android.gradle.telemetry.withSentryTelemetry
 import io.sentry.android.gradle.util.PropertiesUtil
@@ -33,6 +34,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -72,6 +74,11 @@ abstract class InjectSentryMetaPropertiesIntoAssetsTask : DefaultTask() {
   @get:InputFiles
   abstract val inputPropertyFiles: ConfigurableFileCollection
 
+  @get:PathSensitive(PathSensitivity.NONE)
+  @get:InputFiles
+  @get:Optional
+  abstract val dependenciesReportDir: DirectoryProperty
+
   @TaskAction
   fun taskAction() {
     val input = inputDir.get().asFile
@@ -79,6 +86,14 @@ abstract class InjectSentryMetaPropertiesIntoAssetsTask : DefaultTask() {
     output.mkdirs()
 
     input.copyRecursively(output, overwrite = true)
+
+    // Copy the dependencies report if present
+    val depReportDir = dependenciesReportDir.orNull?.asFile
+    if (depReportDir != null && depReportDir.exists()) {
+      depReportDir.listFiles()?.forEach { file ->
+        file.copyTo(File(output, file.name), overwrite = true)
+      }
+    }
 
     // skip writing the properties file if there are no input property files
     // this avoids generating an empty properties file when all Sentry features are disabled
@@ -108,6 +123,7 @@ abstract class InjectSentryMetaPropertiesIntoAssetsTask : DefaultTask() {
       sentryTelemetryProvider: Provider<SentryTelemetryService>?,
       tasksGeneratingProperties: List<TaskProvider<out PropertiesFileOutputTask>>,
       taskSuffix: String = "",
+      reportDependenciesTask: TaskProvider<SentryExternalDependenciesReportTaskV2>? = null,
     ): TaskProvider<InjectSentryMetaPropertiesIntoAssetsTask> {
       val inputFiles: List<Provider<RegularFile>> =
         tasksGeneratingProperties.mapNotNull { it.flatMap { task -> task.outputFile } }
@@ -116,6 +132,9 @@ abstract class InjectSentryMetaPropertiesIntoAssetsTask : DefaultTask() {
         InjectSentryMetaPropertiesIntoAssetsTask::class.java,
       ) { task ->
         task.inputPropertyFiles.setFrom(inputFiles)
+        reportDependenciesTask?.let { depTask ->
+          task.dependenciesReportDir.set(depTask.flatMap { it.output })
+        }
 
         task.withSentryTelemetry(extension, sentryTelemetryProvider)
       }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskV2.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/dependencies/SentryExternalDependenciesReportTaskV2.kt
@@ -72,7 +72,15 @@ abstract class SentryExternalDependenciesReportTaskV2 : DirectoryOutputTask() {
           }
         task.artifactIds.set(artifactIds)
         task.includeReport.set(includeReport)
-        output?.let { task.output.set(it) }
+        if (output != null) {
+          task.output.set(output)
+        } else {
+          task.output.set(
+            project.layout.buildDirectory.dir(
+              "generated${File.separator}sentry${File.separator}dependencies$taskSuffix"
+            )
+          )
+        }
         task.withSentryTelemetry(extension, sentryTelemetryProvider)
       }
     }


### PR DESCRIPTION
## Summary
- Removes `addGeneratedSourceDirectory` call that exposed a task-backed `Provider<Directory>` via `variant.sources.assets?.all`, causing configuration-time errors for plugins like Paparazzi that query asset sources before tasks execute
- Instead wires the dependencies report (`sentry-external-modules.txt`) through the existing `InjectSentryMetaPropertiesIntoAssetsTask`, which already transforms `SingleArtifact.ASSETS` and copies all assets into the output directory
- `configureDependenciesTask()` now returns the task provider, and `InjectSentryMetaPropertiesIntoAssetsTask` gains an optional `dependenciesReportDir` input that copies the report files into the transformed assets output

🤖 Generated with [Claude Code](https://claude.com/claude-code)