### PR TITLE
ref(gradle): Replace File with DirectoryProperty in SentryCliProvider

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -13,7 +13,6 @@ import com.android.build.api.variant.HostTestBuilder.Companion.UNIT_TEST_TYPE
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.utils.setDisallowChanges
 import io.sentry.BuildConfig
-import io.sentry.android.gradle.SentryPlugin.Companion.sep
 import io.sentry.android.gradle.SentryPropertiesFileProvider.getPropertiesFilePath
 import io.sentry.android.gradle.SentryTasksProvider.capitalized
 import io.sentry.android.gradle.SentryTasksProvider.getAssembleTaskProvider
@@ -43,7 +42,6 @@ import io.sentry.android.gradle.util.SentryPluginUtils.isMinificationEnabled
 import io.sentry.android.gradle.util.SentryPluginUtils.isVariantAllowed
 import io.sentry.android.gradle.util.collectModules
 import io.sentry.android.gradle.util.hookWithAssembleTasks
-import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
@@ -61,7 +59,8 @@ fun ApplicationAndroidComponentsExtension.configure(
   sentryProject: String?,
 ) {
   // temp folder for sentry-related stuff
-  val tmpDir = project.layout.buildDirectory.dir("sentry-tmp").map { it.file("sentry") }.get().asFile
+  val tmpDir =
+    project.layout.buildDirectory.dir("sentry-tmp").map { it.file("sentry") }.get().asFile
   tmpDir.mkdirs()
 
   onVariants { variant ->

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -59,8 +59,7 @@ fun ApplicationAndroidComponentsExtension.configure(
   sentryProject: String?,
 ) {
   // temp folder for sentry-related stuff
-  val tmpDir =
-    project.layout.buildDirectory.dir("tmp").map { it.file("sentry") }.get().asFile
+  val tmpDir = project.layout.buildDirectory.dir("tmp").map { it.file("sentry") }.get().asFile
   tmpDir.mkdirs()
 
   onVariants { variant ->

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -60,7 +60,7 @@ fun ApplicationAndroidComponentsExtension.configure(
 ) {
   // temp folder for sentry-related stuff
   val tmpDir =
-    project.layout.buildDirectory.dir("sentry-tmp").map { it.file("sentry") }.get().asFile
+    project.layout.buildDirectory.dir("tmp").map { it.file("sentry") }.get().asFile
   tmpDir.mkdirs()
 
   onVariants { variant ->

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -61,7 +61,7 @@ fun ApplicationAndroidComponentsExtension.configure(
   sentryProject: String?,
 ) {
   // temp folder for sentry-related stuff
-  val tmpDir = File("${project.buildDir}${sep}tmp${sep}sentry")
+  val tmpDir = project.layout.buildDirectory.dir("sentry-tmp").map { it.file("sentry") }.get().asFile
   tmpDir.mkdirs()
 
   onVariants { variant ->

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -206,7 +206,7 @@ fun Project.cliExecutableProvider(): Provider<String> {
   }
 }
 
-fun Project.getIsolatedRootProjectDir(): Directory {
+private fun Project.getIsolatedRootProjectDir(): Directory {
   return if (GradleVersions.CURRENT >= GradleVersions.VERSION_8_8) {
     isolated.rootProject.projectDirectory
   } else {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -5,6 +5,7 @@ package io.sentry.android.gradle
 import io.sentry.BuildConfig
 import io.sentry.android.gradle.SentryCliValueSource.Params
 import io.sentry.android.gradle.SentryPlugin.Companion.logger
+import io.sentry.android.gradle.util.GradleVersions
 import io.sentry.android.gradle.util.error
 import io.sentry.android.gradle.util.info
 import java.io.File
@@ -13,6 +14,7 @@ import java.io.FileOutputStream
 import java.util.Locale
 import java.util.Properties
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -198,8 +200,16 @@ fun Project.cliExecutableProvider(): Provider<String> {
   // config-cache compatible way to retrieve the cli path, it properly gets invalidated when
   // e.g. switching branches
   return providers.of(SentryCliValueSource::class.java) {
-    it.parameters.projectDir.set(project.layout.projectDirectory)
-    it.parameters.projectBuildDir.set(project.layout.buildDirectory)
-    it.parameters.rootProjDir.set(project.rootProject.layout.projectDirectory)
+    it.parameters.projectDir.set(layout.projectDirectory)
+    it.parameters.projectBuildDir.set(layout.buildDirectory)
+    it.parameters.rootProjDir.set(getIsolatedRootProjectDir())
+  }
+}
+
+fun Project.getIsolatedRootProjectDir(): Directory {
+  return if (GradleVersions.CURRENT >= GradleVersions.VERSION_8_8) {
+    isolated.rootProject.projectDirectory
+  } else {
+    rootProject.layout.projectDirectory
   }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -15,7 +15,6 @@ import java.util.Properties
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -34,7 +33,11 @@ internal object SentryCliProvider {
    */
   @JvmStatic
   @Synchronized
-  fun getSentryCliPath(projectDir: DirectoryProperty, projectBuildDir: DirectoryProperty, rootDir: DirectoryProperty): String {
+  fun getSentryCliPath(
+    projectDir: DirectoryProperty,
+    projectBuildDir: DirectoryProperty,
+    rootDir: DirectoryProperty,
+  ): String {
     val cliPath = memoizedCliPath
     if (!cliPath.isNullOrEmpty() && File(cliPath).exists()) {
       logger.info { "Using memoized cli path: $cliPath" }
@@ -55,7 +58,8 @@ internal object SentryCliProvider {
       logger.info { "cli present in resources: $cliResLocation" }
       // just provide the target extraction path
       // actual extraction will be done prior to task execution
-      val extractedResourcePath = getCliResourcesExtractionPath(projectBuildDir).get().asFile.absolutePath
+      val extractedResourcePath =
+        getCliResourcesExtractionPath(projectBuildDir).get().asFile.absolutePath
       memoizedCliPath = extractedResourcePath
       return extractedResourcePath
     }
@@ -85,13 +89,19 @@ internal object SentryCliProvider {
     return null
   }
 
-  internal fun getSentryPropertiesPath(projectDir: DirectoryProperty, rootDir: DirectoryProperty): String? =
+  internal fun getSentryPropertiesPath(
+    projectDir: DirectoryProperty,
+    rootDir: DirectoryProperty,
+  ): String? =
     listOf(projectDir.file("sentry.properties"), rootDir.file("sentry.properties"))
       .map { it.get().asFile }
       .firstOrNull(File::exists)
       ?.path
 
-  internal fun searchCliInPropertiesFile(projectDir: DirectoryProperty, rootDir: DirectoryProperty): String? {
+  internal fun searchCliInPropertiesFile(
+    projectDir: DirectoryProperty,
+    rootDir: DirectoryProperty,
+  ): String? {
     return getSentryPropertiesPath(projectDir, rootDir)?.let { propertiesFile ->
       runCatching {
           Properties().apply { load(FileInputStream(propertiesFile)) }.getProperty("cli.executable")
@@ -103,7 +113,9 @@ internal object SentryCliProvider {
   internal fun getResourceUrl(resourcePath: String): String? =
     javaClass.getResource(resourcePath)?.toString()
 
-  internal fun getCliResourcesExtractionPath(projectBuildDir: DirectoryProperty): Provider<RegularFile> {
+  internal fun getCliResourcesExtractionPath(
+    projectBuildDir: DirectoryProperty
+  ): Provider<RegularFile> {
     // usually <project>/build/tmp/
     return projectBuildDir.dir("tmp").map { it.file("sentry-cli-${BuildConfig.CliVersion}.exe") }
   }
@@ -149,7 +161,11 @@ internal object SentryCliProvider {
     val cli = File(cliPath)
     if (!cli.exists()) {
       // we only want to auto-extract if the path matches the pre-computed one
-      if (File(cliPath).absolutePath.equals(getCliResourcesExtractionPath(buildDir).get().asFile.absolutePath)) {
+      if (
+        File(cliPath)
+          .absolutePath
+          .equals(getCliResourcesExtractionPath(buildDir).get().asFile.absolutePath)
+      ) {
         val cliResPath = getCliLocationInResources()
         if (!cliResPath.isNullOrBlank()) {
           return extractCliFromResources(cliResPath, cli) ?: cliPath

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -87,7 +87,7 @@ internal object SentryCliProvider {
 
   internal fun getSentryPropertiesPath(projectDir: DirectoryProperty, rootDir: DirectoryProperty): String? =
     listOf(projectDir.file("sentry.properties"), rootDir.file("sentry.properties"))
-      .map({directory -> directory.get().asFile})
+      .map { it.get().asFile }
       .firstOrNull(File::exists)
       ?.path
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -13,6 +13,8 @@ import java.io.FileOutputStream
 import java.util.Locale
 import java.util.Properties
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
@@ -32,7 +34,7 @@ internal object SentryCliProvider {
    */
   @JvmStatic
   @Synchronized
-  fun getSentryCliPath(projectDir: File, projectBuildDir: File, rootDir: File): String {
+  fun getSentryCliPath(projectDir: DirectoryProperty, projectBuildDir: DirectoryProperty, rootDir: DirectoryProperty): String {
     val cliPath = memoizedCliPath
     if (!cliPath.isNullOrEmpty() && File(cliPath).exists()) {
       logger.info { "Using memoized cli path: $cliPath" }
@@ -53,7 +55,7 @@ internal object SentryCliProvider {
       logger.info { "cli present in resources: $cliResLocation" }
       // just provide the target extraction path
       // actual extraction will be done prior to task execution
-      val extractedResourcePath = getCliResourcesExtractionPath(projectBuildDir).absolutePath
+      val extractedResourcePath = getCliResourcesExtractionPath(projectBuildDir).get().asFile.absolutePath
       memoizedCliPath = extractedResourcePath
       return extractedResourcePath
     }
@@ -83,12 +85,13 @@ internal object SentryCliProvider {
     return null
   }
 
-  internal fun getSentryPropertiesPath(projectDir: File, rootDir: File): String? =
-    listOf(File(projectDir, "sentry.properties"), File(rootDir, "sentry.properties"))
+  internal fun getSentryPropertiesPath(projectDir: DirectoryProperty, rootDir: DirectoryProperty): String? =
+    listOf(projectDir.file("sentry.properties"), rootDir.file("sentry.properties"))
+      .map({directory -> directory.get().asFile})
       .firstOrNull(File::exists)
       ?.path
 
-  internal fun searchCliInPropertiesFile(projectDir: File, rootDir: File): String? {
+  internal fun searchCliInPropertiesFile(projectDir: DirectoryProperty, rootDir: DirectoryProperty): String? {
     return getSentryPropertiesPath(projectDir, rootDir)?.let { propertiesFile ->
       runCatching {
           Properties().apply { load(FileInputStream(propertiesFile)) }.getProperty("cli.executable")
@@ -100,9 +103,9 @@ internal object SentryCliProvider {
   internal fun getResourceUrl(resourcePath: String): String? =
     javaClass.getResource(resourcePath)?.toString()
 
-  internal fun getCliResourcesExtractionPath(projectBuildDir: File): File {
+  internal fun getCliResourcesExtractionPath(projectBuildDir: DirectoryProperty): Provider<RegularFile> {
     // usually <project>/build/tmp/
-    return File(File(projectBuildDir, "tmp"), "sentry-cli-${BuildConfig.CliVersion}.exe")
+    return projectBuildDir.dir("tmp").map { it.file("sentry-cli-${BuildConfig.CliVersion}.exe") }
   }
 
   internal fun extractCliFromResources(resourcePath: String, outputPath: File): String? {
@@ -142,11 +145,11 @@ internal object SentryCliProvider {
 
   /** Tries to extract the sentry-cli from resources if the computedCliPath does not exist. */
   @Synchronized
-  internal fun maybeExtractFromResources(buildDir: File, cliPath: String): String {
+  internal fun maybeExtractFromResources(buildDir: DirectoryProperty, cliPath: String): String {
     val cli = File(cliPath)
     if (!cli.exists()) {
       // we only want to auto-extract if the path matches the pre-computed one
-      if (File(cliPath).absolutePath.equals(getCliResourcesExtractionPath(buildDir).absolutePath)) {
+      if (File(cliPath).absolutePath.equals(getCliResourcesExtractionPath(buildDir).get().asFile.absolutePath)) {
         val cliResPath = getCliLocationInResources()
         if (!cliResPath.isNullOrBlank()) {
           return extractCliFromResources(cliResPath, cli) ?: cliPath
@@ -159,18 +162,18 @@ internal object SentryCliProvider {
 
 abstract class SentryCliValueSource : ValueSource<String, Params> {
   interface Params : ValueSourceParameters {
-    @get:Input val projectDir: Property<File>
+    @get:Input val projectDir: DirectoryProperty
 
-    @get:Input val projectBuildDir: Property<File>
+    @get:Input val projectBuildDir: DirectoryProperty
 
-    @get:Input val rootProjDir: Property<File>
+    @get:Input val rootProjDir: DirectoryProperty
   }
 
   override fun obtain(): String? {
     return SentryCliProvider.getSentryCliPath(
-      parameters.projectDir.get(),
-      parameters.projectBuildDir.get(),
-      parameters.rootProjDir.get(),
+      parameters.projectDir,
+      parameters.projectBuildDir,
+      parameters.rootProjDir,
     )
   }
 }
@@ -179,8 +182,8 @@ fun Project.cliExecutableProvider(): Provider<String> {
   // config-cache compatible way to retrieve the cli path, it properly gets invalidated when
   // e.g. switching branches
   return providers.of(SentryCliValueSource::class.java) {
-    it.parameters.projectDir.set(project.projectDir)
-    it.parameters.projectBuildDir.set(project.layout.buildDirectory.asFile.get())
-    it.parameters.rootProjDir.set(project.rootDir)
+    it.parameters.projectDir.set(project.layout.projectDirectory)
+    it.parameters.projectBuildDir.set(project.layout.buildDirectory)
+    it.parameters.rootProjDir.set(project.rootProject.layout.projectDirectory)
   }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt
@@ -4,12 +4,10 @@ import io.sentry.android.gradle.SentryCliProvider
 import io.sentry.android.gradle.telemetry.SentryTelemetryService
 import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.setSentryPipelineEnv
-import java.io.File
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -94,8 +92,7 @@ abstract class SentryCliExecTask : Exec() {
       args.add(1, "/c")
     }
 
-    val cliPath =
-      SentryCliProvider.maybeExtractFromResources(buildDirectory, cliExecutable.get())
+    val cliPath = SentryCliProvider.maybeExtractFromResources(buildDirectory, cliExecutable.get())
     args.add(cliPath)
     args.addAll(preArgs())
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt
@@ -6,6 +6,7 @@ import io.sentry.android.gradle.util.info
 import io.sentry.android.gradle.util.setSentryPipelineEnv
 import java.io.File
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -40,7 +41,7 @@ abstract class SentryCliExecTask : Exec() {
 
   @get:Internal abstract val sentryTelemetryService: Property<SentryTelemetryService>
 
-  private val buildDirectory: Provider<File> = project.layout.buildDirectory.asFile
+  private val buildDirectory: DirectoryProperty = project.layout.buildDirectory
 
   override fun exec() {
     computeCommandLineArgs().let {
@@ -94,7 +95,7 @@ abstract class SentryCliExecTask : Exec() {
     }
 
     val cliPath =
-      SentryCliProvider.maybeExtractFromResources(buildDirectory.get(), cliExecutable.get())
+      SentryCliProvider.maybeExtractFromResources(buildDirectory, cliExecutable.get())
     args.add(cliPath)
     args.addAll(preArgs())
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -442,7 +442,7 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
       execOperations.exec {
         it.isIgnoreExitValue = true
         SentryCliProvider.maybeExtractFromResources(
-          parameters.buildDirectory.get().asFile,
+          parameters.buildDirectory,
           parameters.cliExecutable.get(),
         )
 
@@ -499,7 +499,7 @@ abstract class SentryCliVersionValueSource : ValueSource<String, VersionParams> 
     execOperations.exec {
       it.isIgnoreExitValue = true
       SentryCliProvider.maybeExtractFromResources(
-        parameters.buildDirectory.get().asFile,
+        parameters.buildDirectory,
         parameters.cliExecutable.get(),
       )
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -21,6 +21,7 @@ internal object AgpVersions {
 internal object GradleVersions {
   val CURRENT: SemVer = SemVer.parse(GradleVersion.current().version)
   val VERSION_8_0: SemVer = SemVer.parse("8.0")
+  val VERSION_8_8: SemVer = SemVer.parse("8.8")
 }
 
 internal object SentryVersions {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -68,7 +68,10 @@ class SentryCliProviderTest {
 
     testProjectDir.newFile("sentry.properties").apply { writeText("cli.executable=vim") }
 
-    assertEquals("vim", searchCliInPropertiesFile(dirProp(project.projectDir), dirProp(project.rootDir)))
+    assertEquals(
+      "vim",
+      searchCliInPropertiesFile(dirProp(project.projectDir), dirProp(project.rootDir)),
+    )
   }
 
   @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -23,6 +24,11 @@ class SentryCliProviderTest {
 
   @get:Rule val systemPropertyRule = SystemPropertyRule()
 
+  private fun dirProp(dir: File): DirectoryProperty {
+    val project = ProjectBuilder.builder().build()
+    return project.objects.directoryProperty().apply { set(dir) }
+  }
+
   @Test
   fun `getSentryPropertiesPath returns local properties file`() {
     val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
@@ -31,7 +37,7 @@ class SentryCliProviderTest {
 
     assertEquals(
       project.file("sentry.properties").path,
-      getSentryPropertiesPath(project.projectDir, project.rootDir),
+      getSentryPropertiesPath(dirProp(project.projectDir), dirProp(project.rootDir)),
     )
   }
 
@@ -45,7 +51,7 @@ class SentryCliProviderTest {
 
     assertEquals(
       topLevelProject.file("sentry.properties").path,
-      getSentryPropertiesPath(project.projectDir, project.rootDir),
+      getSentryPropertiesPath(dirProp(project.projectDir), dirProp(project.rootDir)),
     )
   }
 
@@ -53,7 +59,7 @@ class SentryCliProviderTest {
   fun `getSentryPropertiesPath returns null if no properties file is found`() {
     val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
 
-    assertNull(getSentryPropertiesPath(project.projectDir, project.rootDir))
+    assertNull(getSentryPropertiesPath(dirProp(project.projectDir), dirProp(project.rootDir)))
   }
 
   @Test
@@ -62,7 +68,7 @@ class SentryCliProviderTest {
 
     testProjectDir.newFile("sentry.properties").apply { writeText("cli.executable=vim") }
 
-    assertEquals("vim", searchCliInPropertiesFile(project.projectDir, project.rootDir))
+    assertEquals("vim", searchCliInPropertiesFile(dirProp(project.projectDir), dirProp(project.rootDir)))
   }
 
   @Test
@@ -71,7 +77,7 @@ class SentryCliProviderTest {
 
     testProjectDir.newFile("sentry.properties").apply { writeText("another=field") }
 
-    assertNull(searchCliInPropertiesFile(project.projectDir, project.rootDir))
+    assertNull(searchCliInPropertiesFile(dirProp(project.projectDir), dirProp(project.rootDir)))
   }
 
   @Test
@@ -80,14 +86,14 @@ class SentryCliProviderTest {
 
     testProjectDir.newFile("sentry.properties")
 
-    assertNull(searchCliInPropertiesFile(project.projectDir, project.rootDir))
+    assertNull(searchCliInPropertiesFile(dirProp(project.projectDir), dirProp(project.rootDir)))
   }
 
   @Test
   fun `searchCliInPropertiesFile returns null for missing file`() {
     val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
 
-    assertNull(searchCliInPropertiesFile(project.projectDir, project.rootDir))
+    assertNull(searchCliInPropertiesFile(dirProp(project.projectDir), dirProp(project.rootDir)))
   }
 
   @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -11,7 +11,6 @@ import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
@@ -187,9 +186,10 @@ class SentryPluginConfigurationCacheTest :
       run0.output,
     )
 
-    val buildDirProp = ProjectBuilder.builder().build().objects.directoryProperty().apply {
-      set(File(runner.projectDir, "build"))
-    }
+    val buildDirProp =
+      ProjectBuilder.builder().build().objects.directoryProperty().apply {
+        set(File(runner.projectDir, "build"))
+      }
     val cliPath = SentryCliProvider.getCliResourcesExtractionPath(buildDirProp).get().asFile
 
     // On Gradle >= 8, the whole build folder is wiped anyway

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -11,6 +11,8 @@ import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
 import org.hamcrest.CoreMatchers.`is`
@@ -185,7 +187,10 @@ class SentryPluginConfigurationCacheTest :
       run0.output,
     )
 
-    val cliPath = SentryCliProvider.getCliResourcesExtractionPath(File(runner.projectDir, "build"))
+    val buildDirProp = ProjectBuilder.builder().build().objects.directoryProperty().apply {
+      set(File(runner.projectDir, "build"))
+    }
+    val cliPath = SentryCliProvider.getCliResourcesExtractionPath(buildDirProp).get().asFile
 
     // On Gradle >= 8, the whole build folder is wiped anyway
     if (cliPath.exists()) {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -13,6 +13,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.TaskOutcome.SKIPPED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
@@ -296,8 +298,10 @@ class SentryPluginSourceContextTest :
 
   @Test
   fun `uploadSourceBundle task is up-to-date on subsequent builds`() {
-    val sentryCli = SentryCliProvider.getSentryCliPath(File(""), File("build"), File(""))
-    SentryCliProvider.maybeExtractFromResources(File("build"), sentryCli)
+    val helperProject = ProjectBuilder.builder().build()
+    fun dirProp(f: File): DirectoryProperty = helperProject.objects.directoryProperty().apply { set(f) }
+    val sentryCli = SentryCliProvider.getSentryCliPath(dirProp(File("")), dirProp(File("build")), dirProp(File("")))
+    SentryCliProvider.maybeExtractFromResources(dirProp(File("build")), sentryCli)
 
     sentryPropertiesFile.writeText("cli.executable=$sentryCli")
 
@@ -350,8 +354,10 @@ class SentryPluginSourceContextTest :
 
   @Test
   fun `uploadSourceBundle task is not up-to-date on subsequent builds if cli path changes`() {
-    val sentryCli = SentryCliProvider.getSentryCliPath(File(""), File("build"), File(""))
-    SentryCliProvider.maybeExtractFromResources(File("build"), sentryCli)
+    val helperProject = ProjectBuilder.builder().build()
+    fun dirProp(f: File): DirectoryProperty = helperProject.objects.directoryProperty().apply { set(f) }
+    val sentryCli = SentryCliProvider.getSentryCliPath(dirProp(File("")), dirProp(File("build")), dirProp(File("")))
+    SentryCliProvider.maybeExtractFromResources(dirProp(File("build")), sentryCli)
 
     sentryPropertiesFile.writeText("cli.executable=$sentryCli")
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginSourceContextTest.kt
@@ -299,8 +299,14 @@ class SentryPluginSourceContextTest :
   @Test
   fun `uploadSourceBundle task is up-to-date on subsequent builds`() {
     val helperProject = ProjectBuilder.builder().build()
-    fun dirProp(f: File): DirectoryProperty = helperProject.objects.directoryProperty().apply { set(f) }
-    val sentryCli = SentryCliProvider.getSentryCliPath(dirProp(File("")), dirProp(File("build")), dirProp(File("")))
+    fun dirProp(f: File): DirectoryProperty =
+      helperProject.objects.directoryProperty().apply { set(f) }
+    val sentryCli =
+      SentryCliProvider.getSentryCliPath(
+        dirProp(File("")),
+        dirProp(File("build")),
+        dirProp(File("")),
+      )
     SentryCliProvider.maybeExtractFromResources(dirProp(File("build")), sentryCli)
 
     sentryPropertiesFile.writeText("cli.executable=$sentryCli")
@@ -355,8 +361,14 @@ class SentryPluginSourceContextTest :
   @Test
   fun `uploadSourceBundle task is not up-to-date on subsequent builds if cli path changes`() {
     val helperProject = ProjectBuilder.builder().build()
-    fun dirProp(f: File): DirectoryProperty = helperProject.objects.directoryProperty().apply { set(f) }
-    val sentryCli = SentryCliProvider.getSentryCliPath(dirProp(File("")), dirProp(File("build")), dirProp(File("")))
+    fun dirProp(f: File): DirectoryProperty =
+      helperProject.objects.directoryProperty().apply { set(f) }
+    val sentryCli =
+      SentryCliProvider.getSentryCliPath(
+        dirProp(File("")),
+        dirProp(File("build")),
+        dirProp(File("")),
+      )
     SentryCliProvider.maybeExtractFromResources(dirProp(File("build")), sentryCli)
 
     sentryPropertiesFile.writeText("cli.executable=$sentryCli")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTaskTest.kt
@@ -38,7 +38,8 @@ class SentryCliExecTaskTest {
   fun `cli-executable is extracted from resources if required`() {
     val project = createProject()
 
-    val cliPath = SentryCliProvider.getCliResourcesExtractionPath(project.layout.buildDirectory).get().asFile
+    val cliPath =
+      SentryCliProvider.getCliResourcesExtractionPath(project.layout.buildDirectory).get().asFile
 
     assertTrue(!cliPath.exists())
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTaskTest.kt
@@ -38,7 +38,7 @@ class SentryCliExecTaskTest {
   fun `cli-executable is extracted from resources if required`() {
     val project = createProject()
 
-    val cliPath = SentryCliProvider.getCliResourcesExtractionPath(project.buildDir)
+    val cliPath = SentryCliProvider.getCliResourcesExtractionPath(project.layout.buildDirectory).get().asFile
 
     assertTrue(!cliPath.exists())
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
@@ -17,7 +17,7 @@ class SentryTelemetryServiceTest {
     val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
 
     val cliPath =
-      SentryCliProvider.getCliResourcesExtractionPath(project.layout.buildDirectory.asFile.get())
+      SentryCliProvider.getCliResourcesExtractionPath(project.layout.buildDirectory).get().asFile
 
     val infoOutput =
       project.providers


### PR DESCRIPTION
## Summary
- Replace deprecated `project.buildDir` (`File`) and `project.rootDir` (`File`) usages with Gradle's lazy `DirectoryProperty` API (`project.layout.buildDirectory`, `project.layout.projectDirectory`) in `SentryCliProvider`, `SentryCliExecTask`, `SentryTelemetryService`, and `AndroidComponentsConfig`
- Update `SentryCliValueSource`, `SentryCliInfoValueSource`, and `SentryCliVersionValueSource` parameter interfaces to use `DirectoryProperty` instead of `Property<File>`
- Add `Project.getIsolatedRootProjectDir()` which uses the Gradle 8.8+ `isolated.rootProject.projectDirectory` API for isolated projects compatibility, with a fallback for older versions
- Fix all affected unit and integration tests

Relates to [GRADLE-70](https://linear.app/getsentry/issue/GRADLE-70)

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)