### PR TITLE
ci(benchmark): Update gradle-profiler to 0.24.0

### DIFF
--- a/.github/workflows/benchmark-build-speed.yml
+++ b/.github/workflows/benchmark-build-speed.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           curl -s "https://get.sdkman.io" | bash
           source "$HOME/.sdkman/bin/sdkman-init.sh"
-          sdk install gradleprofiler 0.17.0
+          sdk install gradleprofiler 0.24.0
           cd scripts/benchmark
           chmod +x benchmark-build-speed.sh
           ./benchmark-build-speed.sh


### PR DESCRIPTION
Bumps the gradle-profiler version installed via SDKMAN in the build-speed benchmark job from `0.17.0` to the latest release, `0.24.0`.

The job runs only on `workflow_dispatch`, so this has no effect on PR/merge CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)