### PR TITLE
build(deps): Regenerate plugin-build locks on SDK bump (GRADLE-104)

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -28,11 +28,26 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
+      # The SDK lives in plugin-build's STRICT dependency lock + verification metadata,
+      # so the post-update-script regenerates both. Gradle and Java are set up here
+      # because the updater runs that script before opening the PR.
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # pin@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Set up Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-android.sh
           name: Android SDK
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
+          post-update-script: scripts/relock-plugin-build.sh
 
   composable-preview-scanner:
     runs-on: ubuntu-latest

--- a/scripts/relock-plugin-build.sh
+++ b/scripts/relock-plugin-build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regenerate the plugin-build dependency lockfile and SHA-256 verification metadata.
+# Run after bumping a plugin-build dependency, otherwise STRICT-mode locking rejects
+# the new version. See CONTRIBUTING.md.
+cd "$(dirname "$0")/.."
+
+./gradlew -p plugin-build resolveAndLockAll --write-locks --write-verification-metadata sha256


### PR DESCRIPTION
## Summary

The Android SDK is bumped by the `update-deps` workflow's `getsentry/github-workflows/updater` action, which edits the `sentry` version ref in `gradle/libs.versions.toml` and writes the CHANGELOG entry — but it never touches `plugin-build`'s STRICT-mode dependency lock or SHA-256 verification metadata (added in #1256). The resulting PR therefore fails CI with:

```
> Could not resolve io.sentry:sentry:8.44.1.
   > Constraint path: ... 'io.sentry:sentry:{strictly 8.44.0}'
     because of the following reason: Dependency version enforced by Dependency Locking
```

(see #1305).

This wires the updater's `post-update-script` hook to regenerate the lockfile + verification metadata in the same PR commit:

- Add `scripts/relock-plugin-build.sh`, wrapping the canonical regen command (`./gradlew -p plugin-build resolveAndLockAll --write-locks --write-verification-metadata sha256`).
- In the `android` job, set up Gradle and Java 17 before the updater runs (so `JAVA_HOME` is set when the script executes) and pass `post-update-script: scripts/relock-plugin-build.sh`.

The `cli` and `composable-preview-scanner` jobs are left untouched — neither dependency lands in `plugin-build/gradle.lockfile`.

This fixes future SDK bumps. Already-open SDK PRs (e.g. #1305) still need a one-time manual relock on their branch.

#skip-changelog
