### PR TITLE
ref(plugin): Replace File.separator with forward slash

### DIFF
--- a/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/LyricsActivity.kt
+++ b/examples/android-instrumentation-sample/src/main/java/io/sentry/samples/instrumentation/ui/LyricsActivity.kt
@@ -37,7 +37,7 @@ class LyricsActivity : ComponentActivity() {
     filesystem = intent.getSerializableExtra(FILESYSTEM_EXTRA_KEY) as Filesystem
     toolbar.title = "Lyrics for ${track.name}"
 
-    val dir = File("$filesDir${File.separatorChar}lyrics")
+    val dir = File("$filesDir/lyrics")
     dir.mkdirs()
 
     lyricsInput.setText(filesystem.read(this, "${track.id}.txt"))

--- a/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/ASMifyTask.kt
+++ b/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/ASMifyTask.kt
@@ -71,8 +71,7 @@ abstract class ASMifyTask : Exec() {
       val dir = File(tmpDir)
       dir.mkdirs()
 
-      val filename =
-        File(clazz).nameWithoutExtension + "_asmified.java"
+      val filename = File(clazz).nameWithoutExtension + "_asmified.java"
 
       val file = File(dir, filename)
       if (file.exists()) {

--- a/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/ASMifyTask.kt
+++ b/plugin-build/buildSrc/src/main/kotlin/io/sentry/android/gradle/internal/ASMifyTask.kt
@@ -72,7 +72,7 @@ abstract class ASMifyTask : Exec() {
       dir.mkdirs()
 
       val filename =
-        clazz.substringAfterLast(File.separator).substringBefore(".") + "_asmified.java"
+        File(clazz).nameWithoutExtension + "_asmified.java"
 
       val file = File(dir, filename)
       if (file.exists()) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt
@@ -5,7 +5,6 @@ import io.sentry.BuildConfig
 import io.sentry.android.gradle.autoinstall.installDependencies
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.util.AgpVersions
-import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -73,8 +72,6 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
     const val SENTRY_ORG_PARAMETER = "sentryOrg"
     const val SENTRY_PROJECT_PARAMETER = "sentryProject"
     internal const val SENTRY_SDK_VERSION = BuildConfig.SdkVersion
-
-    internal val sep = File.separator
 
     // a single unified logger used by instrumentation
     internal val logger by lazy { LoggerFactory.getLogger(SentryPlugin::class.java) }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPropertiesFileProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPropertiesFileProvider.kt
@@ -25,48 +25,37 @@ internal object SentryPropertiesFileProvider {
     val projDir = project.projectDir
     val rootDir = project.rootDir
 
-    val sep = File.separator
-
     // Local Project dirs
     val possibleFiles = mutableListOf<String>()
     if (buildTypeName.isNotBlank()) {
-      possibleFiles.add("${projDir}${sep}src${sep}${buildTypeName}${sep}$FILENAME")
+      possibleFiles.add("${projDir}/src/${buildTypeName}/$FILENAME")
     }
     if (flavorName.isNotBlank()) {
       if (buildTypeName.isNotBlank()) {
-        possibleFiles.add(
-          "${projDir}${sep}src${sep}${buildTypeName}${sep}$flavorName${sep}$FILENAME"
-        )
-        possibleFiles.add(
-          "${projDir}${sep}src${sep}${flavorName}${sep}${buildTypeName}${sep}$FILENAME"
-        )
+        possibleFiles.add("${projDir}/src/${buildTypeName}/$flavorName/$FILENAME")
+        possibleFiles.add("${projDir}/src/${flavorName}/${buildTypeName}/$FILENAME")
       }
-      possibleFiles.add("${projDir}${sep}src${sep}${flavorName}${sep}$FILENAME")
+      possibleFiles.add("${projDir}/src/${flavorName}/$FILENAME")
     }
-    possibleFiles.add("${projDir}${sep}$FILENAME")
+    possibleFiles.add("${projDir}/$FILENAME")
 
     // Other flavors dirs
     possibleFiles.addAll(
-      variant?.productFlavors?.map { "${projDir}${sep}src${sep}${it}${sep}$FILENAME" }
-        ?: emptyList()
+      variant?.productFlavors?.map { "${projDir}/src/${it}/$FILENAME" } ?: emptyList()
     )
 
     // Root project dirs
     if (buildTypeName.isNotBlank()) {
-      possibleFiles.add("${rootDir}${sep}src${sep}${buildTypeName}${sep}$FILENAME")
+      possibleFiles.add("${rootDir}/src/${buildTypeName}/$FILENAME")
     }
     if (flavorName.isNotBlank()) {
-      possibleFiles.add("${rootDir}${sep}src${sep}${flavorName}${sep}$FILENAME")
+      possibleFiles.add("${rootDir}/src/${flavorName}/$FILENAME")
       if (buildTypeName.isNotBlank()) {
-        possibleFiles.add(
-          "${rootDir}${sep}src${sep}${buildTypeName}${sep}${flavorName}${sep}$FILENAME"
-        )
-        possibleFiles.add(
-          "${rootDir}${sep}src${sep}${flavorName}${sep}${buildTypeName}${sep}$FILENAME"
-        )
+        possibleFiles.add("${rootDir}/src/${buildTypeName}/${flavorName}/$FILENAME")
+        possibleFiles.add("${rootDir}/src/${flavorName}/${buildTypeName}/$FILENAME")
       }
     }
-    possibleFiles.add("${rootDir}${sep}$FILENAME")
+    possibleFiles.add("${rootDir}/$FILENAME")
 
     return possibleFiles
       .distinct()

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -112,13 +112,12 @@ internal object SentryTasksProvider {
     dexguardEnabled: Boolean = false,
   ): Provider<FileCollection> {
     if (dexguardEnabled) {
-      val sep = File.separator
       if (project.plugins.hasPlugin("com.guardsquare.proguard")) {
         val fileCollection =
           project.files(
             File(
               project.buildDir,
-              "outputs${sep}proguard${sep}${variant.name}${sep}mapping${sep}mapping.txt",
+              "outputs/proguard/${variant.name}/mapping/mapping.txt",
             )
           )
         return project.provider { fileCollection }
@@ -135,25 +134,25 @@ internal object SentryTasksProvider {
           project.files(
             File(
               project.buildDir,
-              basePath.plus(listOf("apk", variant.name, "mapping.txt")).joinToString(sep),
+              basePath.plus(listOf("apk", variant.name, "mapping.txt")).joinToString("/"),
             ),
             File(
               project.buildDir,
-              basePath.plus(listOf("bundle", variant.name, "mapping.txt")).joinToString(sep),
+              basePath.plus(listOf("bundle", variant.name, "mapping.txt")).joinToString("/"),
             ),
             File(
               project.buildDir,
               basePath
                 .plus(listOf("apk", variant.flavorName, variant.buildTypeName, "mapping.txt"))
                 .filterNotNull()
-                .joinToString(sep),
+                .joinToString("/"),
             ),
             File(
               project.buildDir,
               basePath
                 .plus(listOf("bundle", variant.flavorName, variant.buildTypeName, "mapping.txt"))
                 .filterNotNull()
-                .joinToString(sep),
+                .joinToString("/"),
             ),
           )
         return project.provider { fileCollection }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt
@@ -115,10 +115,7 @@ internal object SentryTasksProvider {
       if (project.plugins.hasPlugin("com.guardsquare.proguard")) {
         val fileCollection =
           project.files(
-            File(
-              project.buildDir,
-              "outputs/proguard/${variant.name}/mapping/mapping.txt",
-            )
+            File(project.buildDir, "outputs/proguard/${variant.name}/mapping/mapping.txt")
           )
         return project.provider { fileCollection }
       }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/CollectSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/CollectSourcesTask.kt
@@ -75,10 +75,7 @@ internal class SourceCollector {
       if (sourceDir.exists()) {
         SentryPlugin.logger.debug { "Collecting sources in ${sourceDir.absolutePath}" }
         sourceDir.walk().forEach { sourceFile ->
-          val relativePath =
-            sourceFile.absolutePath
-              .removePrefix(sourceDir.absolutePath)
-              .removePrefix(File.separator)
+          val relativePath = sourceFile.toRelativeString(sourceDir)
           val targetFile = outDir.resolve(File(relativePath))
           if (sourceFile.isFile) {
             if (relativePath.isBlank()) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -41,12 +41,10 @@ abstract class SentryUploadNativeSymbolsTask : SentryCliExecTask() {
       args.add("--no-upload")
     }
 
-    val sep = File.separator
-
     // eg absoluteProjectFolderPath/build/intermediates/merged_native_libs/{variantName}
     // where {variantName} could be debug/release...
     args.add(
-      File(buildDir.get(), "intermediates${sep}merged_native_libs${sep}${variantName.get()}")
+      File(buildDir.get(), "intermediates/merged_native_libs/${variantName.get()}")
         .absolutePath
     )
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTask.kt
@@ -44,8 +44,7 @@ abstract class SentryUploadNativeSymbolsTask : SentryCliExecTask() {
     // eg absoluteProjectFolderPath/build/intermediates/merged_native_libs/{variantName}
     // where {variantName} could be debug/release...
     args.add(
-      File(buildDir.get(), "intermediates/merged_native_libs/${variantName.get()}")
-        .absolutePath
+      File(buildDir.get(), "intermediates/merged_native_libs/${variantName.get()}").absolutePath
     )
 
     // Only include sources if includeNativeSources is enabled, as this is opt-in feature

--- a/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
@@ -134,5 +134,4 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
       project.installDependencies(extension, false)
     }
   }
-
 }

--- a/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
@@ -14,7 +14,6 @@ import io.sentry.android.gradle.util.SentryPluginUtils
 import io.sentry.android.gradle.util.hookWithAssembleTasks
 import io.sentry.android.gradle.util.info
 import io.sentry.gradle.common.JavaVariant
-import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -45,7 +44,7 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
 
       val javaExtension = project.extensions.getByType(JavaPluginExtension::class.java)
 
-      val sentryResDir = project.layout.buildDirectory.dir("generated${sep}sentry")
+      val sentryResDir = project.layout.buildDirectory.dir("generated/sentry")
 
       val javaVariant = JavaVariant(project, javaExtension)
       val outputPaths = OutputPaths(project, "java")
@@ -136,7 +135,4 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
     }
   }
 
-  companion object {
-    internal val sep = File.separator
-  }
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryCliProviderTest.kt
@@ -113,7 +113,7 @@ class SentryCliProviderTest {
 
     val foundPath = getResourceUrl(resourcePath)
     assertNotNull(foundPath)
-    assertTrue(foundPath.endsWith("${File.separator}dummy-bin${File.separator}dummy-sentry-cli"))
+    assertTrue(foundPath.endsWith("/dummy-bin/dummy-sentry-cli"))
 
     resourceFile?.delete()
   }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPropertiesFileProviderTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/SentryPropertiesFileProviderTest.kt
@@ -14,12 +14,10 @@ import org.junit.runners.Parameterized
 @RunWith(Parameterized::class)
 class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
 
-  private val sep = File.separator
-
   @Test
   fun `getPropertiesFilePath finds file inside debug folder`() {
     val (project, _) = createTestAndroidProject(forceEvaluate = !AgpVersions.isAGP74(agpVersion))
-    createTestFile(project.projectDir, "src${sep}debug${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/debug/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("debug")
 
@@ -44,7 +42,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         productFlavors.create("lite")
         productFlavors.create("full")
       }
-    createTestFile(project.projectDir, "src${sep}lite${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/lite/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteDebug")
 
@@ -59,7 +57,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         productFlavors.create("lite")
         productFlavors.create("full")
       }
-    createTestFile(project.projectDir, "src${sep}lite${sep}debug${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/lite/debug/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteDebug")
 
@@ -74,7 +72,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         productFlavors.create("lite")
         productFlavors.create("full")
       }
-    createTestFile(project.projectDir, "src${sep}debug${sep}lite${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/debug/lite/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteDebug")
 
@@ -89,7 +87,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         productFlavors.create("lite") { it.dimension("version") }
         productFlavors.create("api30") { it.dimension("api") }
       }
-    createTestFile(project.projectDir, "src${sep}liteApi30${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/liteApi30/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteApi30Debug")
 
@@ -104,7 +102,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         productFlavors.create("lite") { it.dimension("version") }
         productFlavors.create("api30") { it.dimension("api") }
       }
-    createTestFile(project.projectDir, "src${sep}api30${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/api30/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteApi30Debug")
 
@@ -134,7 +132,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         parent = rootProject,
         forceEvaluate = !AgpVersions.isAGP74(agpVersion),
       )
-    createTestFile(rootProject.projectDir, "src${sep}debug${sep}sentry.properties")
+    createTestFile(rootProject.projectDir, "src/debug/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("debug")
 
@@ -152,7 +150,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         flavorDimensions("version")
         productFlavors.create("lite")
       }
-    createTestFile(rootProject.projectDir, "src${sep}lite${sep}sentry.properties")
+    createTestFile(rootProject.projectDir, "src/lite/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteDebug")
 
@@ -170,7 +168,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         flavorDimensions("version")
         productFlavors.create("lite")
       }
-    createTestFile(rootProject.projectDir, "src${sep}lite${sep}debug${sep}sentry.properties")
+    createTestFile(rootProject.projectDir, "src/lite/debug/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteDebug")
 
@@ -194,7 +192,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         forceEvaluate = !AgpVersions.isAGP74(agpVersion),
       )
     // Only place the file under src/debug/ — with null variant this should not be found
-    createTestFile(project.projectDir, "src${sep}debug${sep}sentry.properties")
+    createTestFile(project.projectDir, "src/debug/sentry.properties")
 
     assertEquals(null, getPropertiesFilePath(project))
   }
@@ -210,7 +208,7 @@ class SentryPropertiesFileProviderTest(private val agpVersion: SemVer) {
         flavorDimensions("version")
         productFlavors.create("lite")
       }
-    createTestFile(rootProject.projectDir, "src${sep}debug${sep}lite${sep}sentry.properties")
+    createTestFile(rootProject.projectDir, "src/debug/lite/sentry.properties")
 
     val variant = project.retrieveAndroidVariant("liteDebug")
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryNonAndroidPluginTest.kt
@@ -37,7 +37,7 @@ abstract class BaseSentryNonAndroidPluginTest(private val gradleVersion: String)
     val pluginClasspath =
       PluginUnderTestMetadataReading.readImplementationClasspath()
         .joinToString(separator = ", ") { "\"$it\"" }
-        .replace(File.separator, "/")
+        .replace("\\", "/")
 
     appBuildFile = File(testProjectDir.root, "app/build.gradle")
     appBuildFile.writeText(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/BaseSentryPluginTest.kt
@@ -43,7 +43,7 @@ abstract class BaseSentryPluginTest(
     val pluginClasspath =
       PluginUnderTestMetadataReading.readImplementationClasspath()
         .joinToString(separator = ", ") { "\"$it\"" }
-        .replace(File.separator, "/")
+        .replace("\\", "/")
 
     appBuildFile = File(testProjectDir.root, "app/build.gradle")
     moduleBuildFile = File(testProjectDir.root, "module/build.gradle")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIsolatedProjectsTest.kt
@@ -54,7 +54,7 @@ class SentryPluginIsolatedProjectsTest :
     val pluginClasspath =
       PluginUnderTestMetadataReading.readImplementationClasspath()
         .joinToString(separator = ", ") { "\"$it\"" }
-        .replace(File.separator, "/")
+        .replace("\\", "/")
 
     File(testProjectDir.root, "settings.gradle")
       .writeText(

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/SentryUploadNativeSymbolsTaskTest.kt
@@ -23,12 +23,11 @@ class SentryUploadNativeSymbolsTaskTest {
       }
 
     val args = task.computeCommandLineArgs()
-    val sep = File.separator
 
     assertTrue("sentry-cli" in args)
     assertTrue("debug-files" in args)
     assertTrue("upload" in args)
-    val path = "${project.buildDir}${sep}intermediates" + "${sep}merged_native_libs${sep}debug"
+    val path = File(project.buildDir, "intermediates/merged_native_libs/debug").absolutePath
     assertTrue(path in args)
     assertFalse("--include-sources" in args)
     assertFalse("--log-level=debug" in args)


### PR DESCRIPTION
Java's `File` class accepts forward slashes on all platforms, making `File.separator` unnecessary for path construction
So this PR replaces all `File.separator` / `File.separatorChar` usage with `/` across the codebase

https://googlesamples.github.io/android-custom-lint-rules/checks/GradlePath.md.html
You can also see the warning in google's lint code: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/GradleDetector.kt;l=615


🤖 Generated with [Claude Code](https://claude.com/claude-code)