### PR TITLE
chore(ci): Update CODEOWNERS to include @0xadam-brown

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @markushi @romtsn @adinauer @runningcode @chromy @rbro112
+*       @markushi @romtsn @adinauer @runningcode @0xadam-brown


### PR DESCRIPTION
_#skip-changelog_

Also removed Hector and Ryan since they are on the Seer team now.