### PR TITLE
build(plugin): Remove unused mavenLocal repository

### DIFF
--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -4,7 +4,6 @@ dependencyResolutionManagement {
   repositories {
     mavenCentral()
     google()
-    mavenLocal()
     exclusiveContent {
       forRepository { maven(url = "https://repo.gradle.org/gradle/libs-releases") }
       filter { includeGroup("org.gradle.experimental") }


### PR DESCRIPTION
## Summary

Removes the `mavenLocal()` repository from `plugin-build/settings.gradle.kts`. The plugin build resolves all of its dependencies from `mavenCentral()` and `google()`.

Dropping it also tightens supply-chain hygiene: it removes a path by which a locally-published artifact could slip into the plugin build's resolution.

#skip-changelog

GRADLE-104



🤖 Generated with [Claude Code](https://claude.com/claude-code)