### PR TITLE
ci: Bump Kotlin to 2.3.0 for AGP 9.2 and AGP 9.3

### DIFF
--- a/scripts/generate-compat-matrix.main.kts
+++ b/scripts/generate-compat-matrix.main.kts
@@ -92,7 +92,7 @@ class GenerateMatrix : CliktCommand() {
       mapOf(
         "7.5".toVersion(strict = false) to "1.8.20",
         "9.0.0".toVersion(strict = false) to "2.1.0",
-        "9.5.0-0".toVersion(strict = false) to "2.3.0",
+        "9.2.0-0".toVersion(strict = false) to "2.3.0",
       )
     // TODO: make it dynamic too
     val kotlinVersion = "2.1.0".toVersion()


### PR DESCRIPTION
## Summary
- Lowers the `gradleToKotlin` threshold for Kotlin 2.3.0 in `scripts/generate-compat-matrix.main.kts` from Gradle `9.5.0-0` to `9.2.0-0`, so AGP 9.2 (Gradle 9.2.x) and AGP 9.3 (Gradle 9.3.x) CI matrix jobs compile with Kotlin 2.3.0 instead of 2.1.0.
- AGP 9.0/9.1 entries continue to use Kotlin 2.1.0; AGP < 9 continues to use 1.8.20.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxkcNs99YVK9xB84BwHTry)_