### PR TITLE
build(samples): Unpin NDK version in android-ndk sample

### DIFF
--- a/examples/android-ndk/build.gradle
+++ b/examples/android-ndk/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdk = LibsVersion.SDK_VERSION
-    ndkVersion = "24.0.8215888"
 
     defaultConfig {
         minSdkVersion LibsVersion.MIN_SDK_VERSION


### PR DESCRIPTION
## Summary

The `android-ndk` sample pins `ndkVersion = "24.0.8215888"`. When Mend Renovate resolves the composite build in its hosted runner (`/home/ubuntu/.android-sdk`), configuring this sample forces AGP to install that exact NDK package. Its license is not accepted in Renovate's sandbox, so AGP throws `LicenceNotAcceptedException`, Renovate's dependency resolution fails, and it surfaces as **"package lookup failures"** on the [Dependency Dashboard](https://github.com/getsentry/sentry-android-gradle-plugin/issues/1308) (and the *"Some dependencies could not be looked up"* banner on bump PRs such as #1309).

Dropping the explicit pin lets AGP fall back to the NDK that is already installed and licensed in the environment, so Renovate can configure the build without tripping the license check.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)