### PR TITLE
fix(snapshot): Use string values for all tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix snapshot upload error by using string values for all sidecar tags ([#1199](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1199))
+
 ## 6.7.0
 
 ### Features

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -364,16 +364,16 @@ class $CLASS_NAME(
         imagesDir.mkdirs()
         val info = preview.previewInfo
 
-        val tags = linkedMapOf<String, Any>()
+        val tags = linkedMapOf<String, String>()
         if (info.name.isNotBlank()) tags["preview_name"] = info.name
         if (info.locale.isNotBlank()) tags["locale"] = info.locale
         if (info.device.isNotBlank()) tags["device"] = info.device
-        if (info.fontScale != 1f) tags["font_scale"] = info.fontScale
-        if (info.apiLevel != -1) tags["api_level"] = info.apiLevel
-        if (info.widthDp > 0) tags["width_dp"] = info.widthDp
-        if (info.heightDp > 0) tags["height_dp"] = info.heightDp
-        if (info.showSystemUi) tags["show_system_ui"] = true
-        if (info.showBackground) tags["show_background"] = true
+        if (info.fontScale != 1f) tags["font_scale"] = info.fontScale.toString()
+        if (info.apiLevel != -1) tags["api_level"] = info.apiLevel.toString()
+        if (info.widthDp > 0) tags["width_dp"] = info.widthDp.toString()
+        if (info.heightDp > 0) tags["height_dp"] = info.heightDp.toString()
+        if (info.showSystemUi) tags["show_system_ui"] = "true"
+        if (info.showBackground) tags["show_background"] = "true"
         when (info.uiMode and UI_MODE_NIGHT_MASK) {
             UI_MODE_NIGHT_YES -> tags["ui_mode"] = "dark"
             UI_MODE_NIGHT_NO -> tags["ui_mode"] = "light"

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -165,10 +165,18 @@ class GenerateSnapshotTestsTaskTest {
     assertTrue(content.contains("if (info.name.isNotBlank()) tags[\"preview_name\"] = info.name"))
     assertTrue(content.contains("if (info.locale.isNotBlank()) tags[\"locale\"] = info.locale"))
     assertTrue(content.contains("if (info.device.isNotBlank()) tags[\"device\"] = info.device"))
-    assertTrue(content.contains("if (info.fontScale != 1f) tags[\"font_scale\"] = info.fontScale.toString()"))
-    assertTrue(content.contains("if (info.apiLevel != -1) tags[\"api_level\"] = info.apiLevel.toString()"))
-    assertTrue(content.contains("if (info.widthDp > 0) tags[\"width_dp\"] = info.widthDp.toString()"))
-    assertTrue(content.contains("if (info.heightDp > 0) tags[\"height_dp\"] = info.heightDp.toString()"))
+    assertTrue(
+      content.contains("if (info.fontScale != 1f) tags[\"font_scale\"] = info.fontScale.toString()")
+    )
+    assertTrue(
+      content.contains("if (info.apiLevel != -1) tags[\"api_level\"] = info.apiLevel.toString()")
+    )
+    assertTrue(
+      content.contains("if (info.widthDp > 0) tags[\"width_dp\"] = info.widthDp.toString()")
+    )
+    assertTrue(
+      content.contains("if (info.heightDp > 0) tags[\"height_dp\"] = info.heightDp.toString()")
+    )
     assertTrue(content.contains("if (info.showSystemUi) tags[\"show_system_ui\"] = \"true\""))
     assertTrue(content.contains("if (info.showBackground) tags[\"show_background\"] = \"true\""))
     assertTrue(content.contains("if (tags.isNotEmpty()) metadata[\"tags\"] = tags"))

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -161,16 +161,16 @@ class GenerateSnapshotTestsTaskTest {
   fun `generated sidecar places appearance inputs in tags block`() {
     val content = generateAndRead(packageTrees = listOf("com.example"))
 
-    assertTrue(content.contains("val tags = linkedMapOf<String, Any>()"))
+    assertTrue(content.contains("val tags = linkedMapOf<String, String>()"))
     assertTrue(content.contains("if (info.name.isNotBlank()) tags[\"preview_name\"] = info.name"))
     assertTrue(content.contains("if (info.locale.isNotBlank()) tags[\"locale\"] = info.locale"))
     assertTrue(content.contains("if (info.device.isNotBlank()) tags[\"device\"] = info.device"))
-    assertTrue(content.contains("if (info.fontScale != 1f) tags[\"font_scale\"] = info.fontScale"))
-    assertTrue(content.contains("if (info.apiLevel != -1) tags[\"api_level\"] = info.apiLevel"))
-    assertTrue(content.contains("if (info.widthDp > 0) tags[\"width_dp\"] = info.widthDp"))
-    assertTrue(content.contains("if (info.heightDp > 0) tags[\"height_dp\"] = info.heightDp"))
-    assertTrue(content.contains("if (info.showSystemUi) tags[\"show_system_ui\"] = true"))
-    assertTrue(content.contains("if (info.showBackground) tags[\"show_background\"] = true"))
+    assertTrue(content.contains("if (info.fontScale != 1f) tags[\"font_scale\"] = info.fontScale.toString()"))
+    assertTrue(content.contains("if (info.apiLevel != -1) tags[\"api_level\"] = info.apiLevel.toString()"))
+    assertTrue(content.contains("if (info.widthDp > 0) tags[\"width_dp\"] = info.widthDp.toString()"))
+    assertTrue(content.contains("if (info.heightDp > 0) tags[\"height_dp\"] = info.heightDp.toString()"))
+    assertTrue(content.contains("if (info.showSystemUi) tags[\"show_system_ui\"] = \"true\""))
+    assertTrue(content.contains("if (info.showBackground) tags[\"show_background\"] = \"true\""))
     assertTrue(content.contains("if (tags.isNotEmpty()) metadata[\"tags\"] = tags"))
   }
 


### PR DESCRIPTION
## Summary
- Changed the tags map type from `Map<String, Any>` to `Map<String, String>` in the generated snapshot sidecar
- Numeric tags (`font_scale`, `api_level`, `width_dp`, `height_dp`) now use `.toString()`
- Boolean tags (`show_system_ui`, `show_background`) now use `"true"` instead of `true`

Fixes EME-1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)