### PR TITLE
fix(snapshots): Generate Paparazzi 1.x compatible snapshot test code

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -37,7 +37,6 @@ import io.sentry.android.gradle.tasks.configureNativeSymbolsTask
 import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTaskV2
 import io.sentry.android.gradle.telemetry.SentryTelemetryService
 import io.sentry.android.gradle.util.AgpVersions
-import io.sentry.android.gradle.util.SemVer
 import io.sentry.android.gradle.util.GroovyCompat
 import io.sentry.android.gradle.util.SentryModules
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
@@ -496,12 +495,14 @@ private fun ApplicationVariant.configureSnapshotsTasks(
       "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
     )
 
-    val paparazziMajorVersion = project.provider {
-      val dep = project.configurations.findByName("testImplementation")
-        ?.allDependencies
-        ?.find { it.group == "app.cash.paparazzi" && it.name == "paparazzi" }
-      dep?.version?.let { SemVer.parse(it).major } ?: 2
-    }
+    val paparazziMajorVersion =
+      project.provider {
+        val dep =
+          project.configurations.findByName("testImplementation")?.allDependencies?.find {
+            it.group == "app.cash.paparazzi" && it.name == "paparazzi"
+          }
+        parseMajorVersion(dep?.version)
+      }
 
     val generateTask =
       GenerateSnapshotTestsTask.register(
@@ -545,6 +546,9 @@ private fun ApplicationVariant.configureSnapshotsTasks(
     }
   }
 }
+
+internal fun parseMajorVersion(version: String?, defaultVersion: Int = 2): Int =
+  version?.trimStart()?.takeWhile { it.isDigit() }?.toIntOrNull() ?: defaultVersion
 
 /**
  * Configure the upload AAB and APK tasks and set them up as finalizers on the respective producer

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -37,6 +37,7 @@ import io.sentry.android.gradle.tasks.configureNativeSymbolsTask
 import io.sentry.android.gradle.tasks.dependencies.SentryExternalDependenciesReportTaskV2
 import io.sentry.android.gradle.telemetry.SentryTelemetryService
 import io.sentry.android.gradle.util.AgpVersions
+import io.sentry.android.gradle.util.SemVer
 import io.sentry.android.gradle.util.GroovyCompat
 import io.sentry.android.gradle.util.SentryModules
 import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
@@ -495,12 +496,20 @@ private fun ApplicationVariant.configureSnapshotsTasks(
       "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
     )
 
+    val paparazziMajorVersion = project.provider {
+      val dep = project.configurations.findByName("testImplementation")
+        ?.allDependencies
+        ?.find { it.group == "app.cash.paparazzi" && it.name == "paparazzi" }
+      dep?.version?.let { SemVer.parse(it).major } ?: 2
+    }
+
     val generateTask =
       GenerateSnapshotTestsTask.register(
         project,
         extension.snapshots,
         android,
         this@configureSnapshotsTasks,
+        paparazziMajorVersion,
       )
 
     if (AgpVersions.isAGP90(AgpVersions.CURRENT)) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -10,12 +10,12 @@ import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 
 @CacheableTask

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 
 @CacheableTask
@@ -30,6 +31,8 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
   @get:Input abstract val packageTrees: ListProperty<String>
 
   @get:Input @get:Optional abstract val theme: Property<String>
+
+  @get:Input abstract val paparazziMajorVersion: Property<Int>
 
   @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
@@ -48,6 +51,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         includePrivatePreviews = includePrivatePreviews.get(),
         packageTrees = packageTrees.get(),
         theme = theme.orNull,
+        paparazziMajorVersion = paparazziMajorVersion.get(),
       )
     File(packageDir, "$CLASS_NAME.kt").writeText(content)
     logger.lifecycle("Generated snapshot test: ${packageDir.absolutePath}/$CLASS_NAME.kt")
@@ -62,6 +66,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
       extension: SnapshotsExtension,
       android: BaseExtension,
       variant: ApplicationVariant,
+      paparazziMajorVersion: Provider<Int>,
     ): TaskProvider<GenerateSnapshotTestsTask> {
       return project.tasks.register(
         "sentryGenerateSnapshotsTests${variant.name.capitalized}",
@@ -69,6 +74,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
       ) { task ->
         task.includePrivatePreviews.set(extension.includePrivatePreviews)
         task.theme.set(extension.theme)
+        task.paparazziMajorVersion.value(paparazziMajorVersion)
         // Fall back to the Android namespace when the user doesn't configure packageTrees
         // TODO do we actually need this?
         task.packageTrees.set(
@@ -87,6 +93,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
       includePrivatePreviews: Boolean,
       packageTrees: List<String>,
       theme: String? = null,
+      paparazziMajorVersion: Int = 2,
     ): String {
       val includePrivateExpr =
         if (includePrivatePreviews) "\n                .includePrivatePreviews()" else ""
@@ -240,7 +247,7 @@ private object PaparazziPreviewRule {
             snapshotHandler = TestNameOverrideHandler(
                 when (System.getProperty("paparazzi.test.verify")?.toBoolean() == true) {
                     true -> SnapshotVerifier(maxPercentDifference = tolerance)
-                    false -> HtmlReportWriter(maxPercentDifference = tolerance)
+                    false -> ${if (paparazziMajorVersion >= 2) "HtmlReportWriter(maxPercentDifference = tolerance)" else "HtmlReportWriter()"}
                 }
             ),
             maxPercentDifference = tolerance,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -224,17 +224,17 @@ private class TestNameOverrideHandler(
 
 private object PaparazziPreviewRule {
     const val UNDEFINED_API_LEVEL = -1
-    const val MAX_API_LEVEL = 36
 
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): Paparazzi {
         val previewInfo = preview.previewInfo
-        val previewApiLevel = when (previewInfo.apiLevel == UNDEFINED_API_LEVEL) {
-            true -> MAX_API_LEVEL
-            false -> previewInfo.apiLevel
+        val env = detectEnvironment()
+        val environment = when (previewInfo.apiLevel == UNDEFINED_API_LEVEL) {
+            true -> env
+            false -> env.copy(compileSdkVersion = previewInfo.apiLevel)
         }
         val tolerance = 0.0
         return Paparazzi(
-            environment = detectEnvironment().copy(compileSdkVersion = previewApiLevel),
+            environment = environment,
             deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
             ${if (theme != null) "theme = \"$theme\"," else ""}
             supportsRtl = true,

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -124,11 +124,34 @@ class GenerateSnapshotTestsTaskTest {
     )
   }
 
+  @Test
+  fun `generated file uses HtmlReportWriter without maxPercentDifference for paparazzi 1`() {
+    val content = generateAndRead(
+      packageTrees = listOf("com.example"),
+      paparazziMajorVersion = 1,
+    )
+
+    assertTrue(content.contains("HtmlReportWriter()"))
+    assertFalse(content.contains("HtmlReportWriter(maxPercentDifference"))
+  }
+
+  @Test
+  fun `generated file uses HtmlReportWriter with maxPercentDifference for paparazzi 2`() {
+    val content = generateAndRead(
+      packageTrees = listOf("com.example"),
+      paparazziMajorVersion = 2,
+    )
+
+    assertTrue(content.contains("HtmlReportWriter(maxPercentDifference = tolerance)"))
+    assertFalse(content.contains("HtmlReportWriter()"))
+  }
+
   private fun generateAndRead(
     packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
+    paparazziMajorVersion: Int = 2,
   ): String {
-    val task = createTask(packageTrees, includePrivatePreviews)
+    val task = createTask(packageTrees, includePrivatePreviews, paparazziMajorVersion)
     task.generate()
     val file =
       File(task.outputDir.get().asFile, "io/sentry/snapshot/ComposablePreviewSnapshotTest.kt")
@@ -138,12 +161,14 @@ class GenerateSnapshotTestsTaskTest {
   private fun createTask(
     packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
+    paparazziMajorVersion: Int = 2,
   ): GenerateSnapshotTestsTask {
     val project = ProjectBuilder.builder().build()
     return project.tasks
       .register("testGenerateSnapshotTests", GenerateSnapshotTestsTask::class.java) { task ->
         task.includePrivatePreviews.set(includePrivatePreviews)
         task.packageTrees.set(packageTrees)
+        task.paparazziMajorVersion.set(paparazziMajorVersion)
         task.outputDir.set(tmpDir.newFolder("output"))
       }
       .get()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -1,6 +1,8 @@
 package io.sentry.android.gradle.snapshot
 
+import io.sentry.android.gradle.parseMajorVersion
 import java.io.File
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.gradle.testfixtures.ProjectBuilder
@@ -125,11 +127,27 @@ class GenerateSnapshotTestsTaskTest {
   }
 
   @Test
+  fun `parseMajorVersion extracts major from standard semver`() {
+    assertEquals(1, parseMajorVersion("1.3.5"))
+    assertEquals(2, parseMajorVersion("2.0.0-alpha01"))
+  }
+
+  @Test
+  fun `parseMajorVersion extracts major from dynamic versions`() {
+    assertEquals(1, parseMajorVersion("1.+"))
+    assertEquals(2, parseMajorVersion("2.+"))
+  }
+
+  @Test
+  fun `parseMajorVersion returns default for unparseable versions`() {
+    assertEquals(2, parseMajorVersion("latest.release"))
+    assertEquals(2, parseMajorVersion(null))
+    assertEquals(2, parseMajorVersion("+"))
+  }
+
+  @Test
   fun `generated file uses HtmlReportWriter without maxPercentDifference for paparazzi 1`() {
-    val content = generateAndRead(
-      packageTrees = listOf("com.example"),
-      paparazziMajorVersion = 1,
-    )
+    val content = generateAndRead(packageTrees = listOf("com.example"), paparazziMajorVersion = 1)
 
     assertTrue(content.contains("HtmlReportWriter()"))
     assertFalse(content.contains("HtmlReportWriter(maxPercentDifference"))
@@ -137,10 +155,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file uses HtmlReportWriter with maxPercentDifference for paparazzi 2`() {
-    val content = generateAndRead(
-      packageTrees = listOf("com.example"),
-      paparazziMajorVersion = 2,
-    )
+    val content = generateAndRead(packageTrees = listOf("com.example"), paparazziMajorVersion = 2)
 
     assertTrue(content.contains("HtmlReportWriter(maxPercentDifference = tolerance)"))
     assertFalse(content.contains("HtmlReportWriter()"))


### PR DESCRIPTION
## What

The generated `ComposablePreviewSnapshotTest` now compiles against both Paparazzi 1.x and 2.x. Previously it only worked with 2.x.

## Why

`HtmlReportWriter(maxPercentDifference = tolerance)` doesn't compile against Paparazzi 1.x because the 1.x constructor has no `maxPercentDifference` parameter. In 2.x, `maxPercentDifference` is required (no default), so the no-arg `HtmlReportWriter()` doesn't compile there. The generated code must differ per version.

## How

The plugin detects the Paparazzi major version from the declared `testImplementation` dependencies at configuration time and passes it to `GenerateSnapshotTestsTask`. The task conditionally generates `HtmlReportWriter()` for v1 or `HtmlReportWriter(maxPercentDifference = tolerance)` for v2+. Defaults to v2 when the version can't be determined.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)