### PR TITLE
feat(examples): Add Paparazzi snapshot setup to instrumentation sample

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # pin@v4

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -46,3 +46,7 @@ jobs:
 
       - name: Build the Debug and Release variants
         run: ./gradlew assemble
+
+      - name: Record and upload snapshots
+        if: env.SENTRY_AUTH_TOKEN != ''
+        run: ./gradlew :examples:android-instrumentation-sample:sentryUploadSnapshotsStagingDebug

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   alias(libs.plugins.androidApplication) version BuildPluginsVersion.AGP
   alias(libs.plugins.kotlinAndroid) version BuildPluginsVersion.KOTLIN
   alias(libs.plugins.ksp)
+  alias(libs.plugins.paparazzi)
   id("io.sentry.android.gradle")
   id("io.sentry.kotlin.compiler.gradle")
 }
@@ -86,6 +87,7 @@ dependencies {
   implementation(libs.sample.androidx.composeFoundation)
   implementation(libs.sample.androidx.composeFoundationLayout)
   implementation(libs.sample.androidx.composeNavigation)
+  implementation(libs.sample.androidx.composeUiToolingPreview)
 
   implementation(libs.sample.coroutines.core)
   implementation(libs.sample.coroutines.android)
@@ -113,4 +115,8 @@ sentry {
   telemetryDsn.set(CI.SENTRY_SDKS_DSN)
 
   tracingInstrumentation { forceInstrumentDependencies.set(true) }
+
+  snapshots {
+    enabled.set(true)
+  }
 }

--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -116,7 +116,5 @@ sentry {
 
   tracingInstrumentation { forceInstrumentDependencies.set(true) }
 
-  snapshots {
-    enabled.set(true)
-  }
+  snapshots { enabled.set(true) }
 }

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
@@ -66,16 +66,16 @@ class ComposeActivity : ComponentActivity() {
 @Preview
 @Composable
 fun HomeTextPreview() {
-  HomeText(pillShape = RoundedCornerShape(50))
+  HomeText(rememberNavController(), RoundedCornerShape(50))
 }
 
 @Composable
-fun HomeText(navController: NavController? = null, pillShape: RoundedCornerShape) {
+fun HomeText(navController: NavController, pillShape: RoundedCornerShape) {
   BasicText(
     modifier =
       Modifier.border(2.dp, Color.Gray, pillShape)
         .clip(pillShape)
-        .clickable { navController?.navigate(Destination.Details.route) }
+        .clickable { navController.navigate(Destination.Details.route) }
         .padding(24.dp),
     text = "Home. Tap to go to Details.",
   )
@@ -84,16 +84,16 @@ fun HomeText(navController: NavController? = null, pillShape: RoundedCornerShape
 @Preview
 @Composable
 fun DetailsTextPreview() {
-  DetailsText(pillShape = RoundedCornerShape(50))
+  DetailsText(rememberNavController(), RoundedCornerShape(50))
 }
 
 @Composable
-fun DetailsText(navController: NavController? = null, pillShape: RoundedCornerShape) {
+fun DetailsText(navController: NavController, pillShape: RoundedCornerShape) {
   BasicText(
     modifier =
       Modifier.border(2.dp, Color.Gray, pillShape)
         .clip(pillShape)
-        .clickable { navController?.popBackStack() }
+        .clickable { navController.popBackStack() }
         .padding(24.dp),
     text = "Details. Tap or press back to return.",
   )

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -62,25 +63,37 @@ class ComposeActivity : ComponentActivity() {
   }
 }
 
+@Preview
 @Composable
-fun HomeText(navController: NavController, pillShape: RoundedCornerShape) {
+fun HomeTextPreview() {
+  HomeText(pillShape = RoundedCornerShape(50))
+}
+
+@Composable
+fun HomeText(navController: NavController? = null, pillShape: RoundedCornerShape) {
   BasicText(
     modifier =
       Modifier.border(2.dp, Color.Gray, pillShape)
         .clip(pillShape)
-        .clickable { navController.navigate(Destination.Details.route) }
+        .clickable { navController?.navigate(Destination.Details.route) }
         .padding(24.dp),
     text = "Home. Tap to go to Details.",
   )
 }
 
+@Preview
 @Composable
-fun DetailsText(navController: NavController, pillShape: RoundedCornerShape) {
+fun DetailsTextPreview() {
+  DetailsText(pillShape = RoundedCornerShape(50))
+}
+
+@Composable
+fun DetailsText(navController: NavController? = null, pillShape: RoundedCornerShape) {
   BasicText(
     modifier =
       Modifier.border(2.dp, Color.Gray, pillShape)
         .clip(pillShape)
-        .clickable { navController.popBackStack() }
+        .clickable { navController?.popBackStack() }
         .padding(24.dp),
     text = "Details. Tap or press back to return.",
   )

--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/ComposeActivity.kt
@@ -12,11 +12,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ buildConfig = { id = "com.github.gmazzo.buildconfig", version = "4.2.0" }
 springBoot = { id = "org.springframework.boot", version = "3.4.1" }
 springDependencyManagement = { id = "io.spring.dependency-management", version = "1.1.7" }
 composeCompiler =  { id = "org.jetbrains.kotlin.plugin.compose", version = "2.1.0" }
+paparazzi = { id = "app.cash.paparazzi", version = "2.0.0-alpha04" }
 
 [libraries]
 junit = { group = "junit", name = "junit", version = "4.13.2" }
@@ -70,6 +71,7 @@ sample-androidx-composeNavigation = "androidx.navigation:navigation-compose:2.5.
 sample-androidx-composeActivity = "androidx.activity:activity-compose:1.4.0"
 sample-androidx-composeFoundation = "androidx.compose.foundation:foundation:1.5.4"
 sample-androidx-composeFoundationLayout = "androidx.compose.foundation:foundation-layout:1.5.4"
+sample-androidx-composeUiToolingPreview = "androidx.compose.ui:ui-tooling-preview:1.5.4"
 
 sample-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "sampleCoroutines" }
 sample-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "sampleCoroutines" }


### PR DESCRIPTION
## Summary
- Apply `app.cash.paparazzi` 2.0.0-alpha04 to the `android-instrumentation-sample` and enable `sentry { snapshots { enabled.set(true) } }`
- Add `@Preview` composables (`HomeTextPreview`, `DetailsTextPreview`) so the snapshot scanner has something to discover
- Add a CI step in the pre-merge workflow to record and upload snapshots when `SENTRY_AUTH_TOKEN` is available

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)