### PR TITLE
build(ci): Upload sentry-snapshots-runtime zip for craft (EME-1055)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Build Gradle Plugin and Kotlin Compiler Plugin distribution artifacts
-        run: ./gradlew :plugin-build:assemble :sentry-kotlin-compiler-plugin:assemble
+      - name: Build Gradle Plugin, Kotlin Compiler Plugin, and Snapshots Runtime distribution artifacts
+        run: ./gradlew :plugin-build:assemble :sentry-kotlin-compiler-plugin:assemble :sentry-snapshots-runtime:assemble
 
       - name: Archive artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -38,6 +38,7 @@ jobs:
           path: |
             ${{ github.workspace }}/plugin-build/build/distributions/*.zip
             ${{ github.workspace }}/sentry-kotlin-compiler-plugin/build/distributions/*.zip
+            ${{ github.workspace }}/sentry-snapshots-runtime/build/distributions/*.zip
 
       - name: Verify artifact contents
         shell: bash


### PR DESCRIPTION
## Summary

`sentry-snapshots-runtime` was registered in `.craft.yml` under `registry` and the `maven-publish` plugin is wired up in its `build.gradle.kts`, but it was not published during the 6.5.0 release.

Craft's maven target publishes by downloading the per-commit zip bundle attached to the release commit by `build.yml`'s `upload-artifact` step, extracting each module's `pom-default.xml`, and calling `mvn gpg:sign-and-deploy-file`. Since `build.yml` only assembled and uploaded zips for `plugin-build` and `sentry-kotlin-compiler-plugin`, craft never saw a `sentry-snapshots-runtime.zip` and silently skipped the module.

This PR adds the module to the gradle invocation and to the `upload-artifact` paths so it will ship on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)