### PR TITLE
feat(deps): Auto-update ComposablePreviewScanner version

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -33,3 +33,12 @@ jobs:
           path: scripts/update-android.sh
           name: Android SDK
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
+
+  composable-preview-scanner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
+        with:
+          path: plugin-build/composable-preview-scanner.properties
+          name: ComposablePreviewScanner
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -1,6 +1,5 @@
 import io.sentry.android.gradle.internal.ASMifyTask
 import io.sentry.android.gradle.internal.BootstrapAndroidSdk
-import java.io.FileInputStream
 import java.util.Properties
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
@@ -312,16 +311,18 @@ buildConfig {
   buildConfigField("String", "Version", provider { "\"${project.version}\"" })
   buildConfigField("String", "SdkVersion", provider { "\"${project.property("sdk_version")}\"" })
   buildConfigField("String", "AgpVersion", provider { "\"${BuildPluginsVersion.AGP}\"" })
+  buildConfigField("String", "CliVersion", propertyVersionProvider("sentry-cli.properties"))
   buildConfigField(
     "String",
-    "CliVersion",
-    provider {
-      "\"${Properties().apply {
-          load(FileInputStream(File("$projectDir/sentry-cli.properties")))
-      }.getProperty("version")}\""
-    },
+    "ComposablePreviewScannerVersion",
+    propertyVersionProvider("composable-preview-scanner.properties"),
   )
 }
+
+fun propertyVersionProvider(fileName: String): Provider<String> =
+  providers.fileContents(layout.projectDirectory.file(fileName)).asText.map { content ->
+    "\"${Properties().apply { load(content.reader()) }.getProperty("version")}\""
+  }
 
 tasks.register<ASMifyTask>("asmify")
 

--- a/plugin-build/composable-preview-scanner.properties
+++ b/plugin-build/composable-preview-scanner.properties
@@ -1,0 +1,2 @@
+version = 0.8.1
+repo = https://github.com/sergio-sastre/ComposablePreviewScanner

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -13,6 +13,7 @@ import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.utils.setDisallowChanges
+import io.sentry.BuildConfig
 import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
@@ -493,7 +494,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
 
       project.dependencies.add(
         "testImplementation",
-        "io.github.sergio-sastre.ComposablePreviewScanner:android:0.8.1",
+        "io.github.sergio-sastre.ComposablePreviewScanner:android:${BuildConfig.ComposablePreviewScannerVersion}",
       )
 
       val paparazziMajorVersion =


### PR DESCRIPTION
The version was previously hardcoded inside the plugin source, so each bump required a manual PR. This brings it in line with how `sentry-cli` and the Android SDK versions are kept up to date.

## Summary

- Externalizes the `ComposablePreviewScanner` version into `plugin-build/composable-preview-scanner.properties` (mirrors `sentry-cli.properties`) and exposes it as `BuildConfig.ComposablePreviewScannerVersion`, replacing the hardcoded coordinate string in `AndroidComponentsConfig`.
- Adds a `composable-preview-scanner` job to `.github/workflows/update-deps.yml` using the existing `getsentry/github-workflows/updater` action, so a PR is opened automatically when sergio-sastre/ComposablePreviewScanner publishes a new release (daily + on every push to `main`).

#skip-changelog