### PR TITLE
build(deps): Skip NDK sample during Renovate lockfile updates

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,19 @@ include(":examples:android-gradle")
 
 include(":examples:android-gradle-kts")
 
-include(":examples:android-ndk")
+// Configuring this sample makes AGP download and set up the NDK, which isn't available when
+// Renovate regenerates the dependency lockfile/verification metadata and would fail the run.
+// The sample is never needed to resolve dependencies, so skip it on those runs. Renovate
+// always invokes Gradle with --write-locks/--update-locks and --dependency-verification
+// lenient; normal dev and CI builds don't, so they still build the sample.
+val isDependencyResolutionRun =
+  startParameter.isWriteDependencyLocks ||
+    startParameter.lockedDependenciesToUpdate.isNotEmpty() ||
+    startParameter.dependencyVerificationMode ==
+      org.gradle.api.artifacts.verification.DependencyVerificationMode.LENIENT
+if (!isDependencyResolutionRun) {
+  include(":examples:android-ndk")
+}
 
 include(":examples:android-instrumentation-sample")
 


### PR DESCRIPTION
Renovate updates a dependency and then regenerates the Gradle lockfile. Since the changed dependency lives in the root `gradle/libs.versions.toml`, Renovate runs the root `gradlew`, which evaluates the root `settings.gradle.kts` and includes `:examples:android-ndk`. Configuring that sample makes AGP set up the NDK — which isn't available in Renovate's environment — so the relock fails, leaving a stale lockfile that then breaks the PR build (e.g. #1363).

The `android-ndk` sample is never needed to resolve dependencies, so this skips it on dependency-resolution runs. Rather than a custom env var (which Renovate only forwards if a bot admin allowlists it via `allowedEnv`), the sample is gated on Gradle's own start parameters: Renovate always invokes Gradle with `--write-locks`/`--update-locks` and `--dependency-verification lenient`, none of which normal dev and CI builds use. So those builds still build the sample, and the fix needs no Renovate/Mend configuration.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)