### PR TITLE
build(deps): Bump mockito-kotlin to org.mockito.kotlin 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- Bump mockito-kotlin from `com.nhaarman.mockitokotlin2:2.2.0` to `org.mockito.kotlin:5.4.0` ([#XXXX](https://github.com/getsentry/sentry-android-gradle-plugin/pull/XXXX))
+- Bump mockito-kotlin from `com.nhaarman.mockitokotlin2:2.2.0` to `org.mockito.kotlin:5.4.0` ([#1286](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1286))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Bump mockito-kotlin from `com.nhaarman.mockitokotlin2:2.2.0` to `org.mockito.kotlin:5.4.0` ([#XXXX](https://github.com/getsentry/sentry-android-gradle-plugin/pull/XXXX))
+
 ### Fixes
 
 - Resolve the sentry-cli path as a task input instead of memoizing it in a static field, fixing stale-path build failures when switching branches with the configuration cache enabled ([#1264](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1264))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ sentryAndroidOkhttp = { group = "io.sentry", name = "sentry-android-okhttp", ver
 sentrySpringBootJakarta = { group = "io.sentry", name = "sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
 
 # test
-mockitoKotlin = { group = "com.nhaarman.mockitokotlin2", name = "mockito-kotlin", version = "2.2.0" }
+mockitoKotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "5.4.0" }
 arscLib = { group = "io.github.reandroid", name = "ARSCLib", version = "1.1.4" }
 zip4j = { group = "net.lingala.zip4j", name = "zip4j", version = "2.11.5" }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/AbstractInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/AbstractInstallStrategyTest.kt
@@ -1,14 +1,14 @@
 package io.sentry.android.gradle.autoinstall
 
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertTrue
 import org.gradle.api.artifacts.ComponentMetadataContext
 import org.gradle.api.artifacts.ComponentMetadataDetails
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class AbstractInstallStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/compose/ComposeInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/compose/ComposeInstallStrategyTest.kt
@@ -1,13 +1,5 @@
 package io.sentry.android.gradle.autoinstall.compose
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.check
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -19,6 +11,14 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class ComposeInstallStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/fragment/FragmentInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/fragment/FragmentInstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.fragment
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.check
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class FragmentInstallStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/Graphql22InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/Graphql22InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.graphql
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class Graphql22InstallStrategyTest {
@@ -66,9 +66,7 @@ class Graphql22InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-graphql-22:8.0.0", it)
-        }
+        org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-graphql-22:8.0.0", it) }
       )
   }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/GraphqlInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/graphql/GraphqlInstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.graphql
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class GraphqlInstallStrategyTest {
@@ -65,11 +65,7 @@ class GraphqlInstallStrategyTest {
         "[sentry] sentry-graphql was successfully installed with version: 6.25.2"
     }
     verify(fixture.dependencies)
-      .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-graphql:6.25.2", it)
-        }
-      )
+      .add(org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-graphql:6.25.2", it) })
   }
 
   @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/jdbc/JdbcInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/jdbc/JdbcInstallStrategyTest.kt
@@ -1,11 +1,5 @@
 package io.sentry.android.gradle.autoinstall.jdbc
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -17,6 +11,12 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class JdbcInstallStrategyTest {
@@ -64,11 +64,7 @@ class JdbcInstallStrategyTest {
         "[sentry] sentry-jdbc was successfully installed with version: 6.21.0"
     }
     verify(fixture.dependencies)
-      .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-jdbc:6.21.0", it)
-        }
-      )
+      .add(org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-jdbc:6.21.0", it) })
   }
 
   private class JdbcInstallStrategyImpl(logger: Logger) : JdbcInstallStrategy(logger)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/kotlin/KotlinExtensionsInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/kotlin/KotlinExtensionsInstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.kotlin
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class KotlinExtensionsInstallStrategyTest {
@@ -80,7 +80,7 @@ class KotlinExtensionsInstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-kotlin-extensions:6.25.2", it)
         }
       )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/log4j2/Log4j2InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/log4j2/Log4j2InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.log4j2
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class Log4j2InstallStrategyTest {
@@ -78,11 +78,7 @@ class Log4j2InstallStrategyTest {
         "[sentry] sentry-log4j2 was successfully installed with version: 6.25.2"
     }
     verify(fixture.dependencies)
-      .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-log4j2:6.25.2", it)
-        }
-      )
+      .add(org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-log4j2:6.25.2", it) })
   }
 
   private class Log4j2InstallStrategyImpl(logger: Logger) : Log4j2InstallStrategy(logger)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/logback/LogbackInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/logback/LogbackInstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.logback
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class LogbackInstallStrategyTest {
@@ -78,11 +78,7 @@ class LogbackInstallStrategyTest {
         "[sentry] sentry-logback was successfully installed with version: 6.25.2"
     }
     verify(fixture.dependencies)
-      .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-logback:6.25.2", it)
-        }
-      )
+      .add(org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-logback:6.25.2", it) })
   }
 
   private class LogbackInstallStrategyImpl(logger: Logger) : LogbackInstallStrategy(logger)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/AndroidOkHttpInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/AndroidOkHttpInstallStrategyTest.kt
@@ -1,13 +1,5 @@
 package io.sentry.android.gradle.autoinstall.okhttp
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.check
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -19,6 +11,14 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class AndroidOkHttpInstallStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/OkHttpInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/okhttp/OkHttpInstallStrategyTest.kt
@@ -1,13 +1,5 @@
 package io.sentry.android.gradle.autoinstall.okhttp
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.check
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -19,6 +11,14 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class OkHttpInstallStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/override/WarnOnOverrideStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/override/WarnOnOverrideStrategyTest.kt
@@ -1,10 +1,5 @@
 package io.sentry.android.gradle.autoinstall.override
 
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import io.sentry.android.gradle.util.SentryModules
@@ -15,6 +10,11 @@ import org.gradle.api.artifacts.ComponentMetadataDetails
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class WarnOnOverrideStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/quartz/QuartzInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/quartz/QuartzInstallStrategyTest.kt
@@ -1,11 +1,5 @@
 package io.sentry.android.gradle.autoinstall.quartz
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -17,6 +11,12 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class QuartzInstallStrategyTest {
@@ -64,11 +64,7 @@ class QuartzInstallStrategyTest {
         "[sentry] sentry-quartz was successfully installed with version: 6.30.0"
     }
     verify(fixture.dependencies)
-      .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-quartz:6.30.0", it)
-        }
-      )
+      .add(org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-quartz:6.30.0", it) })
   }
 
   private class QuartzInstallStrategyImpl(logger: Logger) : QuartzInstallStrategy(logger)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring5InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring5InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.spring
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class Spring5InstallStrategyTest {
@@ -91,11 +91,7 @@ class Spring5InstallStrategyTest {
         "[sentry] sentry-spring was successfully installed with version: 6.21.0"
     }
     verify(fixture.dependencies)
-      .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-spring:6.21.0", it)
-        }
-      )
+      .add(org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-spring:6.21.0", it) })
   }
 
   private class Spring5InstallStrategyImpl(logger: Logger) : Spring5InstallStrategy(logger)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring6InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring6InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.spring
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class Spring6InstallStrategyTest {
@@ -92,7 +92,7 @@ class Spring6InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-spring-jakarta:6.21.0", it)
         }
       )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring7InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/Spring7InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.spring
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class Spring7InstallStrategyTest {
@@ -92,9 +92,7 @@ class Spring7InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-spring-7:8.21.0", it)
-        }
+        org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-spring-7:8.21.0", it) }
       )
   }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot2InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.spring
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class SpringBoot2InstallStrategyTest {
@@ -92,9 +92,7 @@ class SpringBoot2InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
-          assertEquals("io.sentry:sentry-spring-boot:6.28.0", it)
-        }
+        org.mockito.kotlin.check<String> { assertEquals("io.sentry:sentry-spring-boot:6.28.0", it) }
       )
   }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot3InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.spring
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class SpringBoot3InstallStrategyTest {
@@ -92,7 +92,7 @@ class SpringBoot3InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-spring-boot-jakarta:6.28.0", it)
         }
       )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot4InstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/spring/SpringBoot4InstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.spring
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class SpringBoot4InstallStrategyTest {
@@ -92,7 +92,7 @@ class SpringBoot4InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-spring-boot-4:8.21.0", it)
         }
       )
@@ -109,7 +109,7 @@ class SpringBoot4InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-spring-boot-4:8.21.0", it)
         }
       )
@@ -126,7 +126,7 @@ class SpringBoot4InstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-spring-boot-4:8.21.0", it)
         }
       )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/sqlite/SqliteInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/sqlite/SqliteInstallStrategyTest.kt
@@ -1,12 +1,5 @@
 package io.sentry.android.gradle.autoinstall.sqlite
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -18,6 +11,13 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class SqliteInstallStrategyTest {
@@ -79,7 +79,7 @@ class SqliteInstallStrategyTest {
     }
     verify(fixture.dependencies)
       .add(
-        com.nhaarman.mockitokotlin2.check<String> {
+        org.mockito.kotlin.check<String> {
           assertEquals("io.sentry:sentry-android-sqlite:6.21.0", it)
         }
       )

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/timber/TimberInstallStrategyTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/autoinstall/timber/TimberInstallStrategyTest.kt
@@ -1,13 +1,5 @@
 package io.sentry.android.gradle.autoinstall.timber
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.check
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.autoinstall.AutoInstallState
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import kotlin.test.assertEquals
@@ -19,6 +11,14 @@ import org.gradle.api.artifacts.DirectDependenciesMetadata
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.VariantMetadata
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 
 class TimberInstallStrategyTest {

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryModulesCollectorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/util/SentryModulesCollectorTest.kt
@@ -1,10 +1,5 @@
 package io.sentry.android.gradle.util
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.android.gradle.extensions.InstrumentationFeature
 import io.sentry.android.gradle.instrumentation.fakes.CapturingTestLogger
 import io.sentry.android.gradle.services.SentryModulesService
@@ -23,6 +18,11 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.whenever
 
 class SentryModulesCollectorTest {
 


### PR DESCRIPTION
## Summary

Bumps the test mocking library from the abandoned `com.nhaarman.mockitokotlin2:2.2.0` (2018) to the maintained `org.mockito.kotlin:5.4.0`.

The old artifact bundles an outdated Mockito/ByteBuddy that struggles to mock and spy modern bytecode. The new artifact ships a current Mockito + ByteBuddy.

## Changes

- `gradle/libs.versions.toml`: `com.nhaarman.mockitokotlin2:2.2.0` → `org.mockito.kotlin:5.4.0`
- Renamed every `com.nhaarman.mockitokotlin2` import to `org.mockito.kotlin` across 22 test files

This is a drop-in replacement — the API surface used (`mock`, `spy`, `whenever`, `doReturn`, `doAnswer`, `any`, `check`, `verify`, `never`) is identical, so no test logic changed. All 394 plugin unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)