### PR TITLE
build(deps): Configure nothing on Renovate dependency runs

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,15 +32,14 @@ dependencyResolutionManagement {
 
 rootProject.name = ("sentry-android-gradle-plugin-composite-build")
 
-include(":examples:android-gradle")
-
-include(":examples:android-gradle-kts")
-
-// Configuring this sample makes AGP download and set up the NDK, which isn't available when
-// Renovate regenerates the dependency lockfile/verification metadata and would fail the run.
-// The sample is never needed to resolve dependencies, so skip it on those runs. Renovate
-// always invokes Gradle with --write-locks/--update-locks and --dependency-verification
-// lenient; normal dev and CI builds don't, so they still build the sample.
+// Renovate updates dependencies by invoking the root wrapper with --write-locks/--update-locks
+// and --dependency-verification lenient, none of which normal dev and CI builds pass. A root
+// invocation can't refresh anything anyway: the only lockfile and verification metadata live in
+// plugin-build, and scripts/relock-plugin-build.sh regenerates those with -p plugin-build. But
+// configuring this build does break those runs, in two ways: the android-ndk sample makes AGP
+// download an NDK that Renovate's environment doesn't have, and --write-verification-metadata
+// calls getRootProject() on every build in the composite, which throws for the included builds
+// that a root `dependencies` task never configures. So configure nothing on those runs.
 val isDependencyResolutionRun =
   startParameter.isWriteDependencyLocks ||
     startParameter.lockedDependenciesToUpdate.isNotEmpty() ||
@@ -48,32 +47,37 @@ val isDependencyResolutionRun =
       org.gradle.api.artifacts.verification.DependencyVerificationMode.LENIENT
 
 if (!isDependencyResolutionRun) {
+  include(":examples:android-gradle")
+
+  include(":examples:android-gradle-kts")
+
   include(":examples:android-ndk")
-}
 
-include(":examples:android-instrumentation-sample")
+  include(":examples:android-instrumentation-sample")
 
-include(":examples:android-room-lib")
+  include(":examples:android-room-lib")
 
-include(":examples:spring-boot-sample")
+  include(":examples:spring-boot-sample")
 
-include(":examples:multi-module-sample")
+  include(":examples:multi-module-sample")
 
-include(":examples:multi-module-sample:spring-boot-in-multi-module-sample")
+  include(":examples:multi-module-sample:spring-boot-in-multi-module-sample")
 
-include(":examples:multi-module-sample:spring-boot-in-multi-module-sample2")
+  include(":examples:multi-module-sample:spring-boot-in-multi-module-sample2")
 
-includeBuild("plugin-build")
+  includeBuild("plugin-build")
 
-// this is needed so we can use kotlin-compiler-plugin directly in the sample app without publishing
-includeBuild("sentry-kotlin-compiler-plugin") {
-  dependencySubstitution {
-    substitute(module("io.sentry:sentry-kotlin-compiler-plugin")).using(project(":"))
+  // this is needed so we can use kotlin-compiler-plugin directly in the sample app without
+  // publishing
+  includeBuild("sentry-kotlin-compiler-plugin") {
+    dependencySubstitution {
+      substitute(module("io.sentry:sentry-kotlin-compiler-plugin")).using(project(":"))
+    }
   }
-}
 
-includeBuild("sentry-snapshots-runtime") {
-  dependencySubstitution {
-    substitute(module("io.sentry:sentry-snapshots-runtime")).using(project(":"))
+  includeBuild("sentry-snapshots-runtime") {
+    dependencySubstitution {
+      substitute(module("io.sentry:sentry-snapshots-runtime")).using(project(":"))
+    }
   }
 }


### PR DESCRIPTION
Follow-up to #1368. Renovate's artifact update runs two Gradle commands with the root wrapper; #1368 fixed the lockfile one by skipping the `android-ndk` sample, but the second one still fails on every dependency PR (e.g. #1339, #1363):

```
./gradlew ... --dependency-verification lenient -q --write-verification-metadata sha256 dependencies

* What went wrong:
There was a failure while populating the build operation queue: The root project is not yet available for build.
```

## Cause

Not the conditional include, and not the configuration cache. The stacktrace lands inside Gradle:

```
WriteDependencyVerificationFile.lambda$resolveAllConfigurationsConcurrently$5
  → DefaultGradle.getRootProject() → IllegalStateException
```

The verification metadata writer walks **every build in the composite** and touches each root project. A root `dependencies` task never configures the included builds that no sample consumes, so it throws. Gradle 9.6.1 reports the same failure more precisely, naming them:

```
3: Project ':sentry-kotlin-compiler-plugin' should be in state Created or later.
4: Project ':sentry-snapshots-runtime'      should be in state Created or later.
```

`plugin-build` is absent from that list because the samples apply its plugin, so it does get configured. **Upgrading Gradle is not a fix** — 9.6.1 hits the same bug, plus the known Kotlin 2.3 metadata incompatibility.

## Change

Widen the existing `isDependencyResolutionRun` guard from the one sample to the whole build: on those runs, configure nothing.

Nothing is lost. A root invocation can't refresh anything anyway — the only lockfile and verification metadata live in `plugin-build`, and `scripts/relock-plugin-build.sh` regenerates those with `-p plugin-build`, which doesn't evaluate these settings. The run does write an untracked root `gradle/verification-metadata.xml`, but Renovate only collects files from `status.modified`, so it won't be committed.

## Verification

Ran Renovate's real invocations locally, `GRADLE_OPTS` included:

| command | before | after |
|---|---|---|
| `--write-verification-metadata sha256 dependencies` | ❌ | ✅ |
| `properties` (subproject discovery) | ✅ | ✅ `subprojects: []` |
| `:dependencies --update-locks androidx.recyclerview:recyclerview` | ✅ | ✅ |

| | Gradle 8.14.5 | Gradle 9.6.1 |
|---|---|---|
| `main` | ❌ | ❌ |
| this branch | ✅ | ✅ |

Normal builds are untouched: `./gradlew projects` still lists all 11 example projects.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)