### PR TITLE
feat(snapshots): Add generateTests flag to disable preview scanning

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -488,45 +488,47 @@ private fun ApplicationVariant.configureSnapshotsTasks(
 
   // Wire Paparazzi test generation and upload task when the Paparazzi plugin is applied
   project.pluginManager.withPlugin("app.cash.paparazzi") {
-    val android = project.extensions.getByType(BaseExtension::class.java)
+    if (extension.snapshots.generateTests.get()) {
+      val android = project.extensions.getByType(BaseExtension::class.java)
 
-    project.dependencies.add(
-      "testImplementation",
-      "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
-    )
-
-    val paparazziMajorVersion =
-      project.provider {
-        val dep =
-          project.configurations.findByName("testImplementation")?.allDependencies?.find {
-            it.group == "app.cash.paparazzi" && it.name == "paparazzi"
-          }
-        parseMajorVersion(dep?.version)
-      }
-
-    val generateTask =
-      GenerateSnapshotTestsTask.register(
-        project,
-        extension.snapshots,
-        android,
-        this@configureSnapshotsTasks,
-        paparazziMajorVersion,
+      project.dependencies.add(
+        "testImplementation",
+        "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
       )
 
-    if (AgpVersions.isAGP90(AgpVersions.CURRENT)) {
-      hostTests[UNIT_TEST_TYPE]?.apply {
-        sources.java?.addGeneratedSourceDirectory(
-          generateTask,
-          GenerateSnapshotTestsTask::outputDir,
+      val paparazziMajorVersion =
+        project.provider {
+          val dep =
+            project.configurations.findByName("testImplementation")?.allDependencies?.find {
+              it.group == "app.cash.paparazzi" && it.name == "paparazzi"
+            }
+          parseMajorVersion(dep?.version)
+        }
+
+      val generateTask =
+        GenerateSnapshotTestsTask.register(
+          project,
+          extension.snapshots,
+          android,
+          this@configureSnapshotsTasks,
+          paparazziMajorVersion,
         )
-      }
-    } else {
-      @Suppress("DEPRECATION_ERROR")
-      unitTest?.apply {
-        sources.java?.addGeneratedSourceDirectory(
-          generateTask,
-          GenerateSnapshotTestsTask::outputDir,
-        )
+
+      if (AgpVersions.isAGP90(AgpVersions.CURRENT)) {
+        hostTests[UNIT_TEST_TYPE]?.apply {
+          sources.java?.addGeneratedSourceDirectory(
+            generateTask,
+            GenerateSnapshotTestsTask::outputDir,
+          )
+        }
+      } else {
+        @Suppress("DEPRECATION_ERROR")
+        unitTest?.apply {
+          sources.java?.addGeneratedSourceDirectory(
+            generateTask,
+            GenerateSnapshotTestsTask::outputDir,
+          )
+        }
       }
     }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
@@ -11,6 +11,8 @@ open class SnapshotsExtension @Inject constructor(objects: ObjectFactory) {
 
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
+  val generateTests: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+
   val includePrivatePreviews: Property<Boolean> =
     objects.property(Boolean::class.java).convention(true)
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
@@ -1,0 +1,51 @@
+package io.sentry.android.gradle.extensions
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+class SnapshotsExtensionTest {
+
+  @Test
+  fun `enabled is false by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    assertFalse(extension.enabled.get())
+  }
+
+  @Test
+  fun `generateTests is true by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    assertTrue(extension.generateTests.get())
+  }
+
+  @Test
+  fun `generateTests can be set to false`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    extension.generateTests.set(false)
+
+    assertFalse(extension.generateTests.get())
+  }
+
+  @Test
+  fun `includePrivatePreviews is true by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    assertTrue(extension.includePrivatePreviews.get())
+  }
+
+  @Test
+  fun `packageTrees is empty by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    assertTrue(extension.packageTrees.get().isEmpty())
+  }
+}


### PR DESCRIPTION
Use the hidewhitespace diff to review: https://github.com/getsentry/sentry-android-gradle-plugin/pull/1146/changes?w=1

## Summary
- Adds a `generateTests` property (default `true`) to `SnapshotsExtension` that controls whether the plugin auto-generates Paparazzi snapshot tests from Compose `@Preview` composables
- When `false`, skips the `ComposablePreviewScanner` dependency, test generation task, and source directory wiring — but keeps the upload task wired to `recordPaparazzi`
- Useful for customers who already have their own Paparazzi snapshot tests and only want to upload results

```kotlin
sentry {
  snapshots {
    enabled = true
    generateTests = false
  }
}
```

Fixes EME-1039

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)