### PR TITLE
fix: Remove BaseExtension usage for AGP 9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fail fast with a clear error when Snapshots feature is used with AGP 7.x ([#1212](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1212))
+
 ## 6.8.0
 
 ### Dependencies

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -468,6 +468,10 @@ private fun ApplicationVariant.configureSnapshotsTasks(
   sentryOrg: String?,
   sentryProject: String?,
 ) {
+  check(AgpVersions.CURRENT >= AgpVersions.VERSION_8_0_0) {
+    "Sentry Snapshots require Android Gradle Plugin 8.0 or higher. " +
+      "Current version: ${AgpVersions.CURRENT}"
+  }
   val variant = AndroidVariant74(this)
   val sentryProps = getPropertiesFilePath(project, variant)
   val taskSuffix = name.capitalized

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -11,7 +11,6 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.android.build.api.variant.Variant
-import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.utils.setDisallowChanges
 import io.sentry.BuildConfig
 import io.sentry.android.gradle.SentryPlugin.Companion.sep
@@ -490,8 +489,6 @@ private fun ApplicationVariant.configureSnapshotsTasks(
   // Wire Paparazzi test generation and upload task when the Paparazzi plugin is applied
   project.pluginManager.withPlugin("app.cash.paparazzi") {
     if (extension.snapshots.previews.generateTests.get()) {
-      val android = project.extensions.getByType(BaseExtension::class.java)
-
       project.dependencies.add(
         "testImplementation",
         "io.github.sergio-sastre.ComposablePreviewScanner:android:${BuildConfig.ComposablePreviewScannerVersion}",
@@ -510,7 +507,6 @@ private fun ApplicationVariant.configureSnapshotsTasks(
         GenerateSnapshotTestsTask.register(
           project,
           extension.snapshots,
-          android,
           this@configureSnapshotsTasks,
           paparazziMajorVersion,
         )

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -1,7 +1,6 @@
 package io.sentry.android.gradle.snapshot
 
 import com.android.build.api.variant.ApplicationVariant
-import com.android.build.gradle.BaseExtension
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
 import io.sentry.android.gradle.extensions.SnapshotsExtension
 import java.io.File
@@ -67,7 +66,6 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
     fun register(
       project: Project,
       extension: SnapshotsExtension,
-      android: BaseExtension,
       variant: ApplicationVariant,
       paparazziMajorVersion: Provider<Int>,
     ): TaskProvider<GenerateSnapshotTestsTask> {
@@ -79,10 +77,9 @@ abstract class GenerateSnapshotTestsTask : DefaultTask() {
         task.theme.set(extension.previews.theme)
         task.diffThreshold.set(extension.diffThreshold)
         task.paparazziMajorVersion.value(paparazziMajorVersion)
-        // Fall back to the Android namespace when the user doesn't configure packageTrees
         task.packageTrees.set(
-          extension.previews.packageTrees.map { packages ->
-            packages.ifEmpty { listOf(android.namespace!!) }
+          extension.previews.packageTrees.zip(variant.namespace) { packages, ns ->
+            packages.ifEmpty { listOf(ns) }
           }
         )
         task.outputDir.set(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -2,7 +2,7 @@
 
 package io.sentry.android.gradle.telemetry
 
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.CommonExtension
 import io.sentry.BuildConfig
 import io.sentry.IHub
 import io.sentry.ISpan
@@ -395,13 +395,13 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
       //            extension.projectName.orNull?.let { tags.put("projectName", it) }
 
       try {
-        val android = project.extensions.findByType(BaseExtension::class.java)
+        val android = project.extensions.findByType(CommonExtension::class.java)
         if (android != null) {
           tags.put(
             "coreLibraryDesugaring_enabled",
             android.compileOptions.isCoreLibraryDesugaringEnabled.toString(),
           )
-          android.defaultConfig.minSdkVersion?.apiLevel?.let { tags.put("minSdk", it.toString()) }
+          android.defaultConfig.minSdk?.let { tags.put("minSdk", it.toString()) }
         }
       } catch (_: Throwable) {
         // Android extensions may not be available (e.g. JVM plugin)

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -7,6 +7,7 @@ import org.gradle.util.GradleVersion
 internal object AgpVersions {
   val CURRENT: SemVer = SemVer.parse(Version.ANDROID_GRADLE_PLUGIN_VERSION)
   val VERSION_7_4_0: SemVer = SemVer.parse("7.4.0-rc01")
+  val VERSION_8_0_0: SemVer = SemVer.parse("8.0.0")
   val VERSION_8_3_0: SemVer = SemVer.parse("8.3.0")
   val VERSION_9_0_0: SemVer = SemVer.parse("9.0.0")
 


### PR DESCRIPTION
`BaseExtension` isn't deprecated when compiling against AGP 8.X but it is suddenly removed in AGP 9.X :(
See docs: https://developer.android.com/build/releases/agp-9-0-0-release-notes

This removes all usages of it.

Separately because of a subtle bug that seer pointed out, I decided that we don't support AGP 7.X with snapshots. In that case we'll throw a clear error message when snapshots are enabled. https://github.com/getsentry/sentry-android-gradle-plugin/pull/1212#discussion_r3281187354