### PR TITLE
style: Apply spotless formatting to settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,7 @@ val isDependencyResolutionRun =
     startParameter.lockedDependenciesToUpdate.isNotEmpty() ||
     startParameter.dependencyVerificationMode ==
       org.gradle.api.artifacts.verification.DependencyVerificationMode.LENIENT
+
 if (!isDependencyResolutionRun) {
   include(":examples:android-ndk")
 }


### PR DESCRIPTION
`./gradlew spotlessApply` reformats `settings.gradle.kts`, adding a blank line between the `isDependencyResolutionRun` declaration and the following `if` block. Committing the result so `spotlessCheck` passes.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)