### PR TITLE
build(deps): Update kctfork to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix duplicate Sentry modifier injection on chained modifiers when compiling with Kotlin 2.2+ ([#1254](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1254))
+
 ## 6.9.0
 
 ### Fixes

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ kotlinCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-comp
 autoService = { group = "com.google.auto.service", name = "auto-service", version = "1.1.1" }
 autoServiceAnnotatons = { group = "com.google.auto.service", name = "auto-service-annotations", version = "1.1.1" }
 kotlinJunit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
-kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.7.1" }
+kotlinCompileTesting = { group = "dev.zacsweers.kctfork", name = "core", version = "0.11.1" }
 truth = { module = "com.google.truth:truth", version = "1.4.5" }
 composeDesktop = { group = "org.jetbrains.compose.desktop", name = "desktop", version = "1.6.10" }
 

--- a/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
+++ b/sentry-kotlin-compiler-plugin/src/kotlin2200/kotlin/io/sentry/compose/JetpackComposeTracingIrExtension22.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.ir.builders.irGetObjectValue
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -173,7 +174,13 @@ class JetpackComposeTracingIrExtension22(private val messageCollector: MessageCo
 
           for (idx in 0 until expression.symbol.owner.parameters.size) {
             val valueParameter = expression.symbol.owner.parameters[idx]
-            if (valueParameter.type.classFqName == modifierClassFqName) {
+            // In Kotlin 2.2 dispatch/extension receivers are part of parameters; only enrich
+            // regular value parameters, otherwise modifier-receiver chains (e.g.
+            // Modifier.fillMaxSize().padding()) would each get their receiver wrapped as well.
+            if (
+              valueParameter.kind == IrParameterKind.Regular &&
+                valueParameter.type.classFqName == modifierClassFqName
+            ) {
               val argument = expression.arguments[idx]
               expression.arguments[idx] = wrapExpression(argument, composableName, builder)
             }


### PR DESCRIPTION
Bumps `dev.zacsweers.kctfork:core` from `0.7.1` to `0.11.1`.

`0.11.1` is the newest release we can use: its embedded Kotlin compiler is `2.2.x`, whose metadata the compiler plugin's pinned Kotlin `2.1` reader still tolerates (readers accept up to +1 minor). `0.12.x` embeds Kotlin `2.3`, whose metadata version `2.3.0` is rejected with `expected version is 2.1.0`.

### Fix surfaced by the bump

Running `:sentry-kotlin-compiler-plugin` tests against an embedded Kotlin `2.2` compiler for the first time exposed a real bug in `JetpackComposeTracingIrExtension22` (the IR extension used in production for Kotlin 2.2+ users). Kotlin 2.2 folds dispatch and extension receivers into the unified `parameters` list, so chained modifiers like `Modifier.fillMaxSize().padding(8.dp)` had the Sentry tag injected onto every `Modifier`-typed receiver as well as the real modifier argument — 3 injections instead of 1. The fix restricts enrichment to regular value parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)