### PR TITLE
feat(snapshot): Make Paparazzi theme configurable

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -11,6 +11,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
@@ -26,6 +27,8 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
   @get:Input abstract val includePrivatePreviews: Property<Boolean>
 
   @get:Input abstract val packageTrees: ListProperty<String>
+
+  @get:Input @get:Optional abstract val theme: Property<String>
 
   @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
@@ -43,6 +46,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
       generateTestFileContent(
         includePrivatePreviews = includePrivatePreviews.get(),
         packageTrees = packageTrees.get(),
+        theme = theme.orNull,
       )
     File(packageDir, "$CLASS_NAME.kt").writeText(content)
     logger.lifecycle("Generated snapshot test: ${packageDir.absolutePath}/$CLASS_NAME.kt")
@@ -63,6 +67,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         GenerateSnapshotTestsTask::class.java,
       ) { task ->
         task.includePrivatePreviews.set(extension.includePrivatePreviews)
+        task.theme.set(extension.theme)
         // Fall back to the Android namespace when the user doesn't configure packageTrees
         task.packageTrees.set(
           extension.packageTrees.map { packages ->
@@ -79,6 +84,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     private fun generateTestFileContent(
       includePrivatePreviews: Boolean,
       packageTrees: List<String>,
+      theme: String? = null,
     ): String {
       val includePrivateExpr =
         if (includePrivatePreviews) "\n                .includePrivatePreviews()" else ""
@@ -221,7 +227,7 @@ private object PaparazziPreviewRule {
         return Paparazzi(
             environment = detectEnvironment().copy(compileSdkVersion = previewApiLevel),
             deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
-            theme = "android:Theme.Translucent.NoTitleBar",
+            ${if (theme != null) "theme = \"$theme\"," else ""}
             supportsRtl = true,
             showSystemUi = previewInfo.showSystemUi,
             renderingMode = when {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/SentrySnapshotExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/SentrySnapshotExtension.kt
@@ -17,4 +17,6 @@ abstract class SentrySnapshotExtension(objects: ObjectFactory) {
 
   val packageTrees: ListProperty<String> =
     objects.listProperty(String::class.java).convention(emptyList())
+
+  val theme: Property<String> = objects.property(String::class.java)
 }


### PR DESCRIPTION
## Summary
- Remove the hardcoded `android:Theme.Translucent.NoTitleBar` Paparazzi theme from the generated snapshot test
- Add a `theme` property to the `sentrySnapshot` extension so users can set their own theme
- When unset, Paparazzi uses its own default theme instead of our opinionated override

```kotlin
sentrySnapshot {
  theme = "com.example:Theme.MyApp"
}
```

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)