### PR TITLE
chore(deps): Bump ComposablePreviewScanner to 0.8.2

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -493,7 +493,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
 
       project.dependencies.add(
         "testImplementation",
-        "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
+        "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.2",
       )
 
       val paparazziMajorVersion =


### PR DESCRIPTION
## Summary
- Bump `io.github.sergio-sastre.ComposablePreviewScanner:android` from `0.8.1` to `0.8.2`.
- Release notes: https://github.com/sergio-sastre/ComposablePreviewScanner/releases/tag/0.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)