### PR TITLE
fix(snapshot): Set default Material theme for Paparazzi snapshots

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -219,6 +219,7 @@ private object PaparazziPreviewRule {
         return Paparazzi(
             environment = detectEnvironment().copy(compileSdkVersion = previewApiLevel),
             deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
+            theme = "android:Theme.Material.Light.NoActionBar.Fullscreen",
             supportsRtl = true,
             showSystemUi = previewInfo.showSystemUi,
             renderingMode = when {


### PR DESCRIPTION
## Summary
- Sets an explicit Material Light theme (`android:Theme.Material.Light.NoActionBar.Fullscreen`) for Paparazzi snapshot tests to ensure consistent rendering across previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)