### PR TITLE
[DNM] feat(snapshots): Add Roborazzi support for Compose preview scanning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.8.20"
 agp = "8.10.1"
+roborazzi = "1.60.0"
 
 asm = "9.4" # // compatibility matrix -> https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/instrumentation/InstrumentationContext#apiversion
 ktfmt = "0.51"
@@ -37,6 +38,7 @@ proguard = { group = "com.guardsquare", name = "proguard-gradle", version = "7.5
 # locally available version. kotlin-gradle-plugin follows the same approach.
 gradleApi = { group = "org.gradle.experimental", name = "gradle-public-api", version = "8.9" }
 agp = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+roborazziGradlePlugin = { group = "io.github.takahirom.roborazzi", name = "roborazzi-gradle-plugin", version.ref = "roborazzi" }
 kotlinCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable" }
 autoService = { group = "com.google.auto.service", name = "auto-service", version = "1.0.1" }
 autoServiceAnnotatons = { group = "com.google.auto.service", name = "auto-service-annotations", version = "1.0.1" }

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   compileOnly(libs.gradleApi)
   compileOnly(libs.agp)
   compileOnly(libs.proguard)
+  compileOnly(libs.roborazziGradlePlugin)
 
   implementation(libs.asm)
   implementation(libs.asmCommons)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -13,6 +13,7 @@ import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.utils.setDisallowChanges
+import io.github.takahirom.roborazzi.RoborazziExtension
 import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
@@ -44,6 +45,7 @@ import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.collectModules
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
@@ -486,8 +488,13 @@ private fun ApplicationVariant.configureSnapshotsTasks(
       taskSuffix = taskSuffix,
     )
 
+  val paparazziSeen = AtomicBoolean(false)
+  val roborazziSeen = AtomicBoolean(false)
+
   // Wire Paparazzi test generation and upload task when the Paparazzi plugin is applied
   project.pluginManager.withPlugin("app.cash.paparazzi") {
+    check(!roborazziSeen.get()) { BOTH_SNAPSHOT_ENGINES_ERROR }
+    paparazziSeen.set(true)
     if (extension.snapshots.previews.generateTests.get()) {
       val android = project.extensions.getByType(BaseExtension::class.java)
 
@@ -547,7 +554,70 @@ private fun ApplicationVariant.configureSnapshotsTasks(
       }
     }
   }
+
+  // Wire snapshot upload when the Roborazzi plugin is applied. Roborazzi already provides
+  // its own @Preview test generation; we just configure it and point its output at our
+  // upload staging directory.
+  project.pluginManager.withPlugin("io.github.takahirom.roborazzi") {
+    check(!paparazziSeen.get()) { BOTH_SNAPSHOT_ENGINES_ERROR }
+    roborazziSeen.set(true)
+    configureRoborazziSnapshots(project, extension, taskSuffix, uploadTask)
+  }
 }
+
+@Suppress("OPT_IN_USAGE")
+private fun ApplicationVariant.configureRoborazziSnapshots(
+  project: Project,
+  extension: SentryPluginExtension,
+  taskSuffix: String,
+  uploadTask: TaskProvider<SentryUploadSnapshotsTask>,
+) {
+  val previews = extension.snapshots.previews
+  val android = project.extensions.getByType(BaseExtension::class.java)
+  val roborazziExt = project.extensions.getByType(RoborazziExtension::class.java)
+
+  val snapshotsDir = project.layout.buildDirectory.dir("sentry/snapshots/$name")
+
+  // Pass DSL fields through to Roborazzi's preview-test generator. We use convention()
+  // rather than set() so a user-supplied value in their build script wins.
+  if (previews.generateTests.get()) {
+    project.dependencies.add(
+      "testImplementation",
+      "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
+    )
+    project.dependencies.add(
+      "testImplementation",
+      "io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:" + ROBORAZZI_VERSION,
+    )
+
+    val previewExt = roborazziExt.generateComposePreviewRobolectricTests
+    previewExt.enable.convention(true)
+    previewExt.packages.convention(
+      previews.packageTrees.map { pkgs -> pkgs.ifEmpty { listOf(android.namespace!!) } }
+    )
+    previewExt.includePrivatePreviews.convention(previews.includePrivatePreviews)
+  }
+
+  // Direct Roborazzi PNGs into our staging dir unless the user pinned their own outputDir.
+  roborazziExt.outputDir.convention(snapshotsDir)
+
+  project.afterEvaluate {
+    val testTaskName = "test${taskSuffix}UnitTest"
+    if (testTaskName !in project.tasks.names) return@afterEvaluate
+
+    uploadTask.configure { task ->
+      task.dependsOn("recordRoborazzi$taskSuffix")
+      task.snapshotsPath.set(roborazziExt.outputDir)
+    }
+  }
+}
+
+private const val BOTH_SNAPSHOT_ENGINES_ERROR =
+  "Sentry snapshots: both app.cash.paparazzi and io.github.takahirom.roborazzi are " +
+    "applied to the same module. Apply only one."
+
+// Pinned to match the compileOnly version in plugin-build/build.gradle.kts.
+private const val ROBORAZZI_VERSION = "1.60.0"
 
 internal fun parseMajorVersion(version: String?, defaultVersion: Int = 2): Int =
   version?.trimStart()?.takeWhile { it.isDigit() }?.toIntOrNull() ?: defaultVersion

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginRoborazziTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginRoborazziTest.kt
@@ -1,0 +1,118 @@
+package io.sentry.android.gradle.integration
+
+import io.sentry.BuildConfig
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.util.GradleVersion
+import org.junit.Test
+
+/**
+ * Verifies the Sentry snapshot upload flow when the Roborazzi plugin is applied. Roborazzi already
+ * provides @Preview-driven Robolectric test generation; the Sentry plugin only configures it, pins
+ * its outputDir, and wires `recordRoborazzi<Variant>` as a dependency of
+ * `sentryUploadSnapshots<Variant>`.
+ */
+class SentryPluginRoborazziTest :
+  BaseSentryPluginTest(BuildConfig.AgpVersion, GradleVersion.current().version) {
+
+  override val additionalBuildClasspath: String =
+    """
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
+        classpath "io.github.takahirom.roborazzi:roborazzi-gradle-plugin:1.60.0"
+        classpath "app.cash.paparazzi:paparazzi-gradle-plugin:1.3.5"
+        """
+      .trimIndent()
+
+  @Test
+  fun `wires sentryUploadSnapshotsDebug to depend on recordRoborazziDebug`() {
+    appBuildFile.writeText(roborazziAppBuildScript())
+
+    val build =
+      runner.appendArguments(":app:sentryUploadSnapshotsDebug", "--dry-run", "--stacktrace").build()
+
+    assertTrue(":app:sentryUploadSnapshotsDebug SKIPPED" in build.output)
+    assertTrue(":app:recordRoborazziDebug SKIPPED" in build.output)
+  }
+
+  @Test
+  fun `does not wire Paparazzi tasks when only Roborazzi is applied`() {
+    appBuildFile.writeText(roborazziAppBuildScript())
+
+    val build = runner.appendArguments(":app:tasks", "--all").build()
+
+    assertFalse("recordPaparazzi" in build.output)
+  }
+
+  @Test
+  fun `fails configuration when both Paparazzi and Roborazzi are applied`() {
+    appBuildFile.writeText(
+      // language=Groovy
+      """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            // Paparazzi and Roborazzi are both already on the buildscript classpath via the
+            // test fixture; apply them by id without re-declaring versions.
+            apply plugin: "io.github.takahirom.roborazzi"
+            apply plugin: "app.cash.paparazzi"
+
+            android {
+              namespace 'com.example'
+            }
+
+            sentry {
+              autoUploadProguardMapping = false
+              autoInstallation { enabled = false }
+              telemetry = false
+              snapshots { enabled = true }
+            }
+            """
+        .trimIndent()
+    )
+
+    val result = runner.appendArguments(":app:tasks").buildAndFail()
+
+    assertContains(
+      result.output,
+      "both app.cash.paparazzi and io.github.takahirom.roborazzi are applied",
+    )
+  }
+
+  private fun roborazziAppBuildScript(): String =
+    // language=Groovy
+    """
+        plugins {
+          id "com.android.application"
+          id "io.sentry.android.gradle"
+          id "io.github.takahirom.roborazzi"
+        }
+
+        android {
+          namespace 'com.example'
+        }
+
+        dependencies {
+          testImplementation 'junit:junit:4.13.2'
+          testImplementation 'org.robolectric:robolectric:4.14.1'
+          testImplementation 'io.github.takahirom.roborazzi:roborazzi:1.60.0'
+          testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose:1.60.0'
+          testImplementation 'io.github.takahirom.roborazzi:roborazzi-junit-rule:1.60.0'
+        }
+
+        sentry {
+          autoUploadProguardMapping = false
+          autoInstallation { enabled = false }
+          telemetry = false
+          snapshots {
+            enabled = true
+            previews {
+              packageTrees = ['com.example']
+            }
+          }
+        }
+        """
+      .trimIndent()
+}


### PR DESCRIPTION
## Summary

Wires `sentryUploadSnapshots<Variant>` into the Roborazzi build flow when `io.github.takahirom.roborazzi` is applied, mirroring the existing Paparazzi integration. Roborazzi already provides @Preview-driven Robolectric test generation, so the plugin only configures it, pins its `outputDir`, and hooks `recordRoborazzi<Variant>` as a dependency of the upload task.

## Behavior

When the user applies `io.github.takahirom.roborazzi` and sets `sentry.snapshots.enabled = true`:

- Auto-adds `roborazzi-compose-preview-scanner-support` and `ComposablePreviewScanner:android` to `testImplementation`.
- Configures Roborazzi's `generateComposePreviewRobolectricTests` from the shared `snapshots.previews` DSL (`enable=true`, `packages` from `packageTrees`, `includePrivatePreviews` pass-through) — using `convention()` so user values override.
- Pins `roborazzi.outputDir` to `build/sentry/snapshots/<variant>/` (also via `convention()`).
- Hooks `recordRoborazzi<Variant>` as a dependency of `sentryUploadSnapshots<Variant>` and points its `snapshotsPath` at the staging dir.

If both `app.cash.paparazzi` and `io.github.takahirom.roborazzi` are applied to the same module, configuration fails with a clear message.

## Notes

- No sidecar JSON is emitted on the Roborazzi path (per-image metadata is deferred to the ingestion side reading Roborazzi's native `results-summary.json` once upstream populates `context_data` with `AndroidPreviewInfo`). Paparazzi keeps its richer sidecar flow.
- Per-snapshot `@SentrySnapshot.diffThreshold` remains Paparazzi-only for now.