### PR TITLE
feat(telemetry): Add coreLibraryDesugaring and minSdk tags

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -2,6 +2,7 @@
 
 package io.sentry.android.gradle.telemetry
 
+import com.android.build.gradle.BaseExtension
 import io.sentry.BuildConfig
 import io.sentry.IHub
 import io.sentry.ISpan
@@ -12,7 +13,6 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SpanStatus
 import io.sentry.TransactionOptions
-import com.android.build.gradle.BaseExtension
 import io.sentry.android.gradle.SentryCliProvider
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.SentryPlugin.Companion.logger
@@ -401,9 +401,7 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
             "coreLibraryDesugaring_enabled",
             android.compileOptions.isCoreLibraryDesugaringEnabled.toString(),
           )
-          android.defaultConfig.minSdkVersion?.apiLevel?.let {
-            tags.put("minSdk", it.toString())
-          }
+          android.defaultConfig.minSdkVersion?.apiLevel?.let { tags.put("minSdk", it.toString()) }
         }
       } catch (_: Throwable) {
         // Android extensions may not be available (e.g. JVM plugin)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -12,6 +12,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SpanStatus
 import io.sentry.TransactionOptions
+import com.android.build.gradle.BaseExtension
 import io.sentry.android.gradle.SentryCliProvider
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.SentryPlugin.Companion.logger
@@ -392,6 +393,21 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
       )
       // TODO PII?
       //            extension.projectName.orNull?.let { tags.put("projectName", it) }
+
+      try {
+        val android = project.extensions.findByType(BaseExtension::class.java)
+        if (android != null) {
+          tags.put(
+            "coreLibraryDesugaring_enabled",
+            android.compileOptions.isCoreLibraryDesugaringEnabled.toString(),
+          )
+          android.defaultConfig.minSdkVersion?.apiLevel?.let {
+            tags.put("minSdk", it.toString())
+          }
+        }
+      } catch (_: Throwable) {
+        // Android extensions may not be available (e.g. JVM plugin)
+      }
 
       return tags
     }


### PR DESCRIPTION
## Summary
- Adds `coreLibraryDesugaring_enabled` and `minSdk` telemetry tags to track desugaring adoption when `minSdk < 26`
- Reads from `BaseExtension.compileOptions.isCoreLibraryDesugaringEnabled` and `defaultConfig.minSdkVersion`
- Gracefully no-ops for the JVM plugin where `BaseExtension` is not available

#skip-changelog

Fixes GRADLE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)