### PR TITLE
ref(gradle): Replace project.buildDir in SentryTelemetryService

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -31,11 +31,11 @@ import io.sentry.gradle.common.SentryVariant
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.User
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.nio.charset.Charset
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -288,7 +288,7 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
       val infoOutput =
         project.providers
           .of(SentryCliInfoValueSource::class.java) { cliVS ->
-            cliVS.parameters.buildDirectory.set(project.buildDir)
+            cliVS.parameters.buildDirectory.set(project.layout.buildDirectory)
             cliVS.parameters.cliExecutable.set(cliExecutable)
             cliVS.parameters.authToken.set(extension.authToken)
             cliVS.parameters.url.set(extension.url)
@@ -315,7 +315,7 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
       val versionOutput =
         project.providers
           .of(SentryCliVersionValueSource::class.java) { cliVS ->
-            cliVS.parameters.buildDirectory.set(project.buildDir)
+            cliVS.parameters.buildDirectory.set(project.layout.buildDirectory)
             cliVS.parameters.cliExecutable.set(cliExecutable)
             cliVS.parameters.url.set(extension.url)
           }
@@ -421,7 +421,7 @@ class SentryMinimalException(message: String) : RuntimeException(message) {
 
 abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
   interface InfoParams : ValueSourceParameters {
-    @get:Input val buildDirectory: Property<File>
+    @get:Input val buildDirectory: DirectoryProperty
 
     @get:Input val cliExecutable: Property<String>
 
@@ -442,7 +442,7 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
       execOperations.exec {
         it.isIgnoreExitValue = true
         SentryCliProvider.maybeExtractFromResources(
-          parameters.buildDirectory.get(),
+          parameters.buildDirectory.get().asFile,
           parameters.cliExecutable.get(),
         )
 
@@ -485,7 +485,7 @@ abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
 
 abstract class SentryCliVersionValueSource : ValueSource<String, VersionParams> {
   interface VersionParams : ValueSourceParameters {
-    @get:Input val buildDirectory: Property<File>
+    @get:Input val buildDirectory: DirectoryProperty
 
     @get:Input val cliExecutable: Property<String>
 
@@ -499,7 +499,7 @@ abstract class SentryCliVersionValueSource : ValueSource<String, VersionParams> 
     execOperations.exec {
       it.isIgnoreExitValue = true
       SentryCliProvider.maybeExtractFromResources(
-        parameters.buildDirectory.get(),
+        parameters.buildDirectory.get().asFile,
         parameters.cliExecutable.get(),
       )
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
@@ -22,7 +22,7 @@ class SentryTelemetryServiceTest {
     val infoOutput =
       project.providers
         .of(SentryCliInfoValueSource::class.java) { cliVS ->
-          cliVS.parameters.buildDirectory.set(project.buildDir)
+          cliVS.parameters.buildDirectory.set(project.layout.buildDirectory)
           cliVS.parameters.cliExecutable.set(cliPath.absolutePath)
           // sets an empty/invalid auth token
           cliVS.parameters.authToken.set("")


### PR DESCRIPTION
## Summary
- Replace deprecated `project.buildDir` with `project.layout.buildDirectory.asFile` in `SentryTelemetryService` and its test

Relates to [GRADLE-70](https://linear.app/getsentry/issue/GRADLE-70)

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)