### PR TITLE
chore: Add binary gitattributes for bin, zip, and gpg files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,9 @@
 *.png           binary
 *.jpg           binary
 *.jpeg          binary
+*.bin           binary
+*.zip           binary
 *.jar           binary
+*.gpg           binary
 *.class         binary
 *.db            binary


### PR DESCRIPTION
## Summary
- Add `*.bin`, `*.zip`, and `*.gpg` as binary file types in `.gitattributes`
- `*.jar` was already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)