### PR TITLE
ci: Remove redundant assemble step from pre-merge workflow

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -45,6 +45,3 @@ jobs:
           name: test-results-${{ matrix.os }}
           path: plugin-build/build/reports/tests/
         if: always()
-
-      - name: Build the Debug and Release variants
-        run: ./gradlew assemble


### PR DESCRIPTION
Removes the `assemble` step from the pre-merge workflow.

On Linux this is redundant with the [Build workflow](.github/workflows/build.yml), which already runs `./gradlew assemble` on `ubuntu-latest`.

Note: pre-merge also runs on macOS and Windows, where this step previously provided the only `assemble` coverage (`preMerge` is skipped on Windows and doesn't depend on `assemble`). Removing it drops that cross-platform build coverage, which is an accepted tradeoff here.