### PR TITLE
refactor(snapshots): Group preview options under a previews sub-extension

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -11,6 +11,7 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.android.build.api.variant.Variant
+import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.utils.setDisallowChanges
 import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
@@ -488,6 +489,8 @@ private fun ApplicationVariant.configureSnapshotsTasks(
   // Wire Paparazzi test generation and upload task when the Paparazzi plugin is applied
   project.pluginManager.withPlugin("app.cash.paparazzi") {
     if (extension.snapshots.previews.generateTests.get()) {
+      val android = project.extensions.getByType(BaseExtension::class.java)
+
       project.dependencies.add(
         "testImplementation",
         "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
@@ -506,6 +509,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
         GenerateSnapshotTestsTask.register(
           project,
           extension.snapshots.previews,
+          android,
           this@configureSnapshotsTasks,
           paparazziMajorVersion,
         )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -11,7 +11,6 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.android.build.api.variant.Variant
-import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.utils.setDisallowChanges
 import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
@@ -488,9 +487,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
 
   // Wire Paparazzi test generation and upload task when the Paparazzi plugin is applied
   project.pluginManager.withPlugin("app.cash.paparazzi") {
-    if (extension.snapshots.generateSnapshotTests.get()) {
-      val android = project.extensions.getByType(BaseExtension::class.java)
-
+    if (extension.snapshots.previews.generateTests.get()) {
       project.dependencies.add(
         "testImplementation",
         "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
@@ -508,8 +505,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
       val generateTask =
         GenerateSnapshotTestsTask.register(
           project,
-          extension.snapshots,
-          android,
+          extension.snapshots.previews,
           this@configureSnapshotsTasks,
           paparazziMajorVersion,
         )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotPreviewsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotPreviewsExtension.kt
@@ -8,8 +8,7 @@ import org.jetbrains.annotations.ApiStatus
 @ApiStatus.Experimental
 open class SnapshotPreviewsExtension @Inject constructor(objects: ObjectFactory) {
 
-  val generateTests: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(true)
+  val generateTests: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   val includePrivatePreviews: Property<Boolean> =
     objects.property(Boolean::class.java).convention(true)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotPreviewsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotPreviewsExtension.kt
@@ -2,6 +2,7 @@ package io.sentry.android.gradle.extensions
 
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.jetbrains.annotations.ApiStatus
 
@@ -12,6 +13,9 @@ open class SnapshotPreviewsExtension @Inject constructor(objects: ObjectFactory)
 
   val includePrivatePreviews: Property<Boolean> =
     objects.property(Boolean::class.java).convention(true)
+
+  val packageTrees: ListProperty<String> =
+    objects.listProperty(String::class.java).convention(emptyList())
 
   val theme: Property<String> = objects.property(String::class.java)
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotPreviewsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotPreviewsExtension.kt
@@ -1,0 +1,18 @@
+package io.sentry.android.gradle.extensions
+
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.jetbrains.annotations.ApiStatus
+
+@ApiStatus.Experimental
+open class SnapshotPreviewsExtension @Inject constructor(objects: ObjectFactory) {
+
+  val generateTests: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
+
+  val includePrivatePreviews: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
+
+  val theme: Property<String> = objects.property(String::class.java)
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.gradle.extensions
 
 import javax.inject.Inject
+import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.jetbrains.annotations.ApiStatus
 
@@ -11,14 +11,10 @@ open class SnapshotsExtension @Inject constructor(objects: ObjectFactory) {
 
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-  val generateSnapshotTests: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(true)
+  val previews: SnapshotPreviewsExtension =
+    objects.newInstance(SnapshotPreviewsExtension::class.java)
 
-  val includePrivatePreviews: Property<Boolean> =
-    objects.property(Boolean::class.java).convention(true)
-
-  val packageTrees: ListProperty<String> =
-    objects.listProperty(String::class.java).convention(emptyList())
-
-  val theme: Property<String> = objects.property(String::class.java)
+  fun previews(action: Action<SnapshotPreviewsExtension>) {
+    action.execute(previews)
+  }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -1,14 +1,12 @@
 package io.sentry.android.gradle.snapshot
 
 import com.android.build.api.variant.ApplicationVariant
-import com.android.build.gradle.BaseExtension
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
-import io.sentry.android.gradle.extensions.SnapshotsExtension
+import io.sentry.android.gradle.extensions.SnapshotPreviewsExtension
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
@@ -27,8 +25,6 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
   }
 
   @get:Input abstract val includePrivatePreviews: Property<Boolean>
-
-  @get:Input abstract val packageTrees: ListProperty<String>
 
   @get:Input @get:Optional abstract val theme: Property<String>
 
@@ -49,7 +45,6 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     val content =
       generateTestFileContent(
         includePrivatePreviews = includePrivatePreviews.get(),
-        packageTrees = packageTrees.get(),
         theme = theme.orNull,
         paparazziMajorVersion = paparazziMajorVersion.get(),
       )
@@ -63,8 +58,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
 
     fun register(
       project: Project,
-      extension: SnapshotsExtension,
-      android: BaseExtension,
+      extension: SnapshotPreviewsExtension,
       variant: ApplicationVariant,
       paparazziMajorVersion: Provider<Int>,
     ): TaskProvider<GenerateSnapshotTestsTask> {
@@ -75,13 +69,6 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         task.includePrivatePreviews.set(extension.includePrivatePreviews)
         task.theme.set(extension.theme)
         task.paparazziMajorVersion.value(paparazziMajorVersion)
-        // Fall back to the Android namespace when the user doesn't configure packageTrees
-        // TODO do we actually need this?
-        task.packageTrees.set(
-          extension.packageTrees.map { packages ->
-            packages.ifEmpty { listOf(android.namespace!!) }
-          }
-        )
         task.outputDir.set(
           project.layout.buildDirectory.dir("generated/sentry/snapshotsTests/${variant.name}")
         )
@@ -91,15 +78,13 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     @Suppress("LongMethod")
     private fun generateTestFileContent(
       includePrivatePreviews: Boolean,
-      packageTrees: List<String>,
       theme: String? = null,
       paparazziMajorVersion: Int = 2,
     ): String {
       val includePrivateExpr =
         if (includePrivatePreviews) "\n                .includePrivatePreviews()" else ""
 
-      val packages = packageTrees.joinToString(", ") { "\"$it\"" }
-      val scanExpr = ".scanPackageTrees($packages)"
+      val scanExpr = ".scanAllPackages()"
 
       return """
 package $PACKAGE_NAME

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -1,12 +1,14 @@
 package io.sentry.android.gradle.snapshot
 
 import com.android.build.api.variant.ApplicationVariant
+import com.android.build.gradle.BaseExtension
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
 import io.sentry.android.gradle.extensions.SnapshotPreviewsExtension
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
@@ -25,6 +27,8 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
   }
 
   @get:Input abstract val includePrivatePreviews: Property<Boolean>
+
+  @get:Input abstract val packageTrees: ListProperty<String>
 
   @get:Input @get:Optional abstract val theme: Property<String>
 
@@ -45,6 +49,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     val content =
       generateTestFileContent(
         includePrivatePreviews = includePrivatePreviews.get(),
+        packageTrees = packageTrees.get(),
         theme = theme.orNull,
         paparazziMajorVersion = paparazziMajorVersion.get(),
       )
@@ -59,6 +64,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     fun register(
       project: Project,
       extension: SnapshotPreviewsExtension,
+      android: BaseExtension,
       variant: ApplicationVariant,
       paparazziMajorVersion: Provider<Int>,
     ): TaskProvider<GenerateSnapshotTestsTask> {
@@ -69,6 +75,12 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         task.includePrivatePreviews.set(extension.includePrivatePreviews)
         task.theme.set(extension.theme)
         task.paparazziMajorVersion.value(paparazziMajorVersion)
+        // Fall back to the Android namespace when the user doesn't configure packageTrees
+        task.packageTrees.set(
+          extension.packageTrees.map { packages ->
+            packages.ifEmpty { listOf(android.namespace!!) }
+          }
+        )
         task.outputDir.set(
           project.layout.buildDirectory.dir("generated/sentry/snapshotsTests/${variant.name}")
         )
@@ -78,13 +90,15 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     @Suppress("LongMethod")
     private fun generateTestFileContent(
       includePrivatePreviews: Boolean,
+      packageTrees: List<String>,
       theme: String? = null,
       paparazziMajorVersion: Int = 2,
     ): String {
       val includePrivateExpr =
         if (includePrivatePreviews) "\n                .includePrivatePreviews()" else ""
 
-      val scanExpr = ".scanAllPackages()"
+      val packages = packageTrees.joinToString(", ") { "\"$it\"" }
+      val scanExpr = ".scanPackageTrees($packages)"
 
       return """
 package $PACKAGE_NAME

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle.extensions
 
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
@@ -16,36 +17,52 @@ class SnapshotsExtensionTest {
   }
 
   @Test
-  fun `generateSnapshotTests is true by default`() {
+  fun `previews generateTests is true by default`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
-    assertTrue(extension.generateSnapshotTests.get())
+    assertTrue(extension.previews.generateTests.get())
   }
 
   @Test
-  fun `generateSnapshotTests can be set to false`() {
+  fun `previews generateTests can be set to false`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
-    extension.generateSnapshotTests.set(false)
+    extension.previews.generateTests.set(false)
 
-    assertFalse(extension.generateSnapshotTests.get())
+    assertFalse(extension.previews.generateTests.get())
   }
 
   @Test
-  fun `includePrivatePreviews is true by default`() {
+  fun `previews includePrivatePreviews is true by default`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
-    assertTrue(extension.includePrivatePreviews.get())
+    assertTrue(extension.previews.includePrivatePreviews.get())
   }
 
   @Test
-  fun `packageTrees is empty by default`() {
+  fun `previews theme has no default`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
-    assertTrue(extension.packageTrees.get().isEmpty())
+    assertNull(extension.previews.theme.orNull)
+  }
+
+  @Test
+  fun `previews block configures sub-extension`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    extension.previews { previews ->
+      previews.generateTests.set(false)
+      previews.includePrivatePreviews.set(false)
+      previews.theme.set("AppTheme")
+    }
+
+    assertFalse(extension.previews.generateTests.get())
+    assertFalse(extension.previews.includePrivatePreviews.get())
+    assertTrue(extension.previews.theme.get() == "AppTheme")
   }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
@@ -43,6 +43,14 @@ class SnapshotsExtensionTest {
   }
 
   @Test
+  fun `previews packageTrees is empty by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    assertTrue(extension.previews.packageTrees.get().isEmpty())
+  }
+
+  @Test
   fun `previews theme has no default`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
@@ -58,11 +66,13 @@ class SnapshotsExtensionTest {
     extension.previews { previews ->
       previews.generateTests.set(false)
       previews.includePrivatePreviews.set(false)
+      previews.packageTrees.set(listOf("com.example"))
       previews.theme.set("AppTheme")
     }
 
     assertFalse(extension.previews.generateTests.get())
     assertFalse(extension.previews.includePrivatePreviews.get())
+    assertTrue(extension.previews.packageTrees.get() == listOf("com.example"))
     assertTrue(extension.previews.theme.get() == "AppTheme")
   }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -16,7 +16,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generates test file in correct package directory`() {
-    val task = createTask(packageTrees = listOf("com.example"))
+    val task = createTask()
 
     task.generate()
 
@@ -27,7 +27,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `cleans output directory on re-run`() {
-    val task = createTask(packageTrees = listOf("com.example"))
+    val task = createTask()
     val outputDir = task.outputDir.get().asFile
 
     // Create a stale file in the output directory
@@ -46,46 +46,36 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file contains correct package declaration`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(content.contains("package io.sentry.snapshot"))
   }
 
   @Test
-  fun `generated file scans configured package tree`() {
-    val content = generateAndRead(packageTrees = listOf("com.example.app"))
+  fun `generated file scans all packages`() {
+    val content = generateAndRead()
 
-    assertTrue(content.contains(".scanPackageTrees(\"com.example.app\")"))
-  }
-
-  @Test
-  fun `generated file scans multiple package trees`() {
-    val content =
-      generateAndRead(packageTrees = listOf("com.example.feature1", "com.example.feature2"))
-
-    assertTrue(
-      content.contains(".scanPackageTrees(\"com.example.feature1\", \"com.example.feature2\")")
-    )
+    assertTrue(content.contains(".scanAllPackages()"))
+    assertFalse(content.contains(".scanPackageTrees("))
   }
 
   @Test
   fun `generated file includes private previews when enabled`() {
-    val content =
-      generateAndRead(packageTrees = listOf("com.example"), includePrivatePreviews = true)
+    val content = generateAndRead(includePrivatePreviews = true)
 
     assertTrue(content.contains(".includePrivatePreviews()"))
   }
 
   @Test
   fun `generated file excludes private previews by default`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertFalse(content.contains(".includePrivatePreviews()"))
   }
 
   @Test
   fun `generated file contains parameterized test runner`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(content.contains("@RunWith(Parameterized::class)"))
     assertTrue(content.contains("class ComposablePreviewSnapshotTest"))
@@ -93,7 +83,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar metadata uses short display name`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(
       content.contains(
@@ -104,14 +94,14 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar metadata uses full screenshotId for image file name`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(content.contains("\"image_file_name\" to screenshotId"))
   }
 
   @Test
   fun `generated file writes sidecar json to images directory`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(content.contains("val imagesDir = File(snapshotDir, \"images\")"))
     assertTrue(content.contains("File(imagesDir, \"\${sidecarName}.json\").writeText(json)"))
@@ -119,7 +109,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar filename is lowercased to match Paparazzi image filenames`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(
       content.contains("screenshotId.lowercase(Locale.US).replace(\"\\\\s\".toRegex(), \"_\")")
@@ -128,7 +118,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar reads SentrySnapshot annotation via reflection`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(content.contains("Class.forName(preview.declaringClass)"))
     assertTrue(content.contains("\"io.sentry.snapshots.runtime.SentrySnapshot\""))
@@ -137,7 +127,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar emits diff_threshold only when non-default`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"))
+    val content = generateAndRead()
 
     assertTrue(
       content.contains(
@@ -167,7 +157,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file uses HtmlReportWriter without maxPercentDifference for paparazzi 1`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"), paparazziMajorVersion = 1)
+    val content = generateAndRead(paparazziMajorVersion = 1)
 
     assertTrue(content.contains("HtmlReportWriter()"))
     assertFalse(content.contains("HtmlReportWriter(maxPercentDifference"))
@@ -175,18 +165,17 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file uses HtmlReportWriter with maxPercentDifference for paparazzi 2`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"), paparazziMajorVersion = 2)
+    val content = generateAndRead(paparazziMajorVersion = 2)
 
     assertTrue(content.contains("HtmlReportWriter(maxPercentDifference = tolerance)"))
     assertFalse(content.contains("HtmlReportWriter()"))
   }
 
   private fun generateAndRead(
-    packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
     paparazziMajorVersion: Int = 2,
   ): String {
-    val task = createTask(packageTrees, includePrivatePreviews, paparazziMajorVersion)
+    val task = createTask(includePrivatePreviews, paparazziMajorVersion)
     task.generate()
     val file =
       File(task.outputDir.get().asFile, "io/sentry/snapshot/ComposablePreviewSnapshotTest.kt")
@@ -194,7 +183,6 @@ class GenerateSnapshotTestsTaskTest {
   }
 
   private fun createTask(
-    packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
     paparazziMajorVersion: Int = 2,
   ): GenerateSnapshotTestsTask {
@@ -202,7 +190,6 @@ class GenerateSnapshotTestsTaskTest {
     return project.tasks
       .register("testGenerateSnapshotTests", GenerateSnapshotTestsTask::class.java) { task ->
         task.includePrivatePreviews.set(includePrivatePreviews)
-        task.packageTrees.set(packageTrees)
         task.paparazziMajorVersion.set(paparazziMajorVersion)
         task.outputDir.set(tmpDir.newFolder("output"))
       }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -16,7 +16,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generates test file in correct package directory`() {
-    val task = createTask()
+    val task = createTask(packageTrees = listOf("com.example"))
 
     task.generate()
 
@@ -27,7 +27,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `cleans output directory on re-run`() {
-    val task = createTask()
+    val task = createTask(packageTrees = listOf("com.example"))
     val outputDir = task.outputDir.get().asFile
 
     // Create a stale file in the output directory
@@ -46,36 +46,46 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file contains correct package declaration`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(content.contains("package io.sentry.snapshot"))
   }
 
   @Test
-  fun `generated file scans all packages`() {
-    val content = generateAndRead()
+  fun `generated file scans configured package tree`() {
+    val content = generateAndRead(packageTrees = listOf("com.example.app"))
 
-    assertTrue(content.contains(".scanAllPackages()"))
-    assertFalse(content.contains(".scanPackageTrees("))
+    assertTrue(content.contains(".scanPackageTrees(\"com.example.app\")"))
+  }
+
+  @Test
+  fun `generated file scans multiple package trees`() {
+    val content =
+      generateAndRead(packageTrees = listOf("com.example.feature1", "com.example.feature2"))
+
+    assertTrue(
+      content.contains(".scanPackageTrees(\"com.example.feature1\", \"com.example.feature2\")")
+    )
   }
 
   @Test
   fun `generated file includes private previews when enabled`() {
-    val content = generateAndRead(includePrivatePreviews = true)
+    val content =
+      generateAndRead(packageTrees = listOf("com.example"), includePrivatePreviews = true)
 
     assertTrue(content.contains(".includePrivatePreviews()"))
   }
 
   @Test
   fun `generated file excludes private previews by default`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertFalse(content.contains(".includePrivatePreviews()"))
   }
 
   @Test
   fun `generated file contains parameterized test runner`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(content.contains("@RunWith(Parameterized::class)"))
     assertTrue(content.contains("class ComposablePreviewSnapshotTest"))
@@ -83,7 +93,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar metadata uses short display name`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(
       content.contains(
@@ -94,14 +104,14 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar metadata uses full screenshotId for image file name`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(content.contains("\"image_file_name\" to screenshotId"))
   }
 
   @Test
   fun `generated file writes sidecar json to images directory`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(content.contains("val imagesDir = File(snapshotDir, \"images\")"))
     assertTrue(content.contains("File(imagesDir, \"\${sidecarName}.json\").writeText(json)"))
@@ -109,7 +119,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar filename is lowercased to match Paparazzi image filenames`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(
       content.contains("screenshotId.lowercase(Locale.US).replace(\"\\\\s\".toRegex(), \"_\")")
@@ -118,7 +128,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar reads SentrySnapshot annotation via reflection`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(content.contains("Class.forName(preview.declaringClass)"))
     assertTrue(content.contains("\"io.sentry.snapshots.runtime.SentrySnapshot\""))
@@ -127,7 +137,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated sidecar emits diff_threshold only when non-default`() {
-    val content = generateAndRead()
+    val content = generateAndRead(packageTrees = listOf("com.example"))
 
     assertTrue(
       content.contains(
@@ -157,7 +167,7 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file uses HtmlReportWriter without maxPercentDifference for paparazzi 1`() {
-    val content = generateAndRead(paparazziMajorVersion = 1)
+    val content = generateAndRead(packageTrees = listOf("com.example"), paparazziMajorVersion = 1)
 
     assertTrue(content.contains("HtmlReportWriter()"))
     assertFalse(content.contains("HtmlReportWriter(maxPercentDifference"))
@@ -165,17 +175,18 @@ class GenerateSnapshotTestsTaskTest {
 
   @Test
   fun `generated file uses HtmlReportWriter with maxPercentDifference for paparazzi 2`() {
-    val content = generateAndRead(paparazziMajorVersion = 2)
+    val content = generateAndRead(packageTrees = listOf("com.example"), paparazziMajorVersion = 2)
 
     assertTrue(content.contains("HtmlReportWriter(maxPercentDifference = tolerance)"))
     assertFalse(content.contains("HtmlReportWriter()"))
   }
 
   private fun generateAndRead(
+    packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
     paparazziMajorVersion: Int = 2,
   ): String {
-    val task = createTask(includePrivatePreviews, paparazziMajorVersion)
+    val task = createTask(packageTrees, includePrivatePreviews, paparazziMajorVersion)
     task.generate()
     val file =
       File(task.outputDir.get().asFile, "io/sentry/snapshot/ComposablePreviewSnapshotTest.kt")
@@ -183,6 +194,7 @@ class GenerateSnapshotTestsTaskTest {
   }
 
   private fun createTask(
+    packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
     paparazziMajorVersion: Int = 2,
   ): GenerateSnapshotTestsTask {
@@ -190,6 +202,7 @@ class GenerateSnapshotTestsTaskTest {
     return project.tasks
       .register("testGenerateSnapshotTests", GenerateSnapshotTestsTask::class.java) { task ->
         task.includePrivatePreviews.set(includePrivatePreviews)
+        task.packageTrees.set(packageTrees)
         task.paparazziMajorVersion.set(paparazziMajorVersion)
         task.outputDir.set(tmpDir.newFolder("output"))
       }


### PR DESCRIPTION
## Summary
- Reshape the experimental `sentry.snapshots { }` DSL so preview scanning and test generation now live under a nested `previews { }` block. `generateSnapshotTests` becomes `previews.generateTests`; `includePrivatePreviews`, `theme`, and `packageTrees` move under `previews`.

### Before
```kotlin
sentry {
  snapshots {
    enabled = true
    generateSnapshotTests = true
    includePrivatePreviews = false
    theme = "AppTheme"
    packageTrees = listOf("com.example.ui")
  }
}
```

### After
```kotlin
sentry {
  snapshots {
    enabled = true
    previews {
      generateTests = true
      includePrivatePreviews = false
      theme = "AppTheme"
      packageTrees = listOf("com.example.ui")
    }
  }
}
```

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)