### PR TITLE
ci: Disable Renovate for the whole io.sentry group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,9 @@
   "semanticCommitScope": "deps",
   "packageRules": [
     {
-      "description": "The Sentry SDK is bumped by the update-deps workflow's updater action, which writes its own CHANGELOG entry. Letting Renovate update it too would create duplicate PRs.",
+      "description": "The Sentry SDK is bumped by the update-deps workflow's updater action, which writes its own CHANGELOG entry. Most io.sentry artifacts share the same version ref, so any of them would rewrite it and collide with the updater. Leave the whole group to the updater.",
       "matchPackageNames": [
-        "io.sentry:sentry"
+        "io.sentry:**"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Summary

Follow-up to a review comment on the previous Renovate config PR: the rule only disabled `io.sentry:sentry`, but other `io.sentry:*` artifacts share the same version ref and could produce duplicate/conflicting PRs.

`sentry`, `sentry-android`, `sentry-okhttp`, and `sentry-spring-boot-starter-jakarta` all resolve through the same `sentry` version ref in `gradle/libs.versions.toml` — the one the `update-deps` workflow's `updater` action bumps (and writes a changelog for). A Renovate PR for any of them would rewrite that shared ref and collide with the updater.

Widen the disable rule from `io.sentry:sentry` to the whole `io.sentry:**` group so the updater remains the single owner, including any `io.sentry` artifact added later.

#skip-changelog