### PR TITLE
feat(size-analysis): Mark sizeAnalysis extension as stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Mark the `sizeAnalysis` extension as stable by removing its `@Experimental` annotation ([#XXXX](https://github.com/getsentry/sentry-android-gradle-plugin/pull/XXXX))
 - Fail the build when OpenTelemetry is downgraded below the version the Sentry OpenTelemetry integration requires ([#1350](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1350))
   - The `sentry-opentelemetry-*` artifacts are built against specific OpenTelemetry versions. When another dependency management mechanism (most commonly Spring Boot `io.spring.dependency-management`) forces OpenTelemetry below the version a Sentry integration requires, running against those downgraded versions can cause `ClassNotFoundException` / `NoSuchMethodError` at runtime. The new `verifySentryOpenTelemetryVersions` task detects this downgrade and fails the build early with guidance on how to fix it.
   - You may disable this check by setting `sentry.verifyOpenTelemetryVersions = false`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Mark the `sizeAnalysis` extension as stable by removing its `@Experimental` annotation ([#XXXX](https://github.com/getsentry/sentry-android-gradle-plugin/pull/XXXX))
+- Mark the `sizeAnalysis` extension as stable by removing its `@Experimental` annotation ([#1361](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1361))
 - Fail the build when OpenTelemetry is downgraded below the version the Sentry OpenTelemetry integration requires ([#1350](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1350))
   - The `sentry-opentelemetry-*` artifacts are built against specific OpenTelemetry versions. When another dependency management mechanism (most commonly Spring Boot `io.spring.dependency-management`) forces OpenTelemetry below the version a Sentry integration requires, running against those downgraded versions can cause `ClassNotFoundException` / `NoSuchMethodError` at runtime. The new `verifySentryOpenTelemetryVersions` task detects this downgrade and fails the build early with guidance on how to fix it.
   - You may disable this check by setting `sentry.verifyOpenTelemetryVersions = false`

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SentryPluginExtension.kt
@@ -114,7 +114,6 @@ abstract class SentryPluginExtension @Inject constructor(objects: ObjectFactory)
 
   val sizeAnalysis: SizeAnalysisExtension = objects.newInstance(SizeAnalysisExtension::class.java)
 
-  @Experimental
   fun sizeAnalysis(sizeAnalysisAction: Action<SizeAnalysisExtension>) {
     sizeAnalysisAction.execute(sizeAnalysis)
   }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtension.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/extensions/SizeAnalysisExtension.kt
@@ -5,9 +5,7 @@ import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
-import org.jetbrains.annotations.ApiStatus.Experimental
 
-@Experimental
 open class SizeAnalysisExtension
 @Inject
 constructor(objects: ObjectFactory, providerFactory: ProviderFactory) {


### PR DESCRIPTION
## Summary

The [Size Analysis product docs](https://docs.sentry.io/product/size-analysis/) treat the feature as generally available — the page carries no `beta` flag (only `new: true`). This removes the `@ApiStatus.Experimental` annotation from the `sizeAnalysis` Gradle DSL so it's no longer marked as an unstable API.

Build Distribution is still documented as `beta: true`, so its `@Experimental` annotation is intentionally left in place.

## Changes

- Remove `@Experimental` from `SizeAnalysisExtension` (and drop the now-unused import)
- Remove `@Experimental` from `SentryPluginExtension.sizeAnalysis(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)