### PR TITLE
feat(snapshots): Add global diffThreshold setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add global `diffThreshold` option for snapshots ([#1186](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1186))
+
 ### Fixes
 
 - Change auto-install trigger for log4j2 from -api to -core dependency ([#1155](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1155))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -509,7 +509,7 @@ private fun ApplicationVariant.configureSnapshotsTasks(
       val generateTask =
         GenerateSnapshotTestsTask.register(
           project,
-          extension.snapshots.previews,
+          extension.snapshots,
           android,
           this@configureSnapshotsTasks,
           paparazziMajorVersion,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtension.kt
@@ -11,6 +11,8 @@ open class SnapshotsExtension @Inject constructor(objects: ObjectFactory) {
 
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
+  val diffThreshold: Property<Double> = objects.property(Double::class.java).convention(0.0)
+
   val previews: SnapshotPreviewsExtension =
     objects.newInstance(SnapshotPreviewsExtension::class.java)
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -3,7 +3,7 @@ package io.sentry.android.gradle.snapshot
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.gradle.BaseExtension
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
-import io.sentry.android.gradle.extensions.SnapshotPreviewsExtension
+import io.sentry.android.gradle.extensions.SnapshotsExtension
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -32,6 +32,8 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
 
   @get:Input @get:Optional abstract val theme: Property<String>
 
+  @get:Input abstract val diffThreshold: Property<Double>
+
   @get:Input abstract val paparazziMajorVersion: Property<Int>
 
   @get:OutputDirectory abstract val outputDir: DirectoryProperty
@@ -51,6 +53,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         includePrivatePreviews = includePrivatePreviews.get(),
         packageTrees = packageTrees.get(),
         theme = theme.orNull,
+        diffThreshold = diffThreshold.get(),
         paparazziMajorVersion = paparazziMajorVersion.get(),
       )
     File(packageDir, "$CLASS_NAME.kt").writeText(content)
@@ -63,7 +66,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
 
     fun register(
       project: Project,
-      extension: SnapshotPreviewsExtension,
+      extension: SnapshotsExtension,
       android: BaseExtension,
       variant: ApplicationVariant,
       paparazziMajorVersion: Provider<Int>,
@@ -72,12 +75,13 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         "sentryGenerateSnapshotsTests${variant.name.capitalized}",
         GenerateSnapshotTestsTask::class.java,
       ) { task ->
-        task.includePrivatePreviews.set(extension.includePrivatePreviews)
-        task.theme.set(extension.theme)
+        task.includePrivatePreviews.set(extension.previews.includePrivatePreviews)
+        task.theme.set(extension.previews.theme)
+        task.diffThreshold.set(extension.diffThreshold)
         task.paparazziMajorVersion.value(paparazziMajorVersion)
         // Fall back to the Android namespace when the user doesn't configure packageTrees
         task.packageTrees.set(
-          extension.packageTrees.map { packages ->
+          extension.previews.packageTrees.map { packages ->
             packages.ifEmpty { listOf(android.namespace!!) }
           }
         )
@@ -92,6 +96,7 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
       includePrivatePreviews: Boolean,
       packageTrees: List<String>,
       theme: String? = null,
+      diffThreshold: Double = 0.0,
       paparazziMajorVersion: Int = 2,
     ): String {
       val includePrivateExpr =
@@ -232,7 +237,7 @@ private object PaparazziPreviewRule {
             true -> env
             false -> env.copy(compileSdkVersion = previewInfo.apiLevel)
         }
-        val tolerance = 0.0
+        val tolerance = $diffThreshold
         return Paparazzi(
             environment = environment,
             deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
@@ -385,7 +390,7 @@ class $CLASS_NAME(
         )
         if (info.group.isNotBlank()) metadata["group"] = info.group
 
-        val diffThreshold: Float? = runCatching {
+        val annotationThreshold: Float? = runCatching {
             val declaring = Class.forName(preview.declaringClass)
             val method = declaring.declaredMethods.firstOrNull { it.name == preview.methodName }
                 ?: return@runCatching null
@@ -394,7 +399,8 @@ class $CLASS_NAME(
             val ann = method.getAnnotation(annClass) ?: return@runCatching null
             annClass.getDeclaredMethod("diffThreshold").invoke(ann) as? Float
         }.getOrNull()
-        if (diffThreshold != null && diffThreshold != 0f) metadata["diff_threshold"] = diffThreshold
+        val effectiveThreshold = annotationThreshold ?: tolerance.toFloat()
+        if (effectiveThreshold != 0f) metadata["diff_threshold"] = effectiveThreshold
 
         if (tags.isNotEmpty()) metadata["tags"] = tags
         metadata["context"] = context

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -390,7 +390,7 @@ class $CLASS_NAME(
         )
         if (info.group.isNotBlank()) metadata["group"] = info.group
 
-        val annotationThreshold: Float? = runCatching {
+        val diffThreshold: Float? = runCatching {
             val declaring = Class.forName(preview.declaringClass)
             val method = declaring.declaredMethods.firstOrNull { it.name == preview.methodName }
                 ?: return@runCatching null
@@ -399,8 +399,7 @@ class $CLASS_NAME(
             val ann = method.getAnnotation(annClass) ?: return@runCatching null
             annClass.getDeclaredMethod("diffThreshold").invoke(ann) as? Float
         }.getOrNull()
-        val effectiveThreshold = annotationThreshold ?: tolerance.toFloat()
-        if (effectiveThreshold != 0f) metadata["diff_threshold"] = effectiveThreshold
+        if (diffThreshold != null && diffThreshold != 0f) metadata["diff_threshold"] = diffThreshold
 
         if (tags.isNotEmpty()) metadata["tags"] = tags
         metadata["context"] = context

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadSnapshotsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadSnapshotsTask.kt
@@ -37,6 +37,8 @@ abstract class SentryUploadSnapshotsTask : SentryCliExecTask() {
     snapshotsPath.set(project.file(path))
   }
 
+  @get:Input @get:Optional abstract val diffThreshold: Property<Double>
+
   @get:Input @get:Optional abstract val vcsHeadSha: Property<String>
   @get:Input @get:Optional abstract val vcsBaseSha: Property<String>
   @get:Input @get:Optional abstract val vcsProvider: Property<String>
@@ -51,6 +53,10 @@ abstract class SentryUploadSnapshotsTask : SentryCliExecTask() {
     args.add("snapshots")
     args.add("--app-id")
     args.add(appId.get())
+
+    diffThreshold.orNull?.let {
+      if (it != 0.0) args.addAll(listOf("--diff-threshold", it.toString()))
+    }
 
     vcsHeadSha.orNull?.let { args.addAll(listOf("--head-sha", it)) }
     vcsBaseSha.orNull?.let { args.addAll(listOf("--base-sha", it)) }
@@ -93,6 +99,7 @@ abstract class SentryUploadSnapshotsTask : SentryCliExecTask() {
         task.sentryAuthToken.set(extension.authToken)
         task.sentryUrl.set(extension.url)
         task.appId.set(applicationId)
+        task.diffThreshold.set(extension.snapshots.diffThreshold)
         task.vcsHeadSha.set(extension.vcsInfo.headSha)
         task.vcsBaseSha.set(extension.vcsInfo.baseSha)
         task.vcsProvider.set(extension.vcsInfo.vcsProvider)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/extensions/SnapshotsExtensionTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.gradle.extensions
 
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -14,6 +15,24 @@ class SnapshotsExtensionTest {
     val extension = project.objects.newInstance(SnapshotsExtension::class.java)
 
     assertFalse(extension.enabled.get())
+  }
+
+  @Test
+  fun `diffThreshold is zero by default`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    assertEquals(0.0, extension.diffThreshold.get())
+  }
+
+  @Test
+  fun `diffThreshold can be configured`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.objects.newInstance(SnapshotsExtension::class.java)
+
+    extension.diffThreshold.set(0.05)
+
+    assertEquals(0.05, extension.diffThreshold.get())
   }
 
   @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -141,7 +141,7 @@ class GenerateSnapshotTestsTaskTest {
 
     assertTrue(
       content.contains(
-        "if (diffThreshold != null && diffThreshold != 0f) metadata[\"diff_threshold\"] = diffThreshold"
+        "if (effectiveThreshold != 0f) metadata[\"diff_threshold\"] = effectiveThreshold"
       )
     )
   }
@@ -225,12 +225,35 @@ class GenerateSnapshotTestsTaskTest {
     assertFalse(content.contains("HtmlReportWriter()"))
   }
 
+  @Test
+  fun `generated file uses default tolerance of zero`() {
+    val content = generateAndRead(packageTrees = listOf("com.example"))
+
+    assertTrue(content.contains("val tolerance = 0.0"))
+  }
+
+  @Test
+  fun `generated file uses configured diffThreshold as tolerance`() {
+    val content = generateAndRead(packageTrees = listOf("com.example"), diffThreshold = 0.05)
+
+    assertTrue(content.contains("val tolerance = 0.05"))
+    assertFalse(content.contains("val tolerance = 0.0\n"))
+  }
+
+  @Test
+  fun `generated sidecar uses global threshold as fallback`() {
+    val content = generateAndRead(packageTrees = listOf("com.example"), diffThreshold = 0.02)
+
+    assertTrue(content.contains("val effectiveThreshold = annotationThreshold ?: tolerance.toFloat()"))
+  }
+
   private fun generateAndRead(
     packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
+    diffThreshold: Double = 0.0,
     paparazziMajorVersion: Int = 2,
   ): String {
-    val task = createTask(packageTrees, includePrivatePreviews, paparazziMajorVersion)
+    val task = createTask(packageTrees, includePrivatePreviews, diffThreshold, paparazziMajorVersion)
     task.generate()
     val file =
       File(task.outputDir.get().asFile, "io/sentry/snapshot/ComposablePreviewSnapshotTest.kt")
@@ -240,6 +263,7 @@ class GenerateSnapshotTestsTaskTest {
   private fun createTask(
     packageTrees: List<String>,
     includePrivatePreviews: Boolean = false,
+    diffThreshold: Double = 0.0,
     paparazziMajorVersion: Int = 2,
   ): GenerateSnapshotTestsTask {
     val project = ProjectBuilder.builder().build()
@@ -247,6 +271,7 @@ class GenerateSnapshotTestsTaskTest {
       .register("testGenerateSnapshotTests", GenerateSnapshotTestsTask::class.java) { task ->
         task.includePrivatePreviews.set(includePrivatePreviews)
         task.packageTrees.set(packageTrees)
+        task.diffThreshold.set(diffThreshold)
         task.paparazziMajorVersion.set(paparazziMajorVersion)
         task.outputDir.set(tmpDir.newFolder("output"))
       }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -141,7 +141,7 @@ class GenerateSnapshotTestsTaskTest {
 
     assertTrue(
       content.contains(
-        "if (effectiveThreshold != 0f) metadata[\"diff_threshold\"] = effectiveThreshold"
+        "if (diffThreshold != null && diffThreshold != 0f) metadata[\"diff_threshold\"] = diffThreshold"
       )
     )
   }
@@ -238,13 +238,6 @@ class GenerateSnapshotTestsTaskTest {
 
     assertTrue(content.contains("val tolerance = 0.05"))
     assertFalse(content.contains("val tolerance = 0.0\n"))
-  }
-
-  @Test
-  fun `generated sidecar uses global threshold as fallback`() {
-    val content = generateAndRead(packageTrees = listOf("com.example"), diffThreshold = 0.02)
-
-    assertTrue(content.contains("val effectiveThreshold = annotationThreshold ?: tolerance.toFloat()"))
   }
 
   private fun generateAndRead(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -237,7 +237,6 @@ class GenerateSnapshotTestsTaskTest {
     val content = generateAndRead(packageTrees = listOf("com.example"), diffThreshold = 0.05)
 
     assertTrue(content.contains("val tolerance = 0.05"))
-    assertFalse(content.contains("val tolerance = 0.0\n"))
   }
 
   private fun generateAndRead(
@@ -246,7 +245,8 @@ class GenerateSnapshotTestsTaskTest {
     diffThreshold: Double = 0.0,
     paparazziMajorVersion: Int = 2,
   ): String {
-    val task = createTask(packageTrees, includePrivatePreviews, diffThreshold, paparazziMajorVersion)
+    val task =
+      createTask(packageTrees, includePrivatePreviews, diffThreshold, paparazziMajorVersion)
     task.generate()
     val file =
       File(task.outputDir.get().asFile, "io/sentry/snapshot/ComposablePreviewSnapshotTest.kt")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadSnapshotsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadSnapshotsTaskTest.kt
@@ -157,6 +157,47 @@ class SentryUploadSnapshotsTaskTest {
   }
 
   @Test
+  fun `diffThreshold is passed to CLI when non-zero`() {
+    val task = createTestTask {
+      it.cliExecutable.set("sentry-cli")
+      it.appId.set("com.example")
+      it.snapshotsPath.set(File("/path/to/snapshots"))
+      it.diffThreshold.set(0.05)
+    }
+
+    val args = task.computeCommandLineArgs()
+
+    assertThat(args).containsAtLeast("--diff-threshold", "0.05").inOrder()
+  }
+
+  @Test
+  fun `diffThreshold is omitted when zero`() {
+    val task = createTestTask {
+      it.cliExecutable.set("sentry-cli")
+      it.appId.set("com.example")
+      it.snapshotsPath.set(File("/path/to/snapshots"))
+      it.diffThreshold.set(0.0)
+    }
+
+    val args = task.computeCommandLineArgs()
+
+    assertThat(args).doesNotContain("--diff-threshold")
+  }
+
+  @Test
+  fun `diffThreshold is omitted when not set`() {
+    val task = createTestTask {
+      it.cliExecutable.set("sentry-cli")
+      it.appId.set("com.example")
+      it.snapshotsPath.set(File("/path/to/snapshots"))
+    }
+
+    val args = task.computeCommandLineArgs()
+
+    assertThat(args).doesNotContain("--diff-threshold")
+  }
+
+  @Test
   fun `vcs parameters are omitted when not set`() {
     val task = createTestTask {
       it.cliExecutable.set("sentry-cli")


### PR DESCRIPTION
## Summary
- Adds a `diffThreshold` property to `SnapshotsExtension` (default `0.0`) so users can set a global pixel-difference tolerance for all snapshots via the DSL
- The generated Paparazzi test uses this value as the tolerance instead of a hardcoded `0.0`
- Passed as `--diff-threshold` to the CLI upload command

```kotlin
sentry {
  snapshots {
    enabled.set(true)
    diffThreshold.set(0.05) // 5% tolerance for all snapshots
  }
}
```

EME-1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)