### PR TITLE
fix: Remove AGP 7.x R8 workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,4 @@
-buildscript {
-  dependencies { classpath("org.apache.commons:commons-compress:1.28.0") }
-}
+buildscript { dependencies { classpath("org.apache.commons:commons-compress:1.28.0") } }
 
 plugins {
   alias(libs.plugins.kotlin) version BuildPluginsVersion.KOTLIN apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,5 @@
 buildscript {
   dependencies { classpath("org.apache.commons:commons-compress:1.28.0") }
-  if (BuildPluginsVersion.AGP.substringBefore(".").toInt() < 8) {
-    // AGP 7.x has troubles with compileSdk 34 due to some R8 shenanigans, so we have to use a newer
-    // version of R* here
-    dependencies { classpath("com.android.tools:r8:8.11.18") }
-  }
 }
 
 plugins {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -74,11 +74,6 @@ abstract class BaseSentryPluginTest(
                 // withPluginClasspath on the Gradle Runner.
                 $additionalBuildClasspath
                 classpath files($pluginClasspath)
-                if ("$androidGradlePluginVersion".split('\\.')[0].toInteger() < 8) {
-                  // AGP 7.x has troubles with compileSdk 34 due to some R8 shenanigans, so we have to use a newer
-                  // version of R* here
-                  classpath 'com.android.tools:r8:8.11.18'
-                }
               }
             }
 


### PR DESCRIPTION
## Summary
- Remove the conditional R8 classpath override that was only needed for AGP 7.x compatibility with compileSdk 34
- AGP 7.x is no longer in the CI matrix and the default AGP version is 8.10.1, making this dead code
- Removes the workaround from both `build.gradle.kts` and the test template in `BaseSentryPluginTest.kt`

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)