### PR TITLE
fix(snapshots): Rename generateTests to generateSnapshotTests

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -488,7 +488,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
 
   // Wire Paparazzi test generation and upload task when the Paparazzi plugin is applied
   project.pluginManager.withPlugin("app.cash.paparazzi") {
-    if (extension.snapshots.generateTests.get()) {
+    if (extension.snapshots.generateSnapshotTests.get()) {
       val android = project.extensions.getByType(BaseExtension::class.java)
 
       project.dependencies.add(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
@@ -11,7 +11,8 @@ open class SnapshotsExtension @Inject constructor(objects: ObjectFactory) {
 
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-  val generateSnapshotTests: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+  val generateSnapshotTests: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
 
   val includePrivatePreviews: Property<Boolean> =
     objects.property(Boolean::class.java).convention(true)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
@@ -11,7 +11,7 @@ open class SnapshotsExtension @Inject constructor(objects: ObjectFactory) {
 
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-  val generateTests: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+  val generateSnapshotTests: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   val includePrivatePreviews: Property<Boolean> =
     objects.property(Boolean::class.java).convention(true)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
@@ -16,21 +16,21 @@ class SnapshotsExtensionTest {
   }
 
   @Test
-  fun `generateTests is true by default`() {
+  fun `generateSnapshotTests is true by default`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
-    assertTrue(extension.generateTests.get())
+    assertTrue(extension.generateSnapshotTests.get())
   }
 
   @Test
-  fun `generateTests can be set to false`() {
+  fun `generateSnapshotTests can be set to false`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
-    extension.generateTests.set(false)
+    extension.generateSnapshotTests.set(false)
 
-    assertFalse(extension.generateTests.get())
+    assertFalse(extension.generateSnapshotTests.get())
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Renames `generateTests` to `generateSnapshotTests` in the snapshots extension for clarity

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)