### PR TITLE
feat(snapshot): Make metadata plugin variant-aware

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/metadata/ExportPreviewMetadataTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/metadata/ExportPreviewMetadataTask.kt
@@ -167,13 +167,10 @@ abstract class ExportPreviewMetadataTask : DefaultTask() {
         task.includePrivatePreviews.set(extension.includePrivatePreviews)
 
         // Local compiled classes
-        task.inputClasspath.from(
-          project.tasks.named(compileTaskName).map { it.outputs.files }
-        )
+        task.inputClasspath.from(project.tasks.named(compileTaskName).map { it.outputs.files })
 
         // Dependency project classes
-        val variantClasspath =
-          project.configurations.getByName("${variantName}RuntimeClasspath")
+        val variantClasspath = project.configurations.getByName("${variantName}RuntimeClasspath")
         task.inputClasspath.from(
           variantClasspath.incoming
             .artifactView { view ->

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/metadata/SentrySnapshotMetadataPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/metadata/SentrySnapshotMetadataPlugin.kt
@@ -15,8 +15,7 @@ class SentrySnapshotMetadataPlugin : Plugin<Project> {
       )
 
     fun wireWithAndroid() {
-      val androidComponents =
-        project.extensions.getByType(AndroidComponentsExtension::class.java)
+      val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
       androidComponents.onVariants { variant ->
         ExportPreviewMetadataTask.register(project, extension, variant.name)
       }


### PR DESCRIPTION
## Summary
- Register per-variant `ExportPreviewMetadata` tasks using `AndroidComponentsExtension.onVariants` instead of hard-coding the debug variant
- Each variant gets its own task (e.g. `exportPreviewMetadataDebug`, `exportPreviewMetadataRelease`) with the correct compile task, runtime classpath, and output path

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)