### PR TITLE
build(publish): Stop declaring kotlin-stdlib in published POMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Compose tracing no longer adds the Sentry modifier multiple times for chained modifiers (e.g. `Modifier.fillMaxSize().padding()`) on Kotlin 2.2 and newer ([#1253](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1253))
+- The published Gradle plugin and `sentry-snapshots-runtime` POMs no longer declare a transitive `kotlin-stdlib` dependency ([#1276](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1276))
 
 ### Dependencies
 

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -2,6 +2,10 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryE
 org.gradle.caching=true
 org.gradle.parallel=true
 
+# Don't auto-add kotlin-stdlib to the published plugin's dependencies; the Gradle runtime
+# already provides the Kotlin stdlib.
+kotlin.stdlib.default.dependency=false
+
 # for debugging
 # org.gradle.logging.level=info
 

--- a/sentry-snapshots-runtime/gradle.properties
+++ b/sentry-snapshots-runtime/gradle.properties
@@ -2,6 +2,10 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryE
 org.gradle.caching=true
 org.gradle.parallel=true
 
+# Don't auto-add kotlin-stdlib to the published artifact's dependencies; consuming projects
+# already bring their own Kotlin stdlib.
+kotlin.stdlib.default.dependency=false
+
 GROUP = io.sentry
 POM_ARTIFACT_ID = sentry-snapshots-runtime
 VERSION_NAME = 6.10.0


### PR DESCRIPTION
The Kotlin Gradle plugin adds `kotlin-stdlib` as a default dependency, which leaks into the published POMs of the Gradle plugin (`io.sentry:sentry-android-gradle-plugin`) and the snapshots runtime (`io.sentry:sentry-snapshots-runtime`).

See Gradle docs for best practices: https://docs.gradle.org/current/userguide/best_practices_dependencies.html#dont_depend_on_kotlin_stdlib

Both artifacts run somewhere the Kotlin stdlib is already on the classpath — Gradle's own runtime for the plugin, and the consuming project for the runtime annotation library — so the declared dependency is redundant. Setting `kotlin.stdlib.default.dependency=false` in each module's `gradle.properties` drops it from the published POMs.

Verified locally: both modules still compile (they pick up stdlib transitively — via the Kotlin Gradle plugin and `androidx.annotation` respectively) and their generated POMs no longer list `kotlin-stdlib`.

`sentry-kotlin-compiler-plugin` is intentionally **not** included: its versioned source sets compile only against `kotlin-compiler-embeddable` and depend on the default stdlib to compile, so disabling it there would require fragile per-source-set `compileOnly` stdlib wiring for no real benefit (it's loaded into the Kotlin compiler classpath, which already provides stdlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)