### PR TITLE
build: Remove Gradle deprecation warnings from sample build scripts

### DIFF
--- a/examples/android-gradle/build.gradle
+++ b/examples/android-gradle/build.gradle
@@ -6,8 +6,8 @@ plugins {
 android {
   compileSdk = LibsVersion.SDK_VERSION
   defaultConfig {
-    minSdk LibsVersion.MIN_SDK_VERSION
-    targetSdk LibsVersion.SDK_VERSION
+    minSdk = LibsVersion.MIN_SDK_VERSION
+    targetSdk = LibsVersion.SDK_VERSION
     versionCode = 1
     versionName = "1.0"
   }
@@ -18,7 +18,7 @@ android {
         'proguard-android-optimize.txt')
     }
   }
-  namespace 'com.example.sampleapp'
+  namespace = 'com.example.sampleapp'
 }
 
 sentry {

--- a/examples/android-ndk/build.gradle
+++ b/examples/android-ndk/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion LibsVersion.MIN_SDK_VERSION
-        targetSdk LibsVersion.SDK_VERSION
+        targetSdk = LibsVersion.SDK_VERSION
         versionCode = 1
         versionName = "1.0"
     }
@@ -23,7 +23,7 @@ android {
             path "jni/Android.mk"
         }
     }
-    namespace 'com.example.sampleapp'
+    namespace = 'com.example.sampleapp'
 }
 
 if (System.getenv("AUTO_UPLOAD")) {

--- a/examples/multi-module-sample/spring-boot-in-multi-module-sample/build.gradle.kts
+++ b/examples/multi-module-sample/spring-boot-in-multi-module-sample/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -28,7 +27,7 @@ dependencies {
   implementation(libs.sample.springBoot.kotlinReflect)
   implementation(libs.sample.springBoot.starterJdbc)
   implementation(libs.sentrySpringBootJakarta)
-  implementation(kotlin(Samples.SpringBoot.kotlinStdLib, KotlinCompilerVersion.VERSION))
+  implementation(kotlin(Samples.SpringBoot.kotlinStdLib))
 
   runtimeOnly(libs.sample.springBoot.hsqldb)
   testImplementation(libs.sample.springBoot.starterTest) {

--- a/examples/multi-module-sample/spring-boot-in-multi-module-sample2/build.gradle.kts
+++ b/examples/multi-module-sample/spring-boot-in-multi-module-sample2/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -28,7 +27,7 @@ dependencies {
   implementation(libs.sample.springBoot.kotlinReflect)
   implementation(libs.sample.springBoot.starterJdbc)
   implementation(libs.sentrySpringBootJakarta)
-  implementation(kotlin(Samples.SpringBoot.kotlinStdLib, KotlinCompilerVersion.VERSION))
+  implementation(kotlin(Samples.SpringBoot.kotlinStdLib))
 
   runtimeOnly(libs.sample.springBoot.hsqldb)
   testImplementation(libs.sample.springBoot.starterTest) {

--- a/examples/spring-boot-sample/build.gradle.kts
+++ b/examples/spring-boot-sample/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -28,7 +27,7 @@ dependencies {
   implementation(libs.sample.springBoot.kotlinReflect)
   implementation(libs.sample.springBoot.starterJdbc)
   implementation(libs.sentrySpringBootJakarta)
-  implementation(kotlin(Samples.SpringBoot.kotlinStdLib, KotlinCompilerVersion.VERSION))
+  implementation(kotlin(Samples.SpringBoot.kotlinStdLib))
 
   runtimeOnly(libs.sample.springBoot.hsqldb)
   testImplementation(libs.sample.springBoot.starterTest) {


### PR DESCRIPTION
Running the build with `--warning-mode all` surfaced two deprecations originating from our own sample build scripts. This PR removes them.

## Fixed

- **Groovy space-assignment syntax** (e.g. `minSdk <value>`) — deprecated and scheduled for removal in Gradle 10. Switched to the assignment syntax (`minSdk = <value>`) in:
  - `examples/android-gradle/build.gradle` (`minSdk`, `targetSdk`, `namespace`)
  - `examples/android-ndk/build.gradle` (`targetSdk`, `namespace`)
- **`KotlinCompilerVersion.VERSION`** — an internal Kotlin compiler class bundled into KGP. Dropped the explicit version argument so the Kotlin plugin manages the stdlib version in:
  - `examples/spring-boot-sample/build.gradle.kts`
  - `examples/multi-module-sample/spring-boot-in-multi-module-sample/build.gradle.kts`
  - `examples/multi-module-sample/spring-boot-in-multi-module-sample2/build.gradle.kts`

## Not fixed (third-party)

The remaining deprecations originate from plugin internals, not our build scripts, and can only be resolved by upgrading those plugins:

- `org.gradle.api.plugins.Convention` — emitted by the Kotlin Gradle Plugin (`AbstractKotlinPlugin.setUpJavaSourceSets`).
- `is-` boolean property warnings (`getCrunchPngs`, `getUseProguard`, `getWearAppUnbundled`) — emitted by AGP DSL classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)