### PR TITLE
docs: Add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ separate builds via `includeBuild`:
 
 - `plugin-build/` — the actual plugin source lives here, under `plugin-build/src`. It has
   its own `settings.gradle.kts` and `gradle.properties`. Look here first for plugin code.
-- `sentry-kotlin-compiler-plugin/` — Kotlin compiler plugin, substituted into samples
+- `sentry-kotlin-compiler-plugin/` — Kotlin compiler plugin which performs Jetpack Compose instrumentation, substituted into samples
   without publishing.
 - `sentry-snapshots-runtime/` — snapshots runtime, also substituted into samples.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ build cache — `./gradlew clean` and add `--no-build-cache`.
 - **Changelog is enforced** by [dangerfile.js](dangerfile.js): every PR must add an entry
   to the "Unreleased" section of [CHANGELOG.md](CHANGELOG.md) that references the PR
   number (e.g. `- Fix X ([#1234](...))`). To opt out, add `#skip-changelog` to the PR
-  description.
+  description. The entry needs the PR number, which you can get with
+  `gh pr view --json number -q '.number'` (or `gh pr view <branch> ...`).
 - `feat:` PRs get a reminder to update [sentry-docs](https://github.com/getsentry/sentry-docs).
 - Commit subjects use conventional-commit style with a scope, e.g. `fix(snapshots): ...`,
   `build(deps): ...`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+Guidance for AI agents and new contributors working in this repo. For human-facing
+setup and debugging instructions, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## What this is
+
+The Sentry Android Gradle Plugin (SAGP). It uploads ProGuard/R8 mappings, debug files,
+and source context, and performs bytecode instrumentation (e.g. Room, OkHttp, file I/O).
+
+## Repository layout
+
+This is a **Gradle composite build**, not a single project. The root
+`settings.gradle.kts` orchestrates the sample apps under `examples/` and pulls in three
+separate builds via `includeBuild`:
+
+- `plugin-build/` — the actual plugin source lives here, under `plugin-build/src`. It has
+  its own `settings.gradle.kts` and `gradle.properties`. Look here first for plugin code.
+- `sentry-kotlin-compiler-plugin/` — Kotlin compiler plugin, substituted into samples
+  without publishing.
+- `sentry-snapshots-runtime/` — snapshots runtime, also substituted into samples.
+
+`buildSrc/` holds version and dependency definitions (`Dependencies.kt`, plugin versions).
+
+## Requirements
+
+- JDK **17** and the Android SDK.
+
+## Common commands
+
+Run from the repo root (the root build delegates into the included builds):
+
+- `make format` → `./gradlew spotlessApply` — apply formatting (ktfmt, Google style).
+  Run this before committing; `spotlessCheck` runs in CI.
+- `make preMerge` → `./gradlew preMerge --continue` — the full local verification that
+  mirrors CI: `check` on the root, the compiler plugin, the snapshots runtime, and each
+  sample app.
+- `./gradlew integrationTest` — runs the plugin's integration tests (publishes the
+  compiler plugin to a local test repo first).
+- Plugin unit tests live in `plugin-build`: `./gradlew :plugin-build:test` (or via the
+  `plugin-build` included build).
+
+Some tests upload mappings/source context and fail without an auth token:
+
+```bash
+export SENTRY_AUTH_TOKEN=<your_token>
+```
+
+## Local sentry-cli
+
+To test against a local `sentry-cli`, set `cli.executable` in the target project's
+`sentry.properties`:
+
+```properties
+cli.executable=/path/to/your/local/sentry-cli
+```
+
+## Debugging the plugin
+
+Run a sample build with the debug agent attached, then connect a Remote JVM debug
+configuration from the IDE:
+
+```bash
+./gradlew :examples:android-instrumentation-sample:assembleDebug -Dorg.gradle.debug=true --no-daemon
+```
+
+If breakpoints in task actions don't hit, the tasks may be up-to-date or served from the
+build cache — `./gradlew clean` and add `--no-build-cache`.
+
+## Pull request conventions
+
+- **Changelog is enforced** by [dangerfile.js](dangerfile.js): every PR must add an entry
+  to the "Unreleased" section of [CHANGELOG.md](CHANGELOG.md) that references the PR
+  number (e.g. `- Fix X ([#1234](...))`). To opt out, add `#skip-changelog` to the PR
+  description.
+- `feat:` PRs get a reminder to update [sentry-docs](https://github.com/getsentry/sentry-docs).
+- Commit subjects use conventional-commit style with a scope, e.g. `fix(snapshots): ...`,
+  `build(deps): ...`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ build cache — `./gradlew clean` and add `--no-build-cache`.
   number (e.g. `- Fix X ([#1234](...))`). To opt out, add `#skip-changelog` to the PR
   description. The entry needs the PR number, which you can get with
   `gh pr view --json number -q '.number'` (or `gh pr view <branch> ...`).
+  - When rebasing, a release cut on `main` may have renamed the old "Unreleased" heading
+    to a version number, leaving your entry under a released section. Move it back into an
+    `## Unreleased` section at the top of the file (add the heading if it's missing).
 - `feat:` PRs get a reminder to update [sentry-docs](https://github.com/getsentry/sentry-docs).
 - Commit subjects use conventional-commit style with a scope, e.g. `fix(snapshots): ...`,
   `build(deps): ...`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adds agent and contributor guidance to the repo. There was no `AGENTS.md`, `CLAUDE.md`, or equivalent before — the useful knowledge was scattered across `CONTRIBUTING.md`, the `Makefile`, `build.gradle.kts`, and `dangerfile.js`.

The new `AGENTS.md` concentrates the things that aren't obvious from a glance at the tree:

- This is a **composite Gradle build** — plugin source lives in `plugin-build/src`, with `sentry-kotlin-compiler-plugin` and `sentry-snapshots-runtime` pulled in via `includeBuild`.
- Common commands: `make format` (spotless), `make preMerge`, `integrationTest`, plugin unit tests.
- The `SENTRY_AUTH_TOKEN` requirement for upload tests and the local `cli.executable` override.
- PR conventions, including the Danger-enforced changelog rule and conventional-commit scopes.

`CLAUDE.md` is a symlink to `AGENTS.md` so Claude Code and other tools read one source of truth with no drift.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)