### PR TITLE
fix(plugin): Make instrumentation log dir variant-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Defer instrumentation log directory creation to execution time and use variant-specific paths to prevent log file corruption during parallel variant transforms ([#1236](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1236))
+
 ### Dependencies
 
 - Bump CLI from v3.4.2 to v3.4.3 ([#1215](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1215))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -58,10 +58,6 @@ fun ApplicationAndroidComponentsExtension.configure(
   sentryOrg: String?,
   sentryProject: String?,
 ) {
-  // temp folder for sentry-related stuff
-  val tmpDir = project.layout.buildDirectory.dir("tmp").map { it.file("sentry") }.get().asFile
-  tmpDir.mkdirs()
-
   onVariants { variant ->
     // Validate distribution configuration for this variant
     val updateSdkVariants = extension.distribution.updateSdkVariants.get()
@@ -232,7 +228,11 @@ fun ApplicationAndroidComponentsExtension.configure(
           params.appStartEnabled.setDisallowChanges(
             extension.tracingInstrumentation.appStart.enabled
           )
-          params.tmpDir.set(tmpDir)
+          params.tmpDir.set(
+            project.layout.buildDirectory.dir(
+              "sentry-logs/instrumentation/${variant.name}"
+            )
+          )
         }
 
         val manifestUpdater =

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -229,9 +229,7 @@ fun ApplicationAndroidComponentsExtension.configure(
             extension.tracingInstrumentation.appStart.enabled
           )
           params.tmpDir.set(
-            project.layout.buildDirectory.dir(
-              "sentry-logs/instrumentation/${variant.name}"
-            )
+            project.layout.buildDirectory.dir("sentry-logs/instrumentation/${variant.name}")
           )
         }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/CommonClassVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/CommonClassVisitor.kt
@@ -22,12 +22,10 @@ class CommonClassVisitor(
     // to avoid file creation in case the debug mode is not set
     if (parameters.debug.get()) {
 
-      // create log dir.
-      val logDir = parameters.tmpDir.get()
+      val logDir = parameters.tmpDir.get().asFile
       logDir.mkdirs()
 
-      // delete and recreate file
-      log = File(parameters.tmpDir.get(), "$className-instrumentation.log")
+      log = File(logDir, "$className-instrumentation.log")
       if (log.exists()) {
         log.delete()
       }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SpanAddingClassVisitorFactory.kt
@@ -27,7 +27,7 @@ import io.sentry.android.gradle.util.SemVer
 import io.sentry.android.gradle.util.SentryModules
 import io.sentry.android.gradle.util.SentryVersions
 import io.sentry.android.gradle.util.info
-import java.io.File
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
@@ -54,7 +54,7 @@ abstract class SpanAddingClassVisitorFactory :
 
     @get:Internal val sentryModulesService: Property<SentryModulesService>
 
-    @get:Internal val tmpDir: Property<File>
+    @get:Internal val tmpDir: DirectoryProperty
 
     @get:Internal var _instrumentable: ClassInstrumentable?
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -6,15 +6,19 @@ import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 import io.sentry.android.gradle.services.SentryModulesService
 import java.io.File
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.testfixtures.ProjectBuilder
 
 class TestSpanAddingParameters(
   private val debugOutput: Boolean = true,
   private val inMemoryDir: File,
 ) : SpanAddingClassVisitorFactory.SpanAddingParameters {
+
+  private val objects = ProjectBuilder.builder().build().objects
 
   override val invalidate: Property<Long>
     get() = DefaultProperty(PropertyHost.NO_OP, Long::class.java).convention(0L)
@@ -30,8 +34,8 @@ class TestSpanAddingParameters(
   override val sentryModulesService: Property<SentryModulesService>
     get() = TODO()
 
-  override val tmpDir: Property<File>
-    get() = DefaultProperty<File>(PropertyHost.NO_OP, File::class.java).convention(inMemoryDir)
+  override val tmpDir: DirectoryProperty
+    get() = objects.directoryProperty().also { it.set(inMemoryDir) }
 
   override var _instrumentable: ClassInstrumentable? = null
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -660,7 +660,7 @@ class SentryPluginTest :
     // since it's an integration test, we just test that the log file was created for the class
     // meaning our CommonClassVisitor has visited and instrumented it
     val debugOutput =
-      testProjectDir.root.resolve("app/build/tmp/sentry/RealCall-instrumentation.log")
+      testProjectDir.root.resolve("app/build/sentry-logs/instrumentation/debug/RealCall-instrumentation.log")
     assertTrue { debugOutput.exists() && debugOutput.length() > 0 }
   }
 
@@ -960,7 +960,7 @@ class SentryPluginTest :
     // since it's an integration test, we just test that the log file wasn't created
     // for the class meaning our CommonClassVisitor has NOT instrumented it
     val debugOutput =
-      testProjectDir.root.resolve("app/build/tmp/sentry/RealCall-instrumentation.log")
+      testProjectDir.root.resolve("app/build/sentry-logs/instrumentation/debug/RealCall-instrumentation.log")
     assertTrue { !debugOutput.exists() }
   }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -660,7 +660,9 @@ class SentryPluginTest :
     // since it's an integration test, we just test that the log file was created for the class
     // meaning our CommonClassVisitor has visited and instrumented it
     val debugOutput =
-      testProjectDir.root.resolve("app/build/sentry-logs/instrumentation/debug/RealCall-instrumentation.log")
+      testProjectDir.root.resolve(
+        "app/build/sentry-logs/instrumentation/debug/RealCall-instrumentation.log"
+      )
     assertTrue { debugOutput.exists() && debugOutput.length() > 0 }
   }
 
@@ -960,7 +962,9 @@ class SentryPluginTest :
     // since it's an integration test, we just test that the log file wasn't created
     // for the class meaning our CommonClassVisitor has NOT instrumented it
     val debugOutput =
-      testProjectDir.root.resolve("app/build/sentry-logs/instrumentation/debug/RealCall-instrumentation.log")
+      testProjectDir.root.resolve(
+        "app/build/sentry-logs/instrumentation/debug/RealCall-instrumentation.log"
+      )
     assertTrue { !debugOutput.exists() }
   }
 


### PR DESCRIPTION
## Summary
- The debug instrumentation log directory (`build/tmp/sentry`) was shared across all variants, which could cause log file corruption when AGP runs variant transforms in parallel
- Each variant now writes to its own directory: `build/sentry-logs/instrumentation/<variantName>`
- Removes the eager `mkdirs()` at configuration time — `CommonClassVisitor` already creates the directory at execution time
- Migrates `tmpDir` from `Property<File>` to `DirectoryProperty` using the Gradle layout API
- Updates integration tests to reference the new variant-specific path

🤖 Generated with [Claude Code](https://claude.com/claude-code)