### PR TITLE
ci: Set Renovate commit type so dep bumps skip the changelog

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "build",
+  "semanticCommitScope": "deps",
+  "packageRules": [
+    {
+      "description": "The Sentry SDK is bumped by the update-deps workflow's updater action, which writes its own CHANGELOG entry. Letting Renovate update it too would create duplicate PRs.",
+      "matchPackageNames": [
+        "io.sentry:sentry"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Deps bundled into the published plugin are user-facing, so use a fix: title to make Danger require a CHANGELOG entry. Everything else stays build(deps): and is skipped.",
+      "matchPackageNames": [
+        "org.ow2.asm:asm-util",
+        "org.ow2.asm:asm-commons"
+      ],
+      "semanticCommitType": "fix"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate's Gradle version-catalog manager can't distinguish runtime deps from test/build deps, so it titled every bump `fix(deps):` — which makes Danger require a changelog entry even for noise like a test-only `zip4j` bump (see [#1309](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1309)).

This adds Renovate config to:

- Default every bump to `build(deps):`, which Danger maps to "no changelog needed" and skips.
- Keep `org.ow2.asm:asm-util` / `asm-commons` on `fix(deps):` — they're bundled into the published plugin, so a bump is user-facing and should carry a changelog entry.
- Disable `io.sentry:sentry` in Renovate, since the `update-deps` workflow's `updater` action already bumps the SDK and writes its own changelog entry (avoids duplicate PRs).

#skip-changelog