### PR TITLE
chore: Add Gradle wrapper checksum verification (GRADLE-104)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
## What

Adds `distributionSha256Sum` to `gradle/wrapper/gradle-wrapper.properties` so the Gradle wrapper verifies the integrity of the downloaded distribution against a known-good SHA256 hash before using it.

## Why

Without a checksum, the Gradle wrapper trusts whatever is served at the distribution URL. Adding the SHA256 ensures the downloaded zip matches the expected artifact, protecting against tampering or accidental corruption. Refs GRADLE-104.