### PR TITLE
ci: Add Gradle ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: "gradle"
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
## Summary

- Adds the `gradle` package ecosystem to Dependabot so it will automatically open PRs for Gradle wrapper updates.
- Previously only `github-actions` was configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)