### PR TITLE
build(deps): Bump sentry-cli to 3.6.2

### DIFF
--- a/.github/workflows/integration-tests-sentry-cli.yml
+++ b/.github/workflows/integration-tests-sentry-cli.yml
@@ -14,7 +14,11 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     env:
+      # sentry-cli 3.6.2+ ignores an auth token when the URL comes from a different
+      # configuration source, so the URL and token must share one source. CLI arguments
+      # and environment variables count as a single runtime source, so both live here.
       SENTRY_URL: http://127.0.0.1:8000
+      SENTRY_AUTH_TOKEN: <token>
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- This breaking change is only for customers using self-hosted Sentry together with a user auth token (not an org auth token) and the url and auth token are configured separately:
+  - If so, this breaking change applies to you in order to patch a security flaw. [Please read this](https://github.com/getsentry/sentry-cli/issues/3380#issuecomment-5059013026) for further details.
+
+### Dependencies
+
+- Bump CLI from v3.6.1 to v3.6.2 ([#1373](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1373))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#362)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/3.6.1...3.6.2)
+
 ## 6.16.0
 
 ### Features

--- a/plugin-build/sentry-cli.properties
+++ b/plugin-build/sentry-cli.properties
@@ -1,2 +1,2 @@
-version = 3.6.1
+version = 3.6.2
 repo = https://github.com/getsentry/sentry-cli

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIntegrationTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginIntegrationTest.kt
@@ -37,7 +37,6 @@ class SentryPluginIntegrationTest :
       "Integration test server endpoint is not set",
       System.getenv("SENTRY_URL").isNullOrBlank(),
     )
-    sentryPropertiesFile.appendText("auth.token=<token>")
     applyAutoUploadProguardMapping()
 
     val build = runner.appendArguments(":app:assembleRelease").build()
@@ -54,7 +53,6 @@ class SentryPluginIntegrationTest :
       "Integration test server endpoint is not set",
       System.getenv("SENTRY_URL").isNullOrBlank(),
     )
-    sentryPropertiesFile.appendText("auth.token=<token>")
     applyUploadNativeSymbols()
 
     val build = runner.appendArguments(":app:assembleRelease").build()
@@ -71,7 +69,6 @@ class SentryPluginIntegrationTest :
       "Integration test server endpoint is not set",
       System.getenv("SENTRY_URL").isNullOrBlank(),
     )
-    sentryPropertiesFile.appendText("auth.token=<token>")
     applyUploadSourceContexts()
 
     testProjectDir.withDummyComposeFile()
@@ -93,7 +90,6 @@ class SentryPluginIntegrationTest :
       "Integration test server endpoint is not set",
       System.getenv("SENTRY_URL").isNullOrBlank(),
     )
-    sentryPropertiesFile.appendText("auth.token=<token>")
     applySizeAnalysis()
 
     val build = runner.appendArguments(":app:assembleRelease").build()


### PR DESCRIPTION
Bumps the bundled `sentry-cli` from 3.6.1 to 3.6.2.

## Why the repo needs reconfiguring

sentry-cli 3.6.2 [no longer combines a URL and a non-embedded auth token from different configuration sources](https://github.com/getsentry/sentry-cli/pull/3378): when the URL and token come from different sources, one is ignored with a warning.