### PR TITLE
feat(compose): Support the Kotlin 2.4 compiler plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8431)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.43.0...8.43.1)
 
+### API Changes
+
+- The `debug` extension property is now typed as `Property<Boolean>` instead of `Property<Boolean?>` ([#1253](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1253))
+
 ## 6.9.0
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for the Kotlin 2.4 compiler in the Compose tracing compiler plugin ([#1253](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1253))
 
+### Fixes
+
+- Compose tracing no longer adds the Sentry modifier multiple times for chained modifiers (e.g. `Modifier.fillMaxSize().padding()`) on Kotlin 2.2 and newer ([#1253](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1253))
+
 ### Dependencies
 
 - Bump Android SDK from v8.43.0 to v8.43.1 ([#1261](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1261))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add support for the Kotlin 2.4 compiler in the Compose tracing compiler plugin ([#1253](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1253))
+
 ### Dependencies
 
 - Bump Android SDK from v8.43.0 to v8.43.1 ([#1261](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1261))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,8 @@ kotlinCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-comp
 autoService = { group = "com.google.auto.service", name = "auto-service", version = "1.1.1" }
 autoServiceAnnotatons = { group = "com.google.auto.service", name = "auto-service-annotations", version = "1.1.1" }
 kotlinJunit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
-kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.7.1" }
+# Pre-release: first kctfork that supports the Kotlin 2.4 compiler. Pin to a stable release once available.
+kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.13.0-alpha01" }
 truth = { module = "com.google.truth:truth", version = "1.4.5" }
 composeDesktop = { group = "org.jetbrains.compose.desktop", name = "desktop", version = "1.6.10" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ autoService = { group = "com.google.auto.service", name = "auto-service", versio
 autoServiceAnnotatons = { group = "com.google.auto.service", name = "auto-service-annotations", version = "1.1.1" }
 kotlinJunit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 # Pre-release: first kctfork that supports the Kotlin 2.4 compiler. Pin to a stable release once available.
-kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.13.0-alpha01" }
+kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.12.1" }
 truth = { module = "com.google.truth:truth", version = "1.4.5" }
 composeDesktop = { group = "org.jetbrains.compose.desktop", name = "desktop", version = "1.6.10" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,6 @@ kotlinCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-comp
 autoService = { group = "com.google.auto.service", name = "auto-service", version = "1.1.1" }
 autoServiceAnnotatons = { group = "com.google.auto.service", name = "auto-service-annotations", version = "1.1.1" }
 kotlinJunit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
-# Pre-release: first kctfork that supports the Kotlin 2.4 compiler. Pin to a stable release once available.
 kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.12.1" }
 truth = { module = "com.google.truth:truth", version = "1.4.5" }
 composeDesktop = { group = "org.jetbrains.compose.desktop", name = "desktop", version = "1.6.10" }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -146,8 +146,7 @@ internal object SentryCliProvider {
   }
 
   internal fun getCliSuffix(): String? {
-    // TODO: change to .lowercase(Locale.ROOT) when using Kotlin 1.6
-    val osName = System.getProperty("os.name").toLowerCase(Locale.ROOT)
+    val osName = System.getProperty("os.name").lowercase(Locale.ROOT)
     val osArch = System.getProperty("os.arch")
     return when {
       "mac" in osName -> "Darwin-universal"

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -173,7 +173,7 @@ abstract class SentryPluginExtension @Inject constructor(objects: ObjectFactory)
    *
    * Default is disabled.
    */
-  val debug: Property<Boolean> = objects.property<Boolean?>(Boolean::class.java).convention(false)
+  val debug: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
   /**
    * The slug of the Sentry organization to use for uploading proguard mappings/source contexts.

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/SentryPluginUtils.kt
@@ -22,7 +22,7 @@ internal object SentryPluginUtils {
     if (isEmpty()) {
       ""
     } else {
-      substring(0, 1).toUpperCase(Locale.US) + substring(1)
+      substring(0, 1).uppercase(Locale.US) + substring(1)
     }
 
   fun isMinificationEnabled(

--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-  alias(libs.plugins.kotlin) version "2.4.0"
-  alias(libs.plugins.kapt) version "2.4.0"
+  alias(libs.plugins.kotlin) version "2.3.21"
+  alias(libs.plugins.kapt) version "2.3.21"
   id("distribution")
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.spotless)
@@ -104,7 +104,7 @@ kotlin {
   jvmToolchain(11)
   compilerOptions {
     jvmTarget.set(JvmTarget.JVM_11)
-    languageVersion.set(KotlinVersion.KOTLIN_2_0)
-    apiVersion.set(KotlinVersion.KOTLIN_2_0)
+    languageVersion.set(KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(KotlinVersion.KOTLIN_1_9)
   }
 }

--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-  alias(libs.plugins.kotlin) version "2.1.0"
-  alias(libs.plugins.kapt) version "2.1.0"
+  alias(libs.plugins.kotlin) version "2.4.0"
+  alias(libs.plugins.kapt) version "2.4.0"
   id("distribution")
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.spotless)
@@ -13,6 +13,7 @@ plugins {
 val kotlin1920: SourceSet by sourceSets.creating
 val kotlin2120: SourceSet by sourceSets.creating
 val kotlin2200: SourceSet by sourceSets.creating
+val kotlin2400: SourceSet by sourceSets.creating
 
 spotless {
   kotlin {
@@ -56,14 +57,17 @@ dependencies {
   testImplementation(kotlin1920.output)
   testImplementation(kotlin2120.output)
   testImplementation(kotlin2200.output)
+  testImplementation(kotlin2400.output)
 
   kotlin1920.compileOnlyConfigurationName("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.24")
   kotlin2120.compileOnlyConfigurationName("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.20")
   kotlin2200.compileOnlyConfigurationName("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
+  kotlin2400.compileOnlyConfigurationName("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.0")
 
   compileOnly(kotlin1920.output)
   compileOnly(kotlin2120.output)
   compileOnly(kotlin2200.output)
+  compileOnly(kotlin2400.output)
 }
 
 kapt { correctErrorTypes = true }
@@ -91,6 +95,7 @@ tasks.withType<Jar>().configureEach {
   from(kotlin1920.output)
   from(kotlin2120.output)
   from(kotlin2200.output)
+  from(kotlin2400.output)
 }
 
 // see
@@ -99,7 +104,7 @@ kotlin {
   jvmToolchain(11)
   compilerOptions {
     jvmTarget.set(JvmTarget.JVM_11)
-    languageVersion.set(KotlinVersion.KOTLIN_1_9)
-    apiVersion.set(KotlinVersion.KOTLIN_1_9)
+    languageVersion.set(KotlinVersion.KOTLIN_2_0)
+    apiVersion.set(KotlinVersion.KOTLIN_2_0)
   }
 }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2120/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension21.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2120/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension21.kt
@@ -6,6 +6,10 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.messageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGetObjectValue
@@ -248,4 +252,12 @@ fun FqName.classId(name: String): ClassId {
 
 fun ClassId.callableId(name: String): CallableId {
   return CallableId(this, Name.identifier(name))
+}
+
+@OptIn(ExperimentalCompilerApi::class)
+fun CompilerPluginRegistrar.ExtensionStorage.registerComposeTracing21(
+  configuration: CompilerConfiguration
+) {
+  val messageCollector = configuration.messageCollector
+  IrGenerationExtension.registerExtension(JetpackComposeTracingIrExtension21(messageCollector))
 }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
@@ -6,6 +6,10 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.messageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGetObjectValue
@@ -265,4 +269,12 @@ fun FqName.classId(name: String): ClassId {
 
 fun ClassId.callableId(name: String): CallableId {
   return CallableId(this, Name.identifier(name))
+}
+
+@OptIn(ExperimentalCompilerApi::class)
+fun CompilerPluginRegistrar.ExtensionStorage.registerComposeTracing22(
+  configuration: CompilerConfiguration
+) {
+  val messageCollector = configuration.messageCollector
+  IrGenerationExtension.registerExtension(JetpackComposeTracingIrExtension22(messageCollector))
 }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
@@ -178,9 +178,9 @@ class JetpackComposeTracingIrExtension22(private val messageCollector: MessageCo
 
           for (idx in 0 until expression.symbol.owner.parameters.size) {
             val valueParameter = expression.symbol.owner.parameters[idx]
-            // The unified parameter API also lists dispatch/extension/context receivers, so wrap
-            // only actual value arguments. Otherwise the Modifier receivers of chained calls
-            // (e.g. Modifier.fillMaxSize().padding()) get tagged too.
+            // In Kotlin 2.2 dispatch/extension receivers are part of parameters; only enrich
+            // regular value parameters, otherwise modifier-receiver chains (e.g.
+            // Modifier.fillMaxSize().padding()) would each get their receiver wrapped as well.
             if (
               valueParameter.kind == IrParameterKind.Regular &&
                 valueParameter.type.classFqName == modifierClassFqName

--- a/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ir.builders.irGetObjectValue
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -177,7 +178,13 @@ class JetpackComposeTracingIrExtension22(private val messageCollector: MessageCo
 
           for (idx in 0 until expression.symbol.owner.parameters.size) {
             val valueParameter = expression.symbol.owner.parameters[idx]
-            if (valueParameter.type.classFqName == modifierClassFqName) {
+            // The unified parameter API also lists dispatch/extension/context receivers, so wrap
+            // only actual value arguments. Otherwise the Modifier receivers of chained calls
+            // (e.g. Modifier.fillMaxSize().padding()) get tagged too.
+            if (
+              valueParameter.kind == IrParameterKind.Regular &&
+                valueParameter.type.classFqName == modifierClassFqName
+            ) {
               val argument = expression.arguments[idx]
               expression.arguments[idx] = wrapExpression(argument, composableName, builder)
             }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2400/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension24.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2400/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension24.kt
@@ -4,12 +4,12 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.messageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGetObjectValue
@@ -31,9 +31,8 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 
-// required only for Kotlin 2.0.0
-// @UnsafeDuringIrConstructionAPI
-class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCollector) :
+// Modified duplicate of JetpackComposeTracingIrExtension22, compiled against 2.4.0
+class JetpackComposeTracingIrExtension24(private val messageCollector: MessageCollector) :
   IrGenerationExtension {
 
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
@@ -90,12 +89,15 @@ class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCo
     }
     val modifierThen = modifierThenRefs.single()
 
-    val sentryModifierTagFunction =
-      FqName("io.sentry.compose").classId("SentryModifier").callableId("sentryTag")
+    val sentryModifierClassId = FqName("io.sentry.compose").classId("SentryModifier")
+
+    val sentryModifierCompanionClass = pluginContext.referenceClass(sentryModifierClassId)?.owner
+
+    val sentryModifierTagFunction = sentryModifierClassId.callableId("sentryTag")
 
     val sentryModifierTagFunctionRefs = pluginContext.referenceFunctions(sentryModifierTagFunction)
 
-    if (sentryModifierTagFunctionRefs.isEmpty()) {
+    if (sentryModifierCompanionClass == null || sentryModifierTagFunctionRefs.isEmpty()) {
       messageCollector.report(
         CompilerMessageSeverity.WARNING,
         "io.sentry.compose.Modifier.sentryTag() not found, " +
@@ -115,6 +117,7 @@ class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCo
       return
     }
     val sentryModifierTagFunctionRef = sentryModifierTagFunctionRefs.single()
+    val sentryModifierCompanionClassRef = sentryModifierCompanionClass.symbol
 
     val transformer =
       object : IrElementTransformerVoidWithContext() {
@@ -165,16 +168,18 @@ class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCo
           // avoid infinite recursion by instrumenting ourselves
           val dispatchReceiver = expression.dispatchReceiver
           if (
-            dispatchReceiver is IrCall && dispatchReceiver.symbol == sentryModifierTagFunctionRef
+            (dispatchReceiver is IrCall &&
+              dispatchReceiver.symbol == sentryModifierTagFunctionRef) ||
+              expression.symbol == sentryModifierTagFunctionRef
           ) {
             return super.visitCall(expression)
           }
 
-          for (idx in 0 until expression.symbol.owner.valueParameters.size) {
-            val valueParameter = expression.symbol.owner.valueParameters[idx]
+          for (idx in 0 until expression.symbol.owner.parameters.size) {
+            val valueParameter = expression.symbol.owner.parameters[idx]
             if (valueParameter.type.classFqName == modifierClassFqName) {
-              val argument = expression.getValueArgument(idx)
-              expression.putValueArgument(idx, wrapExpression(argument, composableName, builder))
+              val argument = expression.arguments[idx]
+              expression.arguments[idx] = wrapExpression(argument, composableName, builder)
             }
           }
           return super.visitCall(expression)
@@ -193,7 +198,7 @@ class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCo
             // Case A: modifier is not supplied
             // -> simply set our modifier as param
             // e.g. BasicText(text = "abc")
-            // into BasicText(text = "abc", modifier = Modifier.sentryTag("<composable>")
+            // into BasicText(text = "abc", modifier = Modifier.sentryTag("<composable>"))
 
             // we can safely set the sentryModifier if there's no value parameter provided
             // but in case the Jetpack Compose Compiler plugin runs before us,
@@ -217,11 +222,12 @@ class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCo
             // Modifier.sentryTag()
             val sentryTagCall = generateSentryTagCall(builder, composableName)
 
-            // Modifier.then()
+            // sentryTag.then(<original expression>)
             val thenCall = builder.irCall(modifierThen, type = modifierType)
-            thenCall.putValueArgument(0, expression)
-            thenCall.dispatchReceiver = sentryTagCall
-
+            // argument 0: dispatch receiver
+            thenCall.arguments[0] = sentryTagCall
+            // argument 1: modifier expression
+            thenCall.arguments[1] = expression
             return thenCall
           }
         }
@@ -232,12 +238,22 @@ class JetpackComposeTracingIrExtension19(private val messageCollector: MessageCo
         ): IrCall {
           val sentryTagCall =
             builder.irCall(sentryModifierTagFunctionRef, type = modifierType).also {
-              it.extensionReceiver =
+              // dispatch receiver: SentryModifier
+              // it.arguments[0]
+              it.arguments[0] =
+                builder.irGetObjectValue(
+                  type = sentryModifierCompanionClassRef.createType(false, emptyList()),
+                  classSymbol = sentryModifierCompanionClassRef,
+                )
+
+              // extension receiver, Modifier
+              it.arguments[1] =
                 builder.irGetObjectValue(
                   type = modifierCompanionClassRef.createType(false, emptyList()),
                   classSymbol = modifierCompanionClassRef,
                 )
-              it.putValueArgument(0, builder.irString(composableName))
+
+              it.arguments[2] = builder.irString(composableName)
             }
           return sentryTagCall
         }
@@ -256,10 +272,9 @@ fun ClassId.callableId(name: String): CallableId {
 }
 
 @OptIn(ExperimentalCompilerApi::class)
-fun CompilerPluginRegistrar.ExtensionStorage.registerComposeTracing19(
+fun CompilerPluginRegistrar.ExtensionStorage.registerComposeTracing24(
   configuration: CompilerConfiguration
 ) {
-  val messageCollector =
-    configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-  IrGenerationExtension.registerExtension(JetpackComposeTracingIrExtension19(messageCollector))
+  val messageCollector = configuration.messageCollector
+  IrGenerationExtension.registerExtension(JetpackComposeTracingIrExtension24(messageCollector))
 }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2400/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension24.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2400/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension24.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.ir.builders.irGetObjectValue
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -177,7 +178,13 @@ class JetpackComposeTracingIrExtension24(private val messageCollector: MessageCo
 
           for (idx in 0 until expression.symbol.owner.parameters.size) {
             val valueParameter = expression.symbol.owner.parameters[idx]
-            if (valueParameter.type.classFqName == modifierClassFqName) {
+            // 2.4's unified parameter API also lists dispatch/extension/context receivers, so
+            // wrap only actual value arguments. Otherwise the Modifier receivers of chained
+            // calls (e.g. Modifier.fillMaxSize().padding()) get tagged too.
+            if (
+              valueParameter.kind == IrParameterKind.Regular &&
+                valueParameter.type.classFqName == modifierClassFqName
+            ) {
               val argument = expression.arguments[idx]
               expression.arguments[idx] = wrapExpression(argument, composableName, builder)
             }

--- a/sentry-kotlin-compiler-plugin/src/kotlin2400/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension24.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2400/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension24.kt
@@ -178,9 +178,9 @@ class JetpackComposeTracingIrExtension24(private val messageCollector: MessageCo
 
           for (idx in 0 until expression.symbol.owner.parameters.size) {
             val valueParameter = expression.symbol.owner.parameters[idx]
-            // 2.4's unified parameter API also lists dispatch/extension/context receivers, so
-            // wrap only actual value arguments. Otherwise the Modifier receivers of chained
-            // calls (e.g. Modifier.fillMaxSize().padding()) get tagged too.
+            // In Kotlin 2.2 dispatch/extension receivers are part of parameters; only enrich
+            // regular value parameters, otherwise modifier-receiver chains (e.g.
+            // Modifier.fillMaxSize().padding()) would each get their receiver wrapped as well.
             if (
               valueParameter.kind == IrParameterKind.Regular &&
                 valueParameter.type.classFqName == modifierClassFqName

--- a/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/SentryKotlinCompilerPlugin.kt
+++ b/sentry-kotlin-compiler-plugin/src/main/kotlin/io/sentry/SentryKotlinCompilerPlugin.kt
@@ -1,17 +1,14 @@
 package io.sentry
 
 import com.google.auto.service.AutoService
-import io.sentry.compose.JetpackComposeTracingIrExtension19
-import io.sentry.compose.JetpackComposeTracingIrExtension21
-import io.sentry.compose.JetpackComposeTracingIrExtension22
-import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import io.sentry.compose.registerComposeTracing19
+import io.sentry.compose.registerComposeTracing21
+import io.sentry.compose.registerComposeTracing22
+import io.sentry.compose.registerComposeTracing24
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
-import org.jetbrains.kotlin.config.messageCollector
 
 @OptIn(ExperimentalCompilerApi::class)
 @AutoService(CompilerPluginRegistrar::class)
@@ -20,8 +17,12 @@ class SentryKotlinCompilerPlugin : CompilerPluginRegistrar() {
   override val supportsK2: Boolean
     get() = true
 
-  val pluginId: String = PLUGIN_ID
+  override val pluginId: String = PLUGIN_ID
 
+  // The extension registration API is binary-incompatible across compiler versions
+  // (e.g. 2.4 replaced ProjectExtensionDescriptor with ExtensionPointDescriptor), so the
+  // registration itself is delegated to a per-version helper compiled against that version's
+  // compiler. This class only dispatches and must reference no version-specific compiler API.
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
     val versionString = KotlinCompilerVersion.getVersion()
     val version =
@@ -31,22 +32,11 @@ class SentryKotlinCompilerPlugin : CompilerPluginRegistrar() {
         SimpleSemVer(2, 1, 20)
       }
 
-    val extension: IrGenerationExtension =
-      if (version >= SimpleSemVer(2, 2, 0)) {
-        val messageCollector = configuration.messageCollector
-        JetpackComposeTracingIrExtension22(messageCollector)
-      } else if (version >= SimpleSemVer(2, 1, 20)) {
-        val messageCollector = configuration.messageCollector
-        // 2.1.20 removed some optional parameters, causing API incompatibility
-        // e.g. java.lang.NoSuchMethodError
-        // see https://github.com/JetBrains/kotlin/commit/dd508452c414a0ee8082aa6f76d664271cb38f2f
-        JetpackComposeTracingIrExtension21(messageCollector)
-      } else {
-        val messageCollector =
-          configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-        JetpackComposeTracingIrExtension19(messageCollector)
-      }
-
-    IrGenerationExtension.registerExtension(extension)
+    when {
+      version >= SimpleSemVer(2, 4, 0) -> registerComposeTracing24(configuration)
+      version >= SimpleSemVer(2, 2, 0) -> registerComposeTracing22(configuration)
+      version >= SimpleSemVer(2, 1, 20) -> registerComposeTracing21(configuration)
+      else -> registerComposeTracing19(configuration)
+    }
   }
 }

--- a/sentry-kotlin-compiler-plugin/src/test/kotlin/io/sentry/compose/JetpackComposeInstrumentationTest.kt
+++ b/sentry-kotlin-compiler-plugin/src/test/kotlin/io/sentry/compose/JetpackComposeInstrumentationTest.kt
@@ -8,14 +8,8 @@ import io.sentry.SentryKotlinCompilerPlugin
 import io.sentry.SentryKotlinCompilerPluginCommandLineProcessor
 import kotlin.test.assertEquals
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
-import org.junit.Ignore
 import org.junit.Test
 
-// The module now compiles against the Kotlin 2.4 compiler, but no stable kotlin-compile-testing
-// (kctfork) release supports 2.4 yet — it passes a null optIn to CommonCompilerArguments, which
-// 2.4 rejects. Re-enable once a stable kctfork supports Kotlin 2.4. The 2.4 instrumentation path
-// is still exercised end-to-end by the sample-app builds in the AGP/Gradle/Kotlin test matrix.
-@Ignore("kctfork has no stable release compatible with the Kotlin 2.4 compiler yet")
 @OptIn(ExperimentalCompilerApi::class)
 class JetpackComposeInstrumentationTest {
 

--- a/sentry-kotlin-compiler-plugin/src/test/kotlin/io/sentry/compose/JetpackComposeInstrumentationTest.kt
+++ b/sentry-kotlin-compiler-plugin/src/test/kotlin/io/sentry/compose/JetpackComposeInstrumentationTest.kt
@@ -8,8 +8,14 @@ import io.sentry.SentryKotlinCompilerPlugin
 import io.sentry.SentryKotlinCompilerPluginCommandLineProcessor
 import kotlin.test.assertEquals
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.Ignore
 import org.junit.Test
 
+// The module now compiles against the Kotlin 2.4 compiler, but no stable kotlin-compile-testing
+// (kctfork) release supports 2.4 yet — it passes a null optIn to CommonCompilerArguments, which
+// 2.4 rejects. Re-enable once a stable kctfork supports Kotlin 2.4. The 2.4 instrumentation path
+// is still exercised end-to-end by the sample-app builds in the AGP/Gradle/Kotlin test matrix.
+@Ignore("kctfork has no stable release compatible with the Kotlin 2.4 compiler yet")
 @OptIn(ExperimentalCompilerApi::class)
 class JetpackComposeInstrumentationTest {
 


### PR DESCRIPTION
## What

- **Adds Kotlin 2.4 support** to the Compose tracing compiler plugin. Kotlin 2.4 replaced `ProjectExtensionDescriptor` with `ExtensionPointDescriptor` as the `IrGenerationExtension` registration descriptor, so the single shared registration call threw `IrGenerationExtension$Companion cannot be cast to ProjectExtensionDescriptor` at runtime on the matrix. Registration is now delegated to per-version helpers (`registerComposeTracing19/21/22/24`), each compiled against its own compiler ABI, with `SentryKotlinCompilerPlugin` only dispatching via version-stable APIs. A new `kotlin2400` variant (built against `kotlin-compiler-embeddable:2.4.0`) handles 2.4 IR generation.
- **Fixes a Compose instrumentation bug** where chained modifiers (e.g. `Modifier.fillMaxSize().padding()`) were tagged multiple times. Since Kotlin 2.2 the unified `IrFunction.parameters` API also lists dispatch/extension/context receivers, so the receivers of chained calls got wrapped too. Wrapping is now restricted to `IrParameterKind.Regular` arguments. Affects the 2.2.0 and 2.4.0 variants; the 1.9.24 / 2.1.20 variants use the older `valueParameters` API and are unaffected.
- **Resolves three CI-matrix compile errors**: `toLowerCase`/`toUpperCase(Locale)` → `lowercase`/`uppercase`, and removes an invalid `<Boolean?>` type argument on the `debug` extension property (it stays `Property<Boolean>`).

## Why

The nightly AGP/Gradle/Kotlin test matrix started exercising Kotlin 2.4 and failed at compiler-plugin registration, on top of the pre-existing deprecation and type-mismatch compile errors.

Closes #1257 
Fixes Gradle-105

## How

- The compiler-plugin module's Kotlin Gradle Plugin is bumped to **2.3.21** (not 2.4): a 2.3 compiler can read 2.4.0 metadata to build the `kotlin2400` variant, while keeping `languageVersion` at 1.9 and allowing a stable `kotlin-compile-testing` (0.12.1).
- Each registration helper lives in its own source set, so only the runtime-selected one is loaded — keeping the version-specific descriptor types off every other Kotlin runtime's classpath.

## Notes

- The `kotlin2400` variant is exercised end-to-end by the matrix's sample-app builds; the module's unit tests run on the 2.3 compiler and cover the fixed `Extension22` path.
- The chained-modifier over-wrapping was a latent bug in the released plugin on Kotlin 2.2+, not new to this PR.