### PR TITLE
feat(snapshots): Emit canvas_theme in snapshot sidecar (EME-1241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Emit `canvas_theme` (`light`/`dark`) in the generated snapshot sidecar metadata, derived from the Compose `@Preview` `uiMode` ([#XXXX](https://github.com/getsentry/sentry-android-gradle-plugin/pull/XXXX))
+- Emit `canvas_theme` (`light`/`dark`) in the generated snapshot sidecar metadata, derived from the Compose `@Preview` `uiMode` ([#1364](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1364))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Emit `canvas_theme` (`light`/`dark`) in the generated snapshot sidecar metadata, derived from the Compose `@Preview` `uiMode` ([#XXXX](https://github.com/getsentry/sentry-android-gradle-plugin/pull/XXXX))
+
 ### Dependencies
 
 - Bump CLI from v3.6.0 to v3.6.1 ([#1367](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1367))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTask.kt
@@ -386,6 +386,10 @@ class $CLASS_NAME(
             "display_name" to screenshotId.removePrefix(preview.declaringClass + "."),
         )
         if (info.group.isNotBlank()) metadata["group"] = info.group
+        when (info.uiMode and UI_MODE_NIGHT_MASK) {
+            UI_MODE_NIGHT_YES -> metadata["canvas_theme"] = "dark"
+            UI_MODE_NIGHT_NO -> metadata["canvas_theme"] = "light"
+        }
 
         val diffThreshold: Float? = runCatching {
             val declaring = Class.forName(preview.declaringClass)

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/snapshot/GenerateSnapshotTestsTaskTest.kt
@@ -192,6 +192,14 @@ class GenerateSnapshotTestsTaskTest {
   }
 
   @Test
+  fun `generated sidecar places canvas_theme in top-level metadata`() {
+    val content = generateAndRead(packageTrees = listOf("com.example"))
+
+    assertTrue(content.contains("UI_MODE_NIGHT_YES -> metadata[\"canvas_theme\"] = \"dark\""))
+    assertTrue(content.contains("UI_MODE_NIGHT_NO -> metadata[\"canvas_theme\"] = \"light\""))
+  }
+
+  @Test
   fun `generated sidecar does not emit legacy night_mode field`() {
     val content = generateAndRead(packageTrees = listOf("com.example"))
 


### PR DESCRIPTION
## Summary

Derives a top-level `canvas_theme` field (`"light"`/`"dark"`) for each generated snapshot sidecar from the Compose `@Preview` `uiMode` night bits. [Sentry Snapshots](https://docs.sentry.io/product/snapshots/uploading-snapshots/#json-metadata) uses `canvas_theme` to render the correct background canvas behind the uploaded image in the web UI.

- Placed at the top level of each image's metadata (sibling of `tags`/`display_name`/`group`/`diff_threshold`), matching the backend schema (`ImageMetadata.canvas_theme: Literal["light","dark"] | None`).
- Mirrors the existing `ui_mode` derivation: emitted only when the night bit is explicitly set, so default previews omit the field.

Closes [EME-1241](https://linear.app/getsentry/issue/EME-1241) and [EME-1217](https://linear.app/getsentry/issue/EME-1217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)