### PR TITLE
feat(snapshot): Default includePrivatePreviews to true

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
@@ -12,7 +12,7 @@ open class SnapshotsExtension @Inject constructor(objects: ObjectFactory) {
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
   val includePrivatePreviews: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(false)
+    objects.property(Boolean::class.java).convention(true)
 
   val packageTrees: ListProperty<String> =
     objects.listProperty(String::class.java).convention(emptyList())

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/metadata/SentrySnapshotMetadataExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/metadata/SentrySnapshotMetadataExtension.kt
@@ -12,5 +12,5 @@ import org.jetbrains.annotations.ApiStatus
 abstract class SentrySnapshotMetadataExtension(objects: ObjectFactory) {
 
   val includePrivatePreviews: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(false)
+    objects.property(Boolean::class.java).convention(true)
 }


### PR DESCRIPTION
## Summary
- Changes the default value of `includePrivatePreviews` from `false` to `true` in both `SnapshotsExtension` and `SentrySnapshotMetadataExtension`

This is to keep the same behavior as emerge's defaults.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)