### PR TITLE
fix(telemetry): Resolve default org via ValueSource at execution (GRADLE-82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Resolve the sentry-cli path as a task input instead of memoizing it in a static field, fixing stale-path build failures when switching branches with the configuration cache enabled ([#1264](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1264))
   - This fixed the issue where sentry-cli could not be found (`A problem occurred starting process 'command  ../sentry-cliXXX.exe'`)
+- Defer the telemetry default-org lookup to execution time so the configuration cache no longer re-runs `sentry-cli` on every build ([#1263](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1263))
 
 ## 6.10.0
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -83,7 +83,7 @@ fun ApplicationAndroidComponentsExtension.configure(
     if (isVariantAllowed(extension, variant.name, variant.flavorName, variant.buildType)) {
       val paths = OutputPaths(project, variant.name)
       val sentryTelemetryProvider =
-        variant.configureTelemetry(project, extension, cliExecutable, sentryOrg, buildEvents)
+        variant.configureTelemetry(project, extension, sentryOrg, buildEvents)
 
       variant.configureDependenciesTask(project, extension, sentryTelemetryProvider)
 
@@ -265,7 +265,6 @@ fun ApplicationAndroidComponentsExtension.configure(
 private fun Variant.configureTelemetry(
   project: Project,
   extension: SentryPluginExtension,
-  cliExecutable: Provider<String>,
   sentryOrg: String?,
   buildEvents: BuildEventListenerRegistryInternal,
 ): Provider<SentryTelemetryService> {
@@ -273,14 +272,7 @@ private fun Variant.configureTelemetry(
   val sentryTelemetryProvider = SentryTelemetryService.register(project)
   project.gradle.taskGraph.whenReady {
     sentryTelemetryProvider.get().start {
-      SentryTelemetryService.createParameters(
-        project,
-        variant,
-        extension,
-        cliExecutable,
-        sentryOrg,
-        "Android",
-      )
+      SentryTelemetryService.createParameters(project, variant, extension, sentryOrg, "Android")
     }
     buildEvents.onOperationCompletion(sentryTelemetryProvider)
   }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryCliProvider.kt
@@ -13,14 +13,17 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.Locale
 import java.util.Properties
+import java.util.concurrent.TimeUnit
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 internal object SentryCliProvider {
 
@@ -194,5 +197,92 @@ private fun Project.getIsolatedRootProjectDir(): Directory {
     isolated.rootProject.projectDirectory
   } else {
     rootProject.layout.projectDirectory
+  }
+}
+
+/**
+ * Resolves the default Sentry organization by running `sentry-cli info`. Implemented as a
+ * ValueSource so the external process is started in a configuration-cache compatible way; querying
+ * the returned provider during task execution keeps the process off the configuration phase.
+ */
+abstract class SentryOrgValueSource : ValueSource<String, SentryOrgValueSource.Params> {
+  interface Params : ValueSourceParameters {
+    @get:Input val projectDir: DirectoryProperty
+
+    @get:Input val projectBuildDir: DirectoryProperty
+
+    @get:Input val rootProjDir: DirectoryProperty
+
+    @get:Input @get:Optional val url: Property<String>
+
+    @get:Input @get:Optional val authToken: Property<String>
+
+    @get:Input @get:Optional val propertiesFilePath: Property<String>
+  }
+
+  override fun obtain(): String? {
+    return try {
+      val cliPath =
+        SentryCliProvider.getSentryCliPath(
+          parameters.projectDir,
+          parameters.projectBuildDir,
+          parameters.rootProjDir,
+        )
+      val resolvedCli =
+        SentryCliProvider.maybeExtractFromResources(parameters.projectBuildDir, cliPath)
+
+      val args = mutableListOf(resolvedCli)
+      parameters.url.orNull?.let {
+        args.add("--url")
+        args.add(it)
+      }
+      args.add("--log-level=error")
+      args.add("info")
+
+      val processBuilder = ProcessBuilder(args).redirectErrorStream(true)
+      parameters.propertiesFilePath.orNull?.let {
+        processBuilder.environment()["SENTRY_PROPERTIES"] = it
+      }
+      parameters.authToken.orNull?.let { processBuilder.environment()["SENTRY_AUTH_TOKEN"] = it }
+      processBuilder.environment()["SENTRY_PIPELINE"] =
+        "sentry-gradle-plugin/${BuildConfig.Version}"
+
+      val process = processBuilder.start()
+      // Wait with the timeout before reading the output: reading first would block indefinitely if
+      // the process hangs (e.g. a network stall), bypassing the timeout. `info` output is small and
+      // bounded, so it cannot fill the pipe buffer and stall the process before we read it here.
+      if (!process.waitFor(CLI_INFO_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        return null
+      }
+      if (process.exitValue() != 0) {
+        return null
+      }
+      val output = process.inputStream.bufferedReader().readText()
+      ORG_REGEX.find(output)?.groupValues?.getOrNull(1)?.takeUnless { it == "-" }
+    } catch (t: Throwable) {
+      logger.info { "Failed to fetch default org from sentry-cli: ${t.message}" }
+      null
+    }
+  }
+
+  companion object {
+    private val ORG_REGEX = Regex("""(?m)Default Organization: (.*)$""")
+    private const val CLI_INFO_TIMEOUT_SECONDS = 5L
+  }
+}
+
+fun Project.defaultOrgProvider(
+  url: String?,
+  authToken: String?,
+  propertiesFilePath: String?,
+): Provider<String> {
+  return providers.of(SentryOrgValueSource::class.java) {
+    it.parameters.projectDir.set(layout.projectDirectory)
+    it.parameters.projectBuildDir.set(layout.buildDirectory)
+    it.parameters.rootProjDir.set(getIsolatedRootProjectDir())
+    url?.let { value -> it.parameters.url.set(value) }
+    authToken?.let { value -> it.parameters.authToken.set(value) }
+    propertiesFilePath?.let { value -> it.parameters.propertiesFilePath.set(value) }
   }
 }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -27,6 +27,7 @@ import io.sentry.exception.ExceptionMechanismException
 import io.sentry.gradle.common.SentryVariant
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.User
+import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails
@@ -49,7 +50,7 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
   private var didAddChildSpans: Boolean = false
   private var started: Boolean = false
   private var orgProvider: Provider<String>? = null
-  private var orgAttached: Boolean = false
+  private val orgAttached = AtomicBoolean(false)
 
   @Synchronized
   fun start(paramsCallback: () -> SentryTelemetryServiceParams) {
@@ -207,10 +208,9 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
   // the underlying sentry-cli process out of the configuration phase so the configuration cache
   // stays valid. An explicitly configured org already set on the scope is left untouched.
   private fun attachDefaultOrg() {
-    if (orgAttached) {
+    if (!orgAttached.compareAndSet(false, true)) {
       return
     }
-    orgAttached = true
     orgProvider?.orNull?.let { org ->
       scopes.configureScope { scope ->
         if (scope.user?.id == null) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryService.kt
@@ -13,37 +13,26 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SpanStatus
 import io.sentry.TransactionOptions
-import io.sentry.android.gradle.SentryCliProvider
 import io.sentry.android.gradle.SentryPlugin
 import io.sentry.android.gradle.SentryPlugin.Companion.logger
 import io.sentry.android.gradle.SentryPropertiesFileProvider
+import io.sentry.android.gradle.defaultOrgProvider
 import io.sentry.android.gradle.extensions.SentryPluginExtension
-import io.sentry.android.gradle.telemetry.SentryCliInfoValueSource.InfoParams
-import io.sentry.android.gradle.telemetry.SentryCliVersionValueSource.VersionParams
 import io.sentry.android.gradle.util.AgpVersions
 import io.sentry.android.gradle.util.SentryCliException
 import io.sentry.android.gradle.util.error
 import io.sentry.android.gradle.util.getBuildServiceName
 import io.sentry.android.gradle.util.info
-import io.sentry.android.gradle.util.setSentryPipelineEnv
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.gradle.common.SentryVariant
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.User
-import java.io.ByteArrayOutputStream
-import java.nio.charset.Charset
-import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ValueSource
-import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters.None
-import org.gradle.api.tasks.Input
 import org.gradle.execution.RunRootBuildWorkBuildOperationType
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.BuildOperationListener
@@ -51,7 +40,6 @@ import org.gradle.internal.operations.OperationFinishEvent
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
-import org.gradle.process.ExecOperations
 import org.gradle.util.GradleVersion
 
 abstract class SentryTelemetryService : BuildService<None>, BuildOperationListener, AutoCloseable {
@@ -60,6 +48,8 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
   private var transaction: ITransaction? = null
   private var didAddChildSpans: Boolean = false
   private var started: Boolean = false
+  private var orgProvider: Provider<String>? = null
+  private var orgAttached: Boolean = false
 
   @Synchronized
   fun start(paramsCallback: () -> SentryTelemetryServiceParams) {
@@ -108,15 +98,10 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
 
         scopes.configureScope { scope ->
           scope.user =
-            User().also { user ->
-              startParameters.defaultSentryOrganization?.let { org ->
-                if (org != "-") {
-                  user.id = org
-                }
-              }
-              startParameters.sentryOrganization?.let { user.id = it }
-            }
+            User().also { user -> startParameters.sentryOrganization?.let { user.id = it } }
         }
+
+        orgProvider = startParameters.cliOrgProvider
 
         started = true
       }
@@ -212,8 +197,27 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
 
   fun startTask(operation: String): ISpan? {
     didAddChildSpans = true
+    attachDefaultOrg()
     scopes.setTag("step", operation)
     return scopes.span?.startChild(operation)
+  }
+
+  // Resolves the default org (via the SentryOrgValueSource provider) on the first tracked task and
+  // attaches it to the telemetry scope. Querying the provider here, during task execution, keeps
+  // the underlying sentry-cli process out of the configuration phase so the configuration cache
+  // stays valid. An explicitly configured org already set on the scope is left untouched.
+  private fun attachDefaultOrg() {
+    if (orgAttached) {
+      return
+    }
+    orgAttached = true
+    orgProvider?.orNull?.let { org ->
+      scopes.configureScope { scope ->
+        if (scope.user?.id == null) {
+          scope.user = User().also { it.id = org }
+        }
+      }
+    }
   }
 
   fun endTask(span: ISpan?, task: Task) {
@@ -238,32 +242,19 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
     val SENTRY_SAAS_DSN: String =
       "https://000e5dea9770b4537055f8a6d28c021e@o1.ingest.sentry.io/4506241308295168"
     val MECHANISM_TYPE: String = "GradleTelemetry"
-    private val orgRegex = Regex("""(?m)Default Organization: (.*)$""")
-    private val versionRegex = Regex("""(?m)sentry-cli (.*)$""")
 
     fun createParameters(
       project: Project,
       variant: SentryVariant?,
       extension: SentryPluginExtension,
-      cliExecutable: Provider<String>,
       sentryOrg: String?,
       buildType: String,
     ): SentryTelemetryServiceParams {
       val tags = extraTagsFromExtension(project, extension)
       val org = sentryOrg ?: extension.org.orNull
-      val isTelemetryEnabled = extension.telemetry.get()
 
-      // if telemetry is disabled we don't even need to exec sentry-cli as telemetry service
-      // will be no-op
-      if (isTelemetryEnabled) {
-        paramsWithExecAvailable(project, cliExecutable, extension, variant, org, buildType, tags)
-          ?.let {
-            return it
-          }
-      }
-      // fallback: sentry-cli is not available or e.g. auth token is not configured
       return SentryTelemetryServiceParams(
-        isTelemetryEnabled,
+        extension.telemetry.get(),
         extension.telemetryDsn.get(),
         org,
         buildType,
@@ -271,73 +262,12 @@ abstract class SentryTelemetryService : BuildService<None>, BuildOperationListen
         extension.debug.get(),
         saas = extension.url.orNull == null,
         cliVersion = BuildConfig.CliVersion,
-      )
-    }
-
-    private fun paramsWithExecAvailable(
-      project: Project,
-      cliExecutable: Provider<String>,
-      extension: SentryPluginExtension,
-      variant: SentryVariant?,
-      sentryOrg: String?,
-      buildType: String,
-      tags: Map<String, String>,
-    ): SentryTelemetryServiceParams? {
-      var cliVersion: String? = BuildConfig.CliVersion
-      var defaultSentryOrganization: String? = null
-      val infoOutput =
-        project.providers
-          .of(SentryCliInfoValueSource::class.java) { cliVS ->
-            cliVS.parameters.buildDirectory.set(project.layout.buildDirectory)
-            cliVS.parameters.cliExecutable.set(cliExecutable)
-            cliVS.parameters.authToken.set(extension.authToken)
-            cliVS.parameters.url.set(extension.url)
-            variant?.let { v ->
-              cliVS.parameters.propertiesFilePath.set(
-                SentryPropertiesFileProvider.getPropertiesFilePath(project, v)
-              )
-            }
-          }
-          .get()
-
-      if (infoOutput.isEmpty()) {
-        return null
-      }
-      val isSaas = infoOutput.contains("(?m)Sentry Server: .*sentry.io$".toRegex())
-
-      orgRegex.find(infoOutput)?.let { matchResult ->
-        val groupValues = matchResult.groupValues
-        if (groupValues.size > 1) {
-          defaultSentryOrganization = groupValues[1]
-        }
-      }
-
-      val versionOutput =
-        project.providers
-          .of(SentryCliVersionValueSource::class.java) { cliVS ->
-            cliVS.parameters.buildDirectory.set(project.layout.buildDirectory)
-            cliVS.parameters.cliExecutable.set(cliExecutable)
-            cliVS.parameters.url.set(extension.url)
-          }
-          .get()
-
-      versionRegex.find(versionOutput)?.let { matchResult ->
-        val groupValues = matchResult.groupValues
-        if (groupValues.size > 1) {
-          cliVersion = groupValues[1]
-        }
-      }
-
-      return SentryTelemetryServiceParams(
-        extension.telemetry.get(),
-        extension.telemetryDsn.get(),
-        sentryOrg,
-        buildType,
-        tags,
-        extension.debug.get(),
-        defaultSentryOrganization,
-        isSaas,
-        cliVersion = cliVersion,
+        cliOrgProvider =
+          project.defaultOrgProvider(
+            extension.url.orNull,
+            extension.authToken.orNull,
+            variant?.let { SentryPropertiesFileProvider.getPropertiesFilePath(project, it) },
+          ),
       )
     }
 
@@ -419,104 +349,6 @@ class SentryMinimalException(message: String) : RuntimeException(message) {
   }
 }
 
-abstract class SentryCliInfoValueSource : ValueSource<String, InfoParams> {
-  interface InfoParams : ValueSourceParameters {
-    @get:Input val buildDirectory: DirectoryProperty
-
-    @get:Input val cliExecutable: Property<String>
-
-    @get:Input val propertiesFilePath: Property<String>
-
-    @get:Input val url: Property<String>
-
-    @get:Input val authToken: Property<String>
-  }
-
-  @get:Inject abstract val execOperations: ExecOperations
-
-  override fun obtain(): String? {
-    val stdOutput = ByteArrayOutputStream()
-    val errOutput = ByteArrayOutputStream()
-
-    val execResult =
-      execOperations.exec {
-        it.isIgnoreExitValue = true
-        SentryCliProvider.maybeExtractFromResources(
-          parameters.buildDirectory,
-          parameters.cliExecutable.get(),
-        )
-
-        val args = mutableListOf(parameters.cliExecutable.get())
-
-        parameters.url.orNull?.let { url ->
-          args.add("--url")
-          args.add(url)
-        }
-
-        args.add("--log-level=error")
-        args.add("info")
-
-        parameters.propertiesFilePath.orNull?.let { path ->
-          it.environment("SENTRY_PROPERTIES", path)
-        }
-
-        parameters.authToken.orNull?.let { authToken ->
-          it.environment("SENTRY_AUTH_TOKEN", authToken)
-        }
-
-        it.setSentryPipelineEnv()
-
-        it.commandLine(args)
-        it.standardOutput = stdOutput
-        it.errorOutput = errOutput
-      }
-
-    if (execResult.exitValue == 0) {
-      return String(stdOutput.toByteArray(), Charset.defaultCharset())
-    } else {
-      logger.info {
-        "Failed to execute sentry-cli info. Error Output: " +
-          String(errOutput.toByteArray(), Charset.defaultCharset())
-      }
-      return ""
-    }
-  }
-}
-
-abstract class SentryCliVersionValueSource : ValueSource<String, VersionParams> {
-  interface VersionParams : ValueSourceParameters {
-    @get:Input val buildDirectory: DirectoryProperty
-
-    @get:Input val cliExecutable: Property<String>
-
-    @get:Input val url: Property<String>
-  }
-
-  @get:Inject abstract val execOperations: ExecOperations
-
-  override fun obtain(): String {
-    val output = ByteArrayOutputStream()
-    execOperations.exec {
-      it.isIgnoreExitValue = true
-      SentryCliProvider.maybeExtractFromResources(
-        parameters.buildDirectory,
-        parameters.cliExecutable.get(),
-      )
-
-      val args = mutableListOf(parameters.cliExecutable.get())
-
-      args.add("--log-level=error")
-      args.add("--version")
-
-      it.setSentryPipelineEnv()
-
-      it.commandLine(args)
-      it.standardOutput = output
-    }
-    return String(output.toByteArray(), Charset.defaultCharset())
-  }
-}
-
 data class SentryTelemetryServiceParams(
   val sendTelemetry: Boolean,
   val dsn: String,
@@ -524,7 +356,7 @@ data class SentryTelemetryServiceParams(
   val buildType: String,
   val extraTags: Map<String, String>,
   val isDebug: Boolean,
-  val defaultSentryOrganization: String? = null,
   val saas: Boolean? = null,
   val cliVersion: String? = null,
+  val cliOrgProvider: Provider<String>? = null,
 )

--- a/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/jvm/gradle/SentryJvmPlugin.kt
@@ -66,7 +66,6 @@ constructor(private val buildEvents: BuildEventListenerRegistryInternal) : Plugi
             project,
             javaVariant,
             extension,
-            cliExecutable,
             sentryOrgParameter,
             "JVM",
           )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/telemetry/SentryTelemetryServiceTest.kt
@@ -1,7 +1,9 @@
 package io.sentry.android.gradle.telemetry
 
-import io.sentry.android.gradle.SentryCliProvider
+import io.sentry.BuildConfig
+import io.sentry.android.gradle.extensions.SentryPluginExtension
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -11,24 +13,34 @@ class SentryTelemetryServiceTest {
 
   @get:Rule val testProjectDir = TemporaryFolder()
 
-  @Suppress("UnstableApiUsage")
   @Test
-  fun `SentryCliInfoValueSource returns empty string when no auth token is present`() {
+  fun `createParameters uses BuildConfig CliVersion`() {
     val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
+    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java)
 
-    val cliPath =
-      SentryCliProvider.getCliResourcesExtractionPath(project.layout.buildDirectory).get().asFile
+    val params = SentryTelemetryService.createParameters(project, null, extension, null, "test")
 
-    val infoOutput =
-      project.providers
-        .of(SentryCliInfoValueSource::class.java) { cliVS ->
-          cliVS.parameters.buildDirectory.set(project.layout.buildDirectory)
-          cliVS.parameters.cliExecutable.set(cliPath.absolutePath)
-          // sets an empty/invalid auth token
-          cliVS.parameters.authToken.set("")
-        }
-        .get()
+    assertEquals(BuildConfig.CliVersion, params.cliVersion)
+  }
 
-    assertEquals("", infoOutput)
+  @Test
+  fun `createParameters detects SaaS when no URL is set`() {
+    val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
+    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java)
+
+    val params = SentryTelemetryService.createParameters(project, null, extension, null, "test")
+
+    assertTrue(params.saas == true)
+  }
+
+  @Test
+  fun `createParameters detects self-hosted when URL is set`() {
+    val project = ProjectBuilder.builder().withProjectDir(testProjectDir.root).build()
+    val extension = project.extensions.create("sentry", SentryPluginExtension::class.java)
+    extension.url.set("https://sentry.example.com")
+
+    val params = SentryTelemetryService.createParameters(project, null, extension, null, "test")
+
+    assertTrue(params.saas == false)
   }
 }


### PR DESCRIPTION
## Summary

When telemetry is enabled (the default), the plugin resolved the default Sentry organization and CLI version during the **configuration phase** via two `ValueSource`s (`SentryCliInfoValueSource` running `sentry-cli info`, and `SentryCliVersionValueSource` running `sentry-cli --version`). Because both were `.get()`-ed during configuration, Gradle tracked them as configuration inputs and re-evaluated them on **every configuration-cache-hit build** — spawning two `sentry-cli` processes on every build even when no Sentry task ran. On a ~100-module project this added ~38% configuration overhead.

This replaces them with a single `SentryOrgValueSource` that is queried lazily on the first tracked task, so the `sentry-cli` process runs during **execution** and stays off the configuration phase. The CLI version now comes directly from `BuildConfig.CliVersion`.

This is one of two PRs splitting the config-cache work; the companion PR (#GRADLE-70) makes the sentry-cli path resolution config-cache friendly. Whichever lands second will drop the now-unused `cliExecutable` parameter still threaded through `configure()`.

<img width="544" height="155" alt="image" src="https://github.com/user-attachments/assets/9d18722b-f7a4-4690-af30-e3b2542f6396" />

## Behavioral note: when the default org attaches

Previously the default org was resolved at configuration time and set on the telemetry scope inside `start()` (at `taskGraph.whenReady`), so it was attached before execution began. Now it attaches lazily on the **first telemetry-tracked task to execute** (via `attachDefaultOrg()`, called from `startTask`).

Every Sentry upload task is telemetry-wrapped (`withSentryTelemetry` → `startTask`) — mappings, native symbols, app artifact, source bundle, the ProGuard UUID/dependency-report tasks, etc. — so any build that actually does a Sentry upload runs at least one tracked task and gets the default org attached. The only events that would miss the default org are those captured **strictly before any tracked task runs** (e.g. a failure during the configuration phase). That's an inherent and acceptable consequence of moving the `sentry-cli info` call off the configuration phase, which is the whole point of this change; an explicitly configured org is still set eagerly in `start()` and is unaffected.

Fixes GRADLE-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)