### PR TITLE
docs(agents): Prefer Google Truth for new unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,20 @@ Some tests upload mappings/source context and fail without an auth token:
 export SENTRY_AUTH_TOKEN=<your_token>
 ```
 
+## Testing conventions
+
+- Prefer [Google Truth](https://truth.dev/) for assertions in new unit tests
+  (`import com.google.common.truth.Truth.assertThat`). Much of the existing suite still
+  uses `kotlin.test`/JUnit assertions; don't rewrite those wholesale, but reach for Truth
+  when adding new tests or touching assertions in a test you're already editing.
+
+```kotlin
+import com.google.common.truth.Truth.assertThat
+
+assertThat(actual).isEqualTo(expected)
+assertThat(list).containsExactly("a", "b").inOrder()
+```
+
 ## Local sentry-cli
 
 To test against a local `sentry-cli`, set `cli.executable` in the target project's


### PR DESCRIPTION
Adds a **Testing conventions** section to `AGENTS.md` steering agents and new contributors toward [Google Truth](https://truth.dev/) for assertions in new unit tests.

Truth is already a test dependency (`testImplementation(libs.truth)`) and used in a few test files, but the bulk of the suite still uses `kotlin.test`/JUnit assertions. The guidance documents the preference for new tests without mandating a wholesale rewrite of the existing suite.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)