### PR TITLE
feat(snapshot): Register sentryUploadSnapshots for all variants

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -78,13 +78,7 @@ fun ApplicationAndroidComponentsExtension.configure(
       }
     }
 
-    variant.configureSnapshotsTasks(
-      project,
-      extension,
-      cliExecutable,
-      sentryOrg,
-      sentryProject,
-    )
+    variant.configureSnapshotsTasks(project, extension, cliExecutable, sentryOrg, sentryProject)
 
     if (isVariantAllowed(extension, variant.name, variant.flavorName, variant.buildType)) {
       val paths = OutputPaths(project, variant.name)


### PR DESCRIPTION
# Background
Many customers will have sentry filtered for debug variants but those are the variants where we want to have snapshots hence the change.
If we want to be able to auto-wire the paparazzi tasks to the `sentryUploadSnapshots` then we will need to have this enabled for all variants.

## Summary
- Moves `sentryUploadSnapshots` task registration outside the variant filter so it is available for all variants, including ignored ones
- Since this task is never auto-wired to assemble/bundle and must be explicitly invoked, there is no risk of accidental uploads
- Telemetry is passed as `null` (already supported by the register function)

#skip-changelog (this is still unreleased)

🤖 Generated with [Claude Code](https://claude.com/claude-code)