### PR TITLE
fix(auto-install): Use BOM version for Sentry installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Use Sentry BOM versions for auto-installed SDK dependencies ([#1349](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1349))
+
 ### Dependencies
 
 - Bump Android SDK from v8.45.0 to v8.46.0 ([#1343](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1343))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/autoinstall/AutoInstall.kt
@@ -71,7 +71,7 @@ fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boo
       // if autoInstallation is disabled, the autoInstallState will contain initial values
       // which all default to false, hence, the integrations won't be installed as well
       if (extension.autoInstallation.enabled.get()) {
-        val sentryVersion = dependencies.findSentryVersion(isAndroid)
+        val sentryDependency = dependencies.findSentryDependency(isAndroid)
         with(AutoInstallState.getInstance(gradle)) {
           val sentryArtifactId =
             if (isAndroid) {
@@ -80,7 +80,7 @@ fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boo
               SentryModules.SENTRY.name
             }
           this.sentryVersion =
-            installSentrySdk(sentryVersion, dependencies, sentryArtifactId, extension)
+            installSentrySdk(sentryDependency, dependencies, sentryArtifactId, extension)
           this.enabled = true
         }
       }
@@ -90,45 +90,57 @@ fun Project.installDependencies(extension: SentryPluginExtension, isAndroid: Boo
 }
 
 private fun Project.installSentrySdk(
-  sentryVersion: String?,
+  sentryDependency: SentryDependency,
   dependencies: DependencySet,
   sentryArtifactId: String,
   extension: SentryPluginExtension,
 ): String {
-  return if (sentryVersion == null) {
-    val userDefinedVersion = extension.autoInstallation.sentryVersion.get()
+  val sentryVersion = sentryDependency.version ?: extension.autoInstallation.sentryVersion.get()
+  return if (!sentryDependency.isInstalled) {
     val sentryAndroidDep =
-      this.dependencies.create("$SENTRY_GROUP:$sentryArtifactId:$userDefinedVersion")
+      this.dependencies.create("$SENTRY_GROUP:$sentryArtifactId:$sentryVersion")
     dependencies.add(sentryAndroidDep)
-    logger.info { "$sentryArtifactId was successfully installed with version: $userDefinedVersion" }
-    userDefinedVersion
+    logger.info { "$sentryArtifactId was successfully installed with version: $sentryVersion" }
+    sentryVersion
   } else {
     logger.info { "$sentryArtifactId won't be installed because it was already installed directly" }
     sentryVersion
   }
 }
 
-private fun DependencySet.findSentryVersion(isAndroid: Boolean): String? =
+private data class SentryDependency(val version: String?, val isInstalled: Boolean)
+
+private fun DependencySet.findSentryDependency(isAndroid: Boolean): SentryDependency {
+  val installedDependency = find {
+    it.group == SENTRY_GROUP && it.name in installedSentryModuleNames(isAndroid)
+  }
+  val bomVersion = find {
+    it.group == SENTRY_GROUP && it.name in sentryBomModuleNames(isAndroid) && it.version != null
+  }
+
+  return SentryDependency(
+    installedDependency?.version ?: bomVersion?.version,
+    installedDependency != null,
+  )
+}
+
+private fun installedSentryModuleNames(isAndroid: Boolean): Set<String> =
   if (isAndroid) {
-    find {
-        it.group == SENTRY_GROUP &&
-          (it.name == SentryModules.SENTRY_ANDROID_CORE.name ||
-            it.name == SentryModules.SENTRY_ANDROID.name ||
-            it.name == SentryModules.SENTRY_BOM.name) &&
-          it.version != null
-      }
-      ?.version
+    setOf(SentryModules.SENTRY_ANDROID_CORE.name, SentryModules.SENTRY_ANDROID.name)
   } else {
-    find {
-        it.group == SENTRY_GROUP &&
-          (it.name == SentryModules.SENTRY.name ||
-            it.name == SentryModules.SENTRY_SPRING_BOOT2.name ||
-            it.name == SentryModules.SENTRY_SPRING_BOOT3.name ||
-            it.name == SentryModules.SENTRY_SPRING_BOOT4.name ||
-            it.name == SentryModules.SENTRY_BOM.name ||
-            it.name == SentryModules.SENTRY_OPENTELEMETRY_AGENTLESS.name ||
-            it.name == SentryModules.SENTRY_OPENTELEMETRY_AGENTLESS_SPRING.name) &&
-          it.version != null
-      }
-      ?.version
+    setOf(
+      SentryModules.SENTRY.name,
+      SentryModules.SENTRY_SPRING_BOOT2.name,
+      SentryModules.SENTRY_SPRING_BOOT3.name,
+      SentryModules.SENTRY_SPRING_BOOT4.name,
+      SentryModules.SENTRY_OPENTELEMETRY_AGENTLESS.name,
+      SentryModules.SENTRY_OPENTELEMETRY_AGENTLESS_SPRING.name,
+    )
+  }
+
+private fun sentryBomModuleNames(isAndroid: Boolean): Set<String> =
+  if (isAndroid) {
+    setOf(SentryModules.SENTRY_BOM.name)
+  } else {
+    setOf(SentryModules.SENTRY_BOM.name, SentryModules.SENTRY_OPENTELEMETRY_BOM.name)
   }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -76,6 +76,8 @@ internal object SentryModules {
   internal val SENTRY_SPRING_BOOT4 =
     DefaultModuleIdentifier.newId("io.sentry", "sentry-spring-boot-4")
   internal val SENTRY_BOM = DefaultModuleIdentifier.newId("io.sentry", "sentry-bom")
+  internal val SENTRY_OPENTELEMETRY_BOM =
+    DefaultModuleIdentifier.newId("io.sentry", "sentry-opentelemetry-bom")
   internal val SENTRY_OPENTELEMETRY_AGENTLESS =
     DefaultModuleIdentifier.newId("io.sentry", "sentry-opentelemetry-agentless")
   internal val SENTRY_OPENTELEMETRY_AGENTLESS_SPRING =

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallNonAndroidTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallNonAndroidTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle.integration
 
 import io.sentry.android.gradle.SentryPlugin.Companion.SENTRY_SDK_VERSION
+import java.io.File
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.gradle.util.GradleVersion
@@ -30,6 +31,40 @@ class SentryPluginAutoInstallNonAndroidTest :
 
     val result = runListDependenciesTask()
     assertTrue { "io.sentry:sentry:$SENTRY_SDK_VERSION" in result.output }
+  }
+
+  @Test
+  fun `uses sentry-opentelemetry-bom version for auto installed dependencies`() {
+    writeSentryOpenTelemetryBom("8.0.0")
+    appBuildFile.writeText(
+      // language=Groovy
+      """
+            plugins {
+                id "java"
+                id "io.sentry.jvm.gradle"
+            }
+
+            repositories {
+              maven { url file('../repo') }
+            }
+
+            dependencies {
+              implementation platform('io.sentry:sentry-opentelemetry-bom:8.0.0')
+              implementation 'ch.qos.logback:logback-classic:1.0.0'
+            }
+
+            sentry.autoInstallation.enabled = true
+            sentry.autoInstallation.sentryVersion = "6.28.0"
+            """
+        .trimIndent()
+    )
+
+    val result = runListDependenciesTask()
+    assertTrue { "io.sentry:sentry:8.0.0" in result.output }
+    assertTrue { "io.sentry:sentry-logback:8.0.0" in result.output }
+    assertFalse { "io.sentry:sentry:6.28.0" in result.output }
+    assertFalse { "io.sentry:sentry-logback:6.28.0" in result.output }
+    assertFalse { "FAILED" in result.output }
   }
 
   @Test
@@ -597,6 +632,29 @@ class SentryPluginAutoInstallNonAndroidTest :
   }
 
   private fun runListDependenciesTask() = runner.appendArguments("app:dependencies").build()
+
+  private fun writeSentryOpenTelemetryBom(version: String) {
+    val pomFile =
+      File(
+        testProjectDir.root,
+        "repo/io/sentry/sentry-opentelemetry-bom/$version/sentry-opentelemetry-bom-$version.pom",
+      )
+    pomFile.parentFile.mkdirs()
+    pomFile.writeText(
+      """
+      <project xmlns="http://maven.apache.org/POM/4.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry-opentelemetry-bom</artifactId>
+        <version>$version</version>
+        <packaging>pom</packaging>
+      </project>
+      """
+        .trimIndent()
+    )
+  }
 
   private fun getJavaVersion(): Int {
     var version = System.getProperty("java.version")

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginAutoInstallTest.kt
@@ -359,6 +359,40 @@ class SentryPluginAutoInstallTest :
   }
 
   @Test
+  fun `uses sentry-bom version for auto installed dependencies`() {
+    appBuildFile.writeText(
+      // language=Groovy
+      """
+            plugins {
+              id "com.android.application"
+              id "io.sentry.android.gradle"
+            }
+
+            android {
+              namespace 'com.example'
+            }
+
+            dependencies {
+              implementation platform('io.sentry:sentry-bom:7.0.0')
+              implementation 'com.jakewharton.timber:timber:4.7.1'
+            }
+
+            sentry.autoInstallation.enabled = true
+            sentry.autoInstallation.sentryVersion = "6.32.0"
+            sentry.includeProguardMapping = false
+            """
+        .trimIndent()
+    )
+
+    val result = runListDependenciesTask()
+    assertTrue { "io.sentry:sentry-android:7.0.0" in result.output }
+    assertTrue { "io.sentry:sentry-android-timber:7.0.0" in result.output }
+    assertFalse { "io.sentry:sentry-android:6.32.0" in result.output }
+    assertFalse { "io.sentry:sentry-android-timber:6.32.0" in result.output }
+    assertFalse { "FAILED" in result.output }
+  }
+
+  @Test
   fun `considers sentry-opentelemetry-agentless as a core version`() {
     appBuildFile.writeText(
       // language=Groovy


### PR DESCRIPTION
Use the Sentry BOM version as the source of truth for auto-installed SDK dependencies.

Previously SAGP treated `sentry-bom` like a concrete SDK dependency when choosing whether to install the core SDK. That avoided adding `sentry-android`, but it also meant BOM-only projects could not use the BOM version for the dependencies SAGP installs.

This separates version detection from SDK presence detection. Concrete Sentry SDK dependencies still prevent SAGP from adding the core SDK again, while `sentry-bom` and `sentry-opentelemetry-bom` provide the version used for auto-installed dependencies.