### PR TITLE
ci(matrix): fetch googlesource files via git instead of HTTP

### DIFF
--- a/scripts/generate-compat-matrix.main.kts
+++ b/scripts/generate-compat-matrix.main.kts
@@ -17,8 +17,8 @@ import io.github.z4kn4fein.semver.Version
 import io.github.z4kn4fein.semver.toVersion
 import java.io.File
 import java.net.URL
-import kotlin.io.path.createTempDirectory
 import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.io.path.createTempDirectory
 import org.jsoup.Jsoup
 import org.w3c.dom.Element
 
@@ -309,8 +309,7 @@ class GenerateMatrix : CliktCommand() {
       fetchGooglesourceViaGit(
         repoUrl = "https://android.googlesource.com/platform/tools/adt/idea",
         branch = "mirror-goog-studio-main",
-        filePath =
-          "build-common/src/com/android/tools/idea/gradle/util/CompatibleGradleVersion.kt",
+        filePath = "build-common/src/com/android/tools/idea/gradle/util/CompatibleGradleVersion.kt",
       )
 
     // Enum entries: VERSION_X_Y_Z(GradleVersion.version("X.Y.Z")).
@@ -450,11 +449,7 @@ class GenerateMatrix : CliktCommand() {
    * @param branch branch name, e.g. "mirror-goog-studio-main"
    * @param filePath repo-relative file path
    */
-  private fun fetchGooglesourceViaGit(
-    repoUrl: String,
-    branch: String,
-    filePath: String,
-  ): String {
+  private fun fetchGooglesourceViaGit(repoUrl: String, branch: String, filePath: String): String {
     val tmpDir = createTempDirectory("googlesource-${repoUrl.substringAfterLast('/')}").toFile()
     try {
       exec(

--- a/scripts/generate-compat-matrix.main.kts
+++ b/scripts/generate-compat-matrix.main.kts
@@ -15,6 +15,7 @@ import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.github.z4kn4fein.semver.Version
 import io.github.z4kn4fein.semver.toVersion
+import java.io.File
 import java.net.URL
 import javax.xml.parsers.DocumentBuilderFactory
 import org.jsoup.Jsoup
@@ -304,8 +305,11 @@ class GenerateMatrix : CliktCommand() {
     agpVersions: List<Version>
   ): Pair<Map<Version, Version>, Version> {
     val source =
-      fetchGooglesourceText(
-        "https://android.googlesource.com/platform/tools/adt/idea/+/refs/heads/mirror-goog-studio-main/build-common/src/com/android/tools/idea/gradle/util/CompatibleGradleVersion.kt?format=TEXT"
+      fetchGooglesourceViaGit(
+        repoUrl = "https://android.googlesource.com/platform/tools/adt/idea",
+        branch = "mirror-goog-studio-main",
+        filePath =
+          "build-common/src/com/android/tools/idea/gradle/util/CompatibleGradleVersion.kt",
       )
 
     // Enum entries: VERSION_X_Y_Z(GradleVersion.version("X.Y.Z")).
@@ -426,8 +430,10 @@ class GenerateMatrix : CliktCommand() {
    */
   private fun fetchGradleLatestVersion(): Version {
     val source =
-      fetchGooglesourceText(
-        "https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-main/common/src/main/java/com/android/SdkConstants.java?format=TEXT"
+      fetchGooglesourceViaGit(
+        repoUrl = "https://android.googlesource.com/platform/tools/base",
+        branch = "mirror-goog-studio-main",
+        filePath = "common/src/main/java/com/android/SdkConstants.java",
       )
     val match =
       Regex("""GRADLE_LATEST_VERSION\s*=\s*"([^"]+)"""").find(source)
@@ -435,9 +441,47 @@ class GenerateMatrix : CliktCommand() {
     return Version.parse(match.groupValues[1], strict = false)
   }
 
-  /** Decodes gitiles' `?format=TEXT` response (base64-encoded) to raw source text. */
-  private fun fetchGooglesourceText(url: String): String =
-    URL(url).readText().let { String(java.util.Base64.getDecoder().decode(it)) }
+  /**
+   * Fetches a single file from a googlesource repo via a shallow sparse clone. More reliable than
+   * the gitiles `?format=TEXT` HTTP endpoint, which returns 503 under load.
+   *
+   * @param repoUrl base repo URL, e.g. "https://android.googlesource.com/platform/tools/adt/idea"
+   * @param branch branch name, e.g. "mirror-goog-studio-main"
+   * @param filePath repo-relative file path
+   */
+  private fun fetchGooglesourceViaGit(
+    repoUrl: String,
+    branch: String,
+    filePath: String,
+  ): String {
+    val tmpDir = createTempDir("googlesource-${repoUrl.substringAfterLast('/')}")
+    try {
+      exec(
+        "git",
+        "clone",
+        "--depth=1",
+        "--no-checkout",
+        "--filter=blob:none",
+        "--branch",
+        branch,
+        repoUrl,
+        tmpDir.absolutePath,
+      )
+      exec("git", "-C", tmpDir.absolutePath, "sparse-checkout", "set", filePath)
+      exec("git", "-C", tmpDir.absolutePath, "checkout")
+      return File(tmpDir, filePath).readText()
+    } finally {
+      tmpDir.deleteRecursively()
+    }
+  }
+
+  /** Runs a command, throwing if it exits non-zero. */
+  private fun exec(vararg cmd: String) {
+    val proc = ProcessBuilder(*cmd).redirectErrorStream(true).start()
+    val out = proc.inputStream.bufferedReader().readText()
+    val code = proc.waitFor()
+    if (code != 0) error("Command failed (exit $code): ${cmd.joinToString(" ")}\n$out")
+  }
 
   private fun parseVersionOrNull(s: String): Version? =
     try {

--- a/scripts/generate-compat-matrix.main.kts
+++ b/scripts/generate-compat-matrix.main.kts
@@ -463,7 +463,7 @@ class GenerateMatrix : CliktCommand() {
         repoUrl,
         tmpDir.absolutePath,
       )
-      exec("git", "-C", tmpDir.absolutePath, "sparse-checkout", "set", filePath)
+      exec("git", "-C", tmpDir.absolutePath, "sparse-checkout", "set", "--no-cone", filePath)
       exec("git", "-C", tmpDir.absolutePath, "checkout")
       return File(tmpDir, filePath).readText()
     } finally {

--- a/scripts/generate-compat-matrix.main.kts
+++ b/scripts/generate-compat-matrix.main.kts
@@ -17,6 +17,7 @@ import io.github.z4kn4fein.semver.Version
 import io.github.z4kn4fein.semver.toVersion
 import java.io.File
 import java.net.URL
+import kotlin.io.path.createTempDirectory
 import javax.xml.parsers.DocumentBuilderFactory
 import org.jsoup.Jsoup
 import org.w3c.dom.Element
@@ -454,7 +455,7 @@ class GenerateMatrix : CliktCommand() {
     branch: String,
     filePath: String,
   ): String {
-    val tmpDir = createTempDir("googlesource-${repoUrl.substringAfterLast('/')}")
+    val tmpDir = createTempDirectory("googlesource-${repoUrl.substringAfterLast('/')}").toFile()
     try {
       exec(
         "git",


### PR DESCRIPTION
## Summary

The `Generate Compat Matrix` step intermittently fails when `android.googlesource.com`'s gitiles `?format=TEXT` endpoint returns a 503, which blocks all downstream test-matrix jobs ([example failure](https://github.com/getsentry/sentry-android-gradle-plugin/actions/runs/28007449480/job/82892611645)):

```
java.io.IOException: Server returned HTTP response code: 503 for URL:
  https://android.googlesource.com/platform/tools/adt/idea/+/refs/heads/mirror-goog-studio-main/
  build-common/src/com/android/tools/idea/gradle/util/CompatibleGradleVersion.kt?format=TEXT
```

Closes #1240

## Changes

Replaces the `fetchGooglesourceText(url)` helper (which used `URL(url).readText()` + base64-decode) with `fetchGooglesourceViaGit()`, which does a depth-1, blob-less sparse clone of just the single file needed and reads it from disk.

Affected sources:
- `CompatibleGradleVersion.kt` (AGP → Gradle compat table)
- `SdkConstants.java` (`GRADLE_LATEST_VERSION` constant)

No other external HTTP calls in the script are changed.

## Verification

- Confirmed 503 as the root cause from the failed run logs
- New helper mirrors the same file content, just via `git clone --depth=1 --no-checkout --filter=blob:none --sparse` instead of HTTP
- `git` is available on all `ubuntu-latest` runners; no new dependencies

#skip-changelog

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC089VFRB8N9%3A1782198317.321199%22)