### PR TITLE
test(gradle): Add isolated-projects compatibility test (EME-1072)

### DIFF
--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
@@ -36,9 +36,7 @@ class SentryPluginIsolatedProjectsTest :
     // otherwise the test would silently degrade into a plain config-cache test.
     assertTrue(output) { "isolated projects" in output.lowercase() }
     assertFalse(
-      "problems were found reporting" in output ||
-        "Isolated projects violations" in output ||
-        "cannot access '" in output,
+      "problems were found " in output || "cannot access '" in output,
       "Expected no isolated-projects violations, but got:\n$output",
     )
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
@@ -1,0 +1,127 @@
+package io.sentry.android.gradle.integration
+
+import io.sentry.BuildConfig
+import io.sentry.android.gradle.util.AgpVersions
+import io.sentry.android.gradle.util.GradleVersions
+import io.sentry.android.gradle.util.SemVer
+import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.util.GradleVersion
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assume.assumeThat
+import org.junit.Test
+
+class SentryPluginIsolatedProjectsTest :
+  BaseSentryPluginTest(BuildConfig.AgpVersion, GradleVersion.current().version) {
+
+  @Test
+  fun `plugin is compatible with isolated projects`() {
+    assumeThat(
+      "Isolated Projects requires AGP 8.3.0+ and Gradle 8.0+",
+      SemVer.parse(BuildConfig.AgpVersion) >= AgpVersions.VERSION_8_3_0 &&
+        GradleVersions.CURRENT >= GradleVersions.VERSION_8_0,
+      `is`(true),
+    )
+
+    writeIsolatedProjectsFixture()
+
+    runner.appendArguments(":app:assembleDebug").appendArguments("--configuration-cache")
+
+    val output = runner.build().output
+
+    assertTrue(output) { "BUILD SUCCESSFUL" in output }
+    // Sanity-check that isolated-projects was actually active during this build —
+    // otherwise the test would silently degrade into a plain config-cache test.
+    assertTrue(output) {
+      "Isolated projects is an incubating feature" in output ||
+        "isolated projects" in output.lowercase()
+    }
+    assertFalse(
+      "problems were found reporting" in output ||
+        "Isolated projects violations" in output ||
+        "cannot access '" in output,
+      "Expected no isolated-projects violations, but got:\n$output",
+    )
+  }
+
+  private fun writeIsolatedProjectsFixture() {
+    // Replace the root build.gradle written by BaseSentryPluginTest — it uses
+    // allprojects {} and subprojects {}, which are fundamentally incompatible with
+    // Gradle's isolated-projects feature. Instead, wire everything per-project.
+    val pluginClasspath =
+      org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+        .readImplementationClasspath()
+        .joinToString(separator = ", ") { "\"$it\"" }
+        .replace(File.separator, "/")
+
+    File(testProjectDir.root, "settings.gradle").writeText(
+      // language=Groovy
+      """
+      include ':app'
+      """
+        .trimIndent()
+    )
+
+    File(testProjectDir.root, "gradle.properties").writeText(
+      """
+      org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+      org.gradle.daemon=false
+      org.gradle.unsafe.isolated-projects=true
+      android.useAndroidX=true
+      android.overrideVersionCheck=true
+      """
+        .trimIndent()
+    )
+
+    File(testProjectDir.root, "build.gradle").writeText(
+      // language=Groovy
+      """
+      buildscript {
+        repositories {
+          google()
+          gradlePluginPortal()
+          mavenCentral()
+        }
+        dependencies {
+          classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
+          classpath files($pluginClasspath)
+        }
+      }
+      """
+        .trimIndent()
+    )
+
+    File(testProjectDir.root, "app/build.gradle").writeText(
+      // language=Groovy
+      """
+      plugins {
+        id 'com.android.application'
+        id 'io.sentry.android.gradle'
+      }
+
+      repositories {
+        google()
+        mavenCentral()
+        mavenLocal()
+      }
+
+      android {
+        namespace 'com.example'
+        compileSdkVersion 35
+        defaultConfig {
+          applicationId 'com.example'
+          minSdkVersion 21
+        }
+      }
+
+      sentry {
+        autoUploadProguardMapping = false
+        autoInstallation.enabled = false
+        telemetry = false
+      }
+      """
+        .trimIndent()
+    )
+  }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
@@ -7,6 +7,7 @@ import io.sentry.android.gradle.util.SemVer
 import java.io.File
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.gradle.util.GradleVersion
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assume.assumeThat
@@ -16,7 +17,7 @@ class SentryPluginIsolatedProjectsTest :
   BaseSentryPluginTest(BuildConfig.AgpVersion, GradleVersion.current().version) {
 
   @Test
-  fun `plugin is compatible with isolated projects`() {
+  fun `plugin is compatible with isolated projects in a multi-module build`() {
     assumeThat(
       "Isolated Projects requires AGP 8.3.0+ and Gradle 8.0+",
       SemVer.parse(BuildConfig.AgpVersion) >= AgpVersions.VERSION_8_3_0 &&
@@ -33,10 +34,7 @@ class SentryPluginIsolatedProjectsTest :
     assertTrue(output) { "BUILD SUCCESSFUL" in output }
     // Sanity-check that isolated-projects was actually active during this build —
     // otherwise the test would silently degrade into a plain config-cache test.
-    assertTrue(output) {
-      "Isolated projects is an incubating feature" in output ||
-        "isolated projects" in output.lowercase()
-    }
+    assertTrue(output) { "isolated projects" in output.lowercase() }
     assertFalse(
       "problems were found reporting" in output ||
         "Isolated projects violations" in output ||
@@ -46,82 +44,126 @@ class SentryPluginIsolatedProjectsTest :
   }
 
   private fun writeIsolatedProjectsFixture() {
-    // Replace the root build.gradle written by BaseSentryPluginTest — it uses
-    // allprojects {} and subprojects {}, which are fundamentally incompatible with
-    // Gradle's isolated-projects feature. Instead, wire everything per-project.
+    // Replace the fixture written by BaseSentryPluginTest — its root build.gradle
+    // uses allprojects {} and subprojects {}, which are fundamentally incompatible
+    // with Gradle's isolated-projects feature. Instead, wire everything per-project
+    // and add an Android library module that :app depends on, so we exercise
+    // cross-project configuration (the interesting scenario for Isolated Projects).
+    //
+    // autoInstallation is intentionally left disabled: it walks the dependency
+    // graph at configuration time and reaches into sibling projects' metadata
+    // (Project.group), which violates Isolated Projects. Tracked in EME-1072.
     val pluginClasspath =
-      org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-        .readImplementationClasspath()
+      PluginUnderTestMetadataReading.readImplementationClasspath()
         .joinToString(separator = ", ") { "\"$it\"" }
         .replace(File.separator, "/")
 
-    File(testProjectDir.root, "settings.gradle").writeText(
-      // language=Groovy
-      """
-      include ':app'
-      """
-        .trimIndent()
-    )
+    File(testProjectDir.root, "settings.gradle")
+      .writeText(
+        // language=Groovy
+        """
+        include ':app', ':library'
+        """
+          .trimIndent()
+      )
 
-    File(testProjectDir.root, "gradle.properties").writeText(
-      """
-      org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
-      org.gradle.daemon=false
-      org.gradle.unsafe.isolated-projects=true
-      android.useAndroidX=true
-      android.overrideVersionCheck=true
-      """
-        .trimIndent()
-    )
+    File(testProjectDir.root, "gradle.properties")
+      .writeText(
+        """
+        org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+        org.gradle.daemon=false
+        org.gradle.unsafe.isolated-projects=true
+        android.useAndroidX=true
+        android.overrideVersionCheck=true
+        """
+          .trimIndent()
+      )
 
-    File(testProjectDir.root, "build.gradle").writeText(
-      // language=Groovy
-      """
-      buildscript {
+    File(testProjectDir.root, "build.gradle")
+      .writeText(
+        // language=Groovy
+        """
+        buildscript {
+          repositories {
+            google()
+            gradlePluginPortal()
+            mavenCentral()
+          }
+          dependencies {
+            classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
+            classpath files($pluginClasspath)
+          }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(testProjectDir.root, "app/build.gradle")
+      .writeText(
+        // language=Groovy
+        """
+        plugins {
+          id 'com.android.application'
+          id 'io.sentry.android.gradle'
+        }
+
         repositories {
           google()
-          gradlePluginPortal()
           mavenCentral()
         }
+
+        android {
+          namespace 'com.example'
+          compileSdkVersion 35
+          defaultConfig {
+            applicationId 'com.example'
+            minSdkVersion 21
+          }
+        }
+
         dependencies {
-          classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
-          classpath files($pluginClasspath)
+          implementation project(':library')
         }
-      }
-      """
-        .trimIndent()
-    )
 
-    File(testProjectDir.root, "app/build.gradle").writeText(
-      // language=Groovy
-      """
-      plugins {
-        id 'com.android.application'
-        id 'io.sentry.android.gradle'
-      }
-
-      repositories {
-        google()
-        mavenCentral()
-        mavenLocal()
-      }
-
-      android {
-        namespace 'com.example'
-        compileSdkVersion 35
-        defaultConfig {
-          applicationId 'com.example'
-          minSdkVersion 21
+        sentry {
+          autoUploadProguardMapping = true
+          autoInstallation.enabled = false
+          telemetry = true
         }
-      }
+        """
+          .trimIndent()
+      )
 
-      sentry {
-        autoUploadProguardMapping = false
-        autoInstallation.enabled = false
-        telemetry = false
-      }
-      """
-        .trimIndent()
-    )
+    val libraryDir = File(testProjectDir.root, "library").apply { mkdirs() }
+    File(libraryDir, "build.gradle")
+      .writeText(
+        // language=Groovy
+        """
+        plugins {
+          id 'com.android.library'
+          id 'io.sentry.android.gradle'
+        }
+
+        repositories {
+          google()
+          mavenCentral()
+        }
+
+        android {
+          namespace 'com.example.library'
+          compileSdkVersion 35
+          defaultConfig {
+            minSdkVersion 21
+          }
+        }
+
+        sentry {
+          autoUploadProguardMapping = false
+          autoInstallation.enabled = false
+          telemetry = false
+        }
+        """
+          .trimIndent()
+      )
   }
 }


### PR DESCRIPTION
## Summary

Adds an integration test verifying the Sentry Android Gradle Plugin is compatible with Gradle's [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html) feature when applied to a realistic consumer build. Works toward [EME-1072](https://linear.app/getsentry/issue/EME-1072).

## Fixture shape

- Multi-module: `:app` (Android application) depends on `:library` (Android library), both apply `io.sentry.android.gradle`
- Wires `repositories`, `android`, and plugin application per-project — no `allprojects {}` / `subprojects {}`, which are incompatible with Isolated Projects
- Enables `org.gradle.unsafe.isolated-projects=true` in `gradle.properties`
- Runs `:app:assembleDebug --configuration-cache`

## Assertions

- `BUILD SUCCESSFUL`
- Output contains the `isolated projects` incubating banner — guards against the test silently degrading into a plain config-cache run
- No Isolated Projects violation markers in output

## Plugin features under test

| Feature | Enabled | Notes |
|---|---|---|
| `autoUploadProguardMapping` | ✅ true | PI-compatible |
| `telemetry` | ✅ true | PI-compatible |
| `autoInstallation.enabled` | ❌ false | **Not PI-compatible** — tracked in EME-1072 |

`autoInstallation` is the only known Isolated Projects blocker surfaced by this test. With it enabled, the build fails at configuration cache storage with:

> Plugin 'io.sentry.android.gradle': Project ':app' cannot access 'Project.group' functionality on another project ':library'

This matches the `InvalidUserCodeException` signal EME-1072 was opened to investigate and is left as a follow-up.