### PR TITLE
refactor: Inject ObjectFactory instead of Project in SentryPluginExtension

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -41,7 +41,7 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
       )
     }
 
-    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java, project)
+    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java)
 
     project.pluginManager.withPlugin("com.android.application") {
       val androidComponentsExt =

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -3,14 +3,12 @@ package io.sentry.android.gradle.extensions
 import io.sentry.android.gradle.telemetry.SentryTelemetryService.Companion.SENTRY_SAAS_DSN
 import javax.inject.Inject
 import org.gradle.api.Action
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.jetbrains.annotations.ApiStatus.Experimental
 
-abstract class SentryPluginExtension @Inject constructor(project: Project) {
-
-  private val objects = project.objects
+abstract class SentryPluginExtension @Inject constructor(objects: ObjectFactory) {
 
   /**
    * Disables or enables the handling of Proguard mapping for Sentry. If enabled the plugin will

--- a/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
@@ -35,7 +35,7 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
   private val configuredForJavaProject = AtomicBoolean(false)
 
   override fun apply(project: Project) {
-    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java, project)
+    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java)
 
     project.pluginManager.withPlugin("org.gradle.java") {
       if (configuredForJavaProject.getAndSet(true)) {


### PR DESCRIPTION
## Summary

- `SentryPluginExtension` only used `Project` to call `project.objects` — inject `ObjectFactory` directly instead
- Removes the unnecessary `Project` dependency from the extension constructor

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)