### PR TITLE
perf(instrumentation): Inject manifest metadata at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Performance
 
-- Resolve Sentry Android manifest metadata at build time to avoid `PackageManager` and `Bundle` parsing during SDK initialization ([#1401](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1401))
+- Resolve Sentry Android manifest metadata at build time to avoid `PackageManager` and `Bundle` parsing, reducing median SDK initialization time by 6.5% in a cold-start benchmark ([#1401](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1401))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Detect AGP `optimization.enable` when the variant is wrapped by AGP analytics ([#1382](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1382))
   - This fixes `java.lang.NoSuchMethodException: com.android.build.api.component.analytics.AnalyticsEnabledApplicationVariant_Decorated.getOptimizationCreationConfig()`
 
+### Performance
+
+- Resolve Sentry Android manifest metadata at build time to avoid `PackageManager` and `Bundle` parsing during SDK initialization ([#1401](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1401))
+
 ### Dependencies
 
 - Bump ComposablePreviewScanner from v0.9.1 to v0.9.2 ([#1381](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1381))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -205,20 +205,6 @@ fun ApplicationAndroidComponentsExtension.configure(
           project.collectModules("${variant.name}RuntimeClasspath", variant.name, it)
         }
 
-      if (runtimeOptimizationsEnabled) {
-        variant.instrumentation.transformClassesWith(
-          SentrySdkOptimizationClassVisitorFactory::class.java,
-          InstrumentationScope.ALL,
-        ) { params ->
-          params.classAvailability.setDisallowChanges(
-            checkNotNull(modules).map(::resolveClassAvailability).orElse(emptyMap())
-          )
-        }
-        variant.instrumentation.setAsmFramesComputationMode(
-          FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
-        )
-      }
-
       if (tracingInstrumentationEnabled) {
         val tracingModulesService = checkNotNull(modulesService)
 
@@ -262,6 +248,27 @@ fun ApplicationAndroidComponentsExtension.configure(
           )
           .toTransform(SingleArtifact.MERGED_MANIFEST)
       }
+
+      if (runtimeOptimizationsEnabled) {
+        variant.instrumentation.transformClassesWith(
+          SentrySdkOptimizationClassVisitorFactory::class.java,
+          InstrumentationScope.ALL,
+        ) { params ->
+          params.classAvailability.setDisallowChanges(
+            checkNotNull(modules).map(::resolveClassAvailability).orElse(emptyMap())
+          )
+          params.buildTimeMetadataEnabled.setDisallowChanges(
+            checkNotNull(modules)
+              .map { checkNotNull(modulesService).get().supportsBuildTimeMetadata() }
+              .orElse(false)
+          )
+          params.mergedManifest.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))
+        }
+        variant.instrumentation.setAsmFramesComputationMode(
+          FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
+        )
+      }
+
       val sizeAnalysisEnabled = extension.sizeAnalysis.enabled.get() == true
       val distributionEnabled = extension.distribution.enabled.get() == true
       if (sizeAnalysisEnabled || distributionEnabled) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -250,6 +250,7 @@ fun ApplicationAndroidComponentsExtension.configure(
       }
 
       if (runtimeOptimizationsEnabled) {
+        val runtimeModulesService = checkNotNull(modulesService)
         variant.instrumentation.transformClassesWith(
           SentrySdkOptimizationClassVisitorFactory::class.java,
           InstrumentationScope.ALL,
@@ -259,12 +260,12 @@ fun ApplicationAndroidComponentsExtension.configure(
           )
           params.buildTimeMetadataEnabled.setDisallowChanges(
             checkNotNull(modules)
-              .map { checkNotNull(modulesService).get().supportsBuildTimeMetadata() }
+              .map { runtimeModulesService.get().supportsBuildTimeMetadata() }
               .orElse(false)
           )
           params.buildTimeMetadataCacheKey.setDisallowChanges(
             params.buildTimeMetadataEnabled.map {
-              if (it) java.util.UUID.randomUUID().toString() else ""
+              if (it) runtimeModulesService.get().buildTimeMetadataCacheKey else ""
             }
           )
           params.mergedManifest.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -262,6 +262,11 @@ fun ApplicationAndroidComponentsExtension.configure(
               .map { checkNotNull(modulesService).get().supportsBuildTimeMetadata() }
               .orElse(false)
           )
+          params.buildTimeMetadataCacheKey.setDisallowChanges(
+            params.buildTimeMetadataEnabled.map {
+              if (it) java.util.UUID.randomUUID().toString() else ""
+            }
+          )
           params.mergedManifest.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))
         }
         variant.instrumentation.setAsmFramesComputationMode(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/ManifestMetadataParser.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/ManifestMetadataParser.kt
@@ -1,0 +1,72 @@
+package io.sentry.android.gradle
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.Element
+
+internal object ManifestMetadataParser {
+  fun parse(manifest: File): Map<String, Any>? =
+    runCatching {
+        val document =
+          manifest.inputStream().buffered().use {
+            DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(it)
+          }
+        val application =
+          document.getElementsByTagName(TAG_APPLICATION).item(0) ?: return emptyMap()
+        val metadata = linkedMapOf<String, Any>()
+
+        for (index in 0 until application.childNodes.length) {
+          val element = application.childNodes.item(index) as? Element ?: continue
+          if (element.tagName != TAG_META_DATA) continue
+
+          val name = element.getAttribute(ATTR_NAME)
+          if (!name.startsWith(SENTRY_PREFIX)) continue
+          val value = element.getAttribute(ATTR_VALUE)
+          if (
+            element.hasAttribute(ATTR_RESOURCE) ||
+              !element.hasAttribute(ATTR_VALUE) ||
+              value.startsWith("@") ||
+              value.contains("${'$'}{")
+          ) {
+            SentryPlugin.logger.info(
+              "Sentry manifest metadata was not optimized because $name could not be resolved at build time."
+            )
+            return null
+          }
+          metadata[name] = inferType(value)
+        }
+        metadata
+      }
+      .onFailure {
+        SentryPlugin.logger.info(
+          "Sentry manifest metadata could not be parsed for optimization.",
+          it,
+        )
+      }
+      .getOrNull()
+
+  internal fun inferType(value: String): Any =
+    when (value) {
+      "true" -> true
+      "false" -> false
+      else -> parseInteger(value) ?: value.toFloatOrNull() ?: value
+    }
+
+  private fun parseInteger(value: String): Int? =
+    if (value.matches(DECIMAL_INTEGER)) {
+      value.toIntOrNull()
+    } else if (value.matches(HEX_INTEGER)) {
+      value.removePrefix("+").let { Integer.decode(it) }
+    } else {
+      null
+    }
+
+  private const val TAG_APPLICATION = "application"
+  private const val TAG_META_DATA = "meta-data"
+  private const val ATTR_NAME = "android:name"
+  private const val ATTR_VALUE = "android:value"
+  private const val ATTR_RESOURCE = "android:resource"
+  private const val SENTRY_PREFIX = "io.sentry."
+  private val DECIMAL_INTEGER = Regex("[+-]?\\d+")
+  private val HEX_INTEGER = Regex("[+-]?0[xX][0-9a-fA-F]+")
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/ManifestMetadataClassVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/ManifestMetadataClassVisitor.kt
@@ -1,0 +1,142 @@
+package io.sentry.android.gradle.instrumentation
+
+import io.sentry.android.gradle.SentryPlugin
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.FieldVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/** Injects fully resolved build-time manifest metadata into `ManifestMetadataReader`. */
+internal class ManifestMetadataClassVisitor(
+  apiVersion: Int,
+  nextClassVisitor: ClassVisitor,
+  private val metadata: Map<String, Any>,
+) : ClassVisitor(apiVersion, nextClassVisitor) {
+  private var hasMetadataField = false
+  private var hasStaticInitializer = false
+
+  override fun visitField(
+    access: Int,
+    name: String?,
+    descriptor: String?,
+    signature: String?,
+    value: Any?,
+  ): FieldVisitor? {
+    if (name == METADATA_FIELD && descriptor == MAP_DESCRIPTOR) hasMetadataField = true
+    return super.visitField(access, name, descriptor, signature, value)
+  }
+
+  override fun visitMethod(
+    access: Int,
+    name: String?,
+    descriptor: String?,
+    signature: String?,
+    exceptions: Array<out String>?,
+  ): MethodVisitor {
+    val visitor = super.visitMethod(access, name, descriptor, signature, exceptions)
+    if (name != STATIC_INITIALIZER || descriptor != VOID_METHOD_DESCRIPTOR) return visitor
+
+    hasStaticInitializer = true
+    return object : MethodVisitor(api, visitor) {
+      override fun visitInsn(opcode: Int) {
+        if (opcode == Opcodes.RETURN && hasMetadataField) injectMetadata(this)
+        super.visitInsn(opcode)
+      }
+    }
+  }
+
+  override fun visitEnd() {
+    if (!hasMetadataField) {
+      SentryPlugin.logger.info(
+        "Sentry manifest metadata was not optimized because the current SDK version does not support this optimization."
+      )
+    }
+    if (hasMetadataField && !hasStaticInitializer) {
+      val visitor =
+        super.visitMethod(
+          Opcodes.ACC_STATIC,
+          STATIC_INITIALIZER,
+          VOID_METHOD_DESCRIPTOR,
+          null,
+          null,
+        )
+      visitor.visitCode()
+      injectMetadata(visitor)
+      visitor.visitInsn(Opcodes.RETURN)
+      visitor.visitMaxs(0, 0)
+      visitor.visitEnd()
+    }
+    super.visitEnd()
+  }
+
+  private fun injectMetadata(visitor: MethodVisitor) {
+    visitor.visitTypeInsn(Opcodes.NEW, HASH_MAP_NAME)
+    visitor.visitInsn(Opcodes.DUP)
+    visitor.visitMethodInsn(Opcodes.INVOKESPECIAL, HASH_MAP_NAME, "<init>", "()V", false)
+    visitor.visitFieldInsn(Opcodes.PUTSTATIC, READER_INTERNAL_NAME, METADATA_FIELD, MAP_DESCRIPTOR)
+
+    metadata.forEach { (key, value) ->
+      visitor.visitFieldInsn(
+        Opcodes.GETSTATIC,
+        READER_INTERNAL_NAME,
+        METADATA_FIELD,
+        MAP_DESCRIPTOR,
+      )
+      visitor.visitLdcInsn(key)
+      visitor.emitValue(value)
+      visitor.visitMethodInsn(
+        Opcodes.INVOKEINTERFACE,
+        "java/util/Map",
+        "put",
+        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+        true,
+      )
+      visitor.visitInsn(Opcodes.POP)
+    }
+  }
+
+  private fun MethodVisitor.emitValue(value: Any) {
+    when (value) {
+      is Boolean -> {
+        visitInsn(if (value) Opcodes.ICONST_1 else Opcodes.ICONST_0)
+        visitMethodInsn(
+          Opcodes.INVOKESTATIC,
+          "java/lang/Boolean",
+          "valueOf",
+          "(Z)Ljava/lang/Boolean;",
+          false,
+        )
+      }
+      is Int -> {
+        visitLdcInsn(value)
+        visitMethodInsn(
+          Opcodes.INVOKESTATIC,
+          "java/lang/Integer",
+          "valueOf",
+          "(I)Ljava/lang/Integer;",
+          false,
+        )
+      }
+      is Float -> {
+        visitLdcInsn(value)
+        visitMethodInsn(
+          Opcodes.INVOKESTATIC,
+          "java/lang/Float",
+          "valueOf",
+          "(F)Ljava/lang/Float;",
+          false,
+        )
+      }
+      is String -> visitLdcInsn(value)
+    }
+  }
+
+  private companion object {
+    const val READER_INTERNAL_NAME = "io/sentry/android/core/ManifestMetadataReader"
+    const val METADATA_FIELD = "buildTimeMetadata"
+    const val MAP_DESCRIPTOR = "Ljava/util/Map;"
+    const val HASH_MAP_NAME = "java/util/HashMap"
+    const val STATIC_INITIALIZER = "<clinit>"
+    const val VOID_METHOD_DESCRIPTOR = "()V"
+  }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SentrySdkOptimizationClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SentrySdkOptimizationClassVisitorFactory.kt
@@ -4,11 +4,17 @@ import com.android.build.api.instrumentation.AsmClassVisitorFactory
 import com.android.build.api.instrumentation.ClassContext
 import com.android.build.api.instrumentation.ClassData
 import com.android.build.api.instrumentation.InstrumentationParameters
+import io.sentry.android.gradle.ManifestMetadataParser
 import io.sentry.android.gradle.util.SentryModules
 import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.objectweb.asm.ClassVisitor
 
 abstract class SentrySdkOptimizationClassVisitorFactory :
@@ -16,26 +22,51 @@ abstract class SentrySdkOptimizationClassVisitorFactory :
 
   interface SdkOptimizationParameters : InstrumentationParameters {
     @get:Input val classAvailability: MapProperty<String, Boolean>
+
+    @get:Input val buildTimeMetadataEnabled: Property<Boolean>
+
+    @get:InputFile @get:PathSensitive(PathSensitivity.NONE) val mergedManifest: RegularFileProperty
   }
+
+  private fun buildTimeMetadata(): Map<String, Any>? =
+    if (parameters.get().buildTimeMetadataEnabled.get()) {
+      ManifestMetadataParser.parse(parameters.get().mergedManifest.asFile.get())
+    } else {
+      null
+    }
 
   override fun createClassVisitor(
     classContext: ClassContext,
     nextClassVisitor: ClassVisitor,
-  ): ClassVisitor {
-    return LoadClassClassVisitor(
-      instrumentationContext.apiVersion.get(),
-      nextClassVisitor,
-      parameters.get().classAvailability.get(),
-    )
-  }
+  ): ClassVisitor =
+    when (classContext.currentClassData.className) {
+      LOAD_CLASS_NAME ->
+        LoadClassClassVisitor(
+          instrumentationContext.apiVersion.get(),
+          nextClassVisitor,
+          parameters.get().classAvailability.get(),
+        )
+      MANIFEST_METADATA_READER_NAME ->
+        ManifestMetadataClassVisitor(
+          instrumentationContext.apiVersion.get(),
+          nextClassVisitor,
+          checkNotNull(buildTimeMetadata()),
+        )
+      else -> nextClassVisitor
+    }
 
   // Empty availability means the runtime classpath is unknown. Skip this transformation so
   // LoadClass falls back to reflection.
   override fun isInstrumentable(classData: ClassData): Boolean =
-    classData.className == LOAD_CLASS_NAME && parameters.get().classAvailability.get().isNotEmpty()
+    when (classData.className) {
+      LOAD_CLASS_NAME -> parameters.get().classAvailability.get().isNotEmpty()
+      MANIFEST_METADATA_READER_NAME -> buildTimeMetadata() != null
+      else -> false
+    }
 
   internal companion object {
     const val LOAD_CLASS_NAME = "io.sentry.util.LoadClass"
+    const val MANIFEST_METADATA_READER_NAME = "io.sentry.android.core.ManifestMetadataReader"
 
     val CLASS_MODULES: Map<String, Set<ModuleIdentifier>> =
       sortedMapOf(

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SentrySdkOptimizationClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SentrySdkOptimizationClassVisitorFactory.kt
@@ -25,6 +25,10 @@ abstract class SentrySdkOptimizationClassVisitorFactory :
 
     @get:Input val buildTimeMetadataEnabled: Property<Boolean>
 
+    // The merged manifest cannot be read before dependency transforms are isolated, so use a
+    // per-build key to prevent AGP from reusing metadata injected for another app.
+    @get:Input val buildTimeMetadataCacheKey: Property<String>
+
     @get:InputFile @get:PathSensitive(PathSensitivity.NONE) val mergedManifest: RegularFileProperty
   }
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
@@ -129,6 +129,12 @@ abstract class SentryModulesService :
     sentryModules.isAtLeast(SentryModules.SENTRY_ANDROID_CORE, SentryVersions.VERSION_APP_START) &&
       parameters.appStartEnabled.get()
 
+  fun supportsBuildTimeMetadata(): Boolean =
+    sentryModules.isAtLeast(
+      SentryModules.SENTRY_ANDROID_CORE,
+      SentryVersions.VERSION_BUILD_TIME_METADATA,
+    )
+
   private fun Map<ModuleIdentifier, SemVer>.isAtLeast(
     module: ModuleIdentifier,
     minVersion: SemVer,

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/services/SentryModulesService.kt
@@ -8,6 +8,7 @@ import io.sentry.android.gradle.util.SemVer
 import io.sentry.android.gradle.util.SentryModules
 import io.sentry.android.gradle.util.SentryVersions
 import io.sentry.android.gradle.util.getBuildServiceName
+import java.util.UUID
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.provider.Property
@@ -21,6 +22,8 @@ import org.gradle.tooling.events.OperationCompletionListener
 
 abstract class SentryModulesService :
   BuildService<SentryModulesService.Parameters>, OperationCompletionListener {
+
+  val buildTimeMetadataCacheKey: String = UUID.randomUUID().toString()
 
   @get:Synchronized @set:Synchronized var sentryModules: Map<ModuleIdentifier, SemVer> = emptyMap()
 

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Versions.kt
@@ -38,6 +38,7 @@ internal object SentryVersions {
   internal val VERSION_APP_START = SemVer(7, 1, 0)
   internal val VERSION_SQLITE = SemVer(6, 21, 0)
   internal val VERSION_SQLITE_DRIVER = SemVer(8, 45, 0)
+  internal val VERSION_BUILD_TIME_METADATA = SemVer(8, 54, 0)
   internal val VERSION_ANDROID_OKHTTP_LISTENER = SemVer(6, 20, 0)
   internal val VERSION_OKHTTP = SemVer(7, 0, 0)
 }

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/ManifestMetadataParserTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/ManifestMetadataParserTest.kt
@@ -1,0 +1,83 @@
+package io.sentry.android.gradle
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ManifestMetadataParserTest {
+  @get:Rule val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `parses sentry metadata with PackageManager value types`() {
+    val manifest =
+      manifest(
+        """
+        <meta-data android:name="io.sentry.debug" android:value="true"/>
+        <meta-data android:name="io.sentry.enabled" android:value="false"/>
+        <meta-data android:name="io.sentry.max-breadcrumbs" android:value="42"/>
+        <meta-data android:name="io.sentry.hex" android:value="-0x2A"/>
+        <meta-data android:name="io.sentry.sample-rate" android:value="0.5"/>
+        <meta-data android:name="io.sentry.dsn" android:value="https://example.invalid/1"/>
+        <meta-data android:name="other.metadata" android:value="ignored"/>
+        """
+      )
+
+    assertThat(ManifestMetadataParser.parse(manifest))
+      .containsExactly(
+        "io.sentry.debug",
+        true,
+        "io.sentry.enabled",
+        false,
+        "io.sentry.max-breadcrumbs",
+        42,
+        "io.sentry.hex",
+        -42,
+        "io.sentry.sample-rate",
+        0.5f,
+        "io.sentry.dsn",
+        "https://example.invalid/1",
+      )
+  }
+
+  @Test
+  fun `returns null for resource references`() {
+    assertThat(
+        ManifestMetadataParser.parse(
+          manifest("""<meta-data android:name="io.sentry.dsn" android:value="@string/dsn"/>""")
+        )
+      )
+      .isNull()
+    assertThat(
+        ManifestMetadataParser.parse(
+          manifest("""<meta-data android:name="io.sentry.dsn" android:resource="@string/dsn"/>""")
+        )
+      )
+      .isNull()
+  }
+
+  @Test
+  fun `returns null for unresolved placeholders`() {
+    assertThat(
+        ManifestMetadataParser.parse(
+          manifest("""<meta-data android:name="io.sentry.dsn" android:value="${'$'}{dsn}"/>""")
+        )
+      )
+      .isNull()
+  }
+
+  private fun manifest(metadata: String): File =
+    temporaryFolder.newFile("AndroidManifest-${temporaryFolder.root.listFiles()?.size}.xml").apply {
+      writeText(
+        """
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+          <application>
+            $metadata
+          </application>
+        </manifest>
+        """
+          .trimIndent()
+      )
+    }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/ManifestMetadataClassVisitorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/ManifestMetadataClassVisitorTest.kt
@@ -1,0 +1,105 @@
+package io.sentry.android.gradle.instrumentation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+
+class ManifestMetadataClassVisitorTest {
+  @Test
+  fun `injects typed metadata when static initializer is missing`() {
+    val metadata =
+      mapOf(
+        "io.sentry.debug" to true,
+        "io.sentry.max-breadcrumbs" to 42,
+        "io.sentry.sample-rate" to 0.5f,
+        "io.sentry.dsn" to "https://example.invalid/1",
+      )
+
+    val clazz = load(transformClass(metadata = metadata))
+
+    assertThat(readMetadata(clazz)).containsExactlyEntriesIn(metadata)
+  }
+
+  @Test
+  fun `injects metadata and preserves existing static initializer`() {
+    val metadata = mapOf("io.sentry.debug" to false)
+
+    val clazz = load(transformClass(hasStaticInitializer = true, metadata = metadata))
+
+    assertThat(clazz.getDeclaredField("marker").getInt(null)).isEqualTo(7)
+    assertThat(readMetadata(clazz)).containsExactlyEntriesIn(metadata)
+  }
+
+  @Test
+  fun `does not modify SDK versions without the metadata field`() {
+    val clazz = load(transformClass(hasMetadataField = false))
+
+    assertThat(clazz.declaredFields.map { it.name }).doesNotContain("buildTimeMetadata")
+  }
+
+  private fun transformClass(
+    hasMetadataField: Boolean = true,
+    hasStaticInitializer: Boolean = false,
+    metadata: Map<String, Any> = emptyMap(),
+  ): ByteArray {
+    val original = ClassWriter(0)
+    original.visit(
+      Opcodes.V1_8,
+      Opcodes.ACC_PUBLIC,
+      READER_INTERNAL_NAME,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    if (hasMetadataField) {
+      original
+        .visitField(Opcodes.ACC_STATIC, "buildTimeMetadata", "Ljava/util/Map;", null, null)
+        .visitEnd()
+    }
+    if (hasStaticInitializer) {
+      original
+        .visitField(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, "marker", "I", null, null)
+        .visitEnd()
+      original.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null).apply {
+        visitCode()
+        visitIntInsn(Opcodes.BIPUSH, 7)
+        visitFieldInsn(Opcodes.PUTSTATIC, READER_INTERNAL_NAME, "marker", "I")
+        visitInsn(Opcodes.RETURN)
+        visitMaxs(1, 0)
+        visitEnd()
+      }
+    }
+    original.visitEnd()
+
+    val reader = ClassReader(original.toByteArray())
+    val writer = ClassWriter(reader, ClassWriter.COMPUTE_FRAMES or ClassWriter.COMPUTE_MAXS)
+    reader.accept(ManifestMetadataClassVisitor(Opcodes.ASM9, writer, metadata), 0)
+    return writer.toByteArray()
+  }
+
+  private fun load(bytes: ByteArray): Class<*> =
+    // Loading the transformed bytes in an isolated class loader executes their generated <clinit>.
+    object : ClassLoader(javaClass.classLoader) {
+        fun define(): Class<*> =
+          defineClass(
+            SentrySdkOptimizationClassVisitorFactory.MANIFEST_METADATA_READER_NAME,
+            bytes,
+            0,
+            bytes.size,
+          )
+      }
+      .define()
+
+  @Suppress("UNCHECKED_CAST")
+  private fun readMetadata(clazz: Class<*>): Map<String, Any> =
+    clazz.getDeclaredField("buildTimeMetadata").run {
+      isAccessible = true
+      get(null) as Map<String, Any>
+    }
+
+  private companion object {
+    const val READER_INTERNAL_NAME = "io/sentry/android/core/ManifestMetadataReader"
+  }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -570,6 +570,29 @@ class SentryPluginTest :
   }
 
   @Test
+  fun `injects resolved manifest metadata into the SDK`() {
+    configureFakeMetadataSdk("true")
+
+    runner.appendArguments(":app:assembleRelease").build()
+
+    assertTrue(releaseDexContains(BUILD_TIME_METADATA_KEY))
+    assertTrue(releaseDexContains("io.sentry.gradle-plugin-integrations"))
+  }
+
+  @Test
+  fun `does not inject manifest metadata with resource references`() {
+    configureFakeMetadataSdk("@string/sentry_debug")
+    File(testProjectDir.root, "app/src/main/res/values/strings.xml").apply {
+      parentFile.mkdirs()
+      writeText("<resources><string name=\"sentry_debug\">true</string></resources>")
+    }
+
+    runner.appendArguments(":app:assembleRelease").build()
+
+    assertFalse(releaseDexContains(BUILD_TIME_METADATA_KEY))
+  }
+
+  @Test
   fun `register tracing instrumentation if tracingInstrumentation is enabled`() {
     applyTracingInstrumentation()
 
@@ -1346,6 +1369,79 @@ class SentryPluginTest :
     )
   }
 
+  private fun configureFakeMetadataSdk(value: String) {
+    File(testProjectDir.root, "settings.gradle")
+      .appendText("\nproject(':module').name = 'sentry-android-core'")
+    moduleBuildFile.appendText(
+      """
+
+      group = 'io.sentry'
+      version = '${SentryVersions.VERSION_BUILD_TIME_METADATA}'
+      """
+        .trimIndent()
+    )
+    File(
+        testProjectDir.root,
+        "module/src/main/java/io/sentry/android/core/ManifestMetadataReader.java",
+      )
+      .apply {
+        parentFile.mkdirs()
+        writeText(
+          """
+          package io.sentry.android.core;
+
+          import java.util.Map;
+
+          public final class ManifestMetadataReader {
+            static Map<String, Object> buildTimeMetadata;
+          }
+          """
+            .trimIndent()
+        )
+      }
+    appBuildFile.appendText(
+      """
+
+      dependencies {
+        implementation project(':sentry-android-core')
+      }
+
+      android {
+        buildTypes.release.minifyEnabled = false
+      }
+      """
+        .trimIndent()
+    )
+    File(testProjectDir.root, "app/src/main/AndroidManifest.xml").apply {
+      parentFile.mkdirs()
+      writeText(
+        """
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+          <application>
+            <meta-data android:name="$BUILD_TIME_METADATA_KEY" android:value="$value"/>
+          </application>
+        </manifest>
+        """
+          .trimIndent()
+      )
+    }
+  }
+
+  private fun releaseDexContains(value: String): Boolean {
+    val apk = File(testProjectDir.root, "app/build/outputs/apk/release/app-release-unsigned.apk")
+    return java.util.zip.ZipFile(apk).use { zip ->
+      zip
+        .entries()
+        .asSequence()
+        .filter { it.name.matches(Regex("classes\\d*\\.dex")) }
+        .any { entry ->
+          zip.getInputStream(entry).use {
+            it.readBytes().toString(Charsets.ISO_8859_1).contains(value)
+          }
+        }
+    }
+  }
+
   private fun buildDatabaseInstrumentation(vararg dependencies: String): BuildResult {
     applyTracingInstrumentation(
       features = setOf(InstrumentationFeature.DATABASE),
@@ -1373,6 +1469,7 @@ class SentryPluginTest :
   }
 
   companion object {
+    private const val BUILD_TIME_METADATA_KEY = "io.sentry.test-build-time-injection"
     private const val SQLITE = "androidx.sqlite:sqlite:2.6.2"
     private const val SENTRY_ANDROID_SQLITE_OPEN_HELPER = "io.sentry:sentry-android-sqlite:6.21.0"
     private val SENTRY_ANDROID_SQLITE_DRIVER =

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -581,7 +581,7 @@ class SentryPluginTest :
 
   @Test
   fun `does not inject manifest metadata with resource references`() {
-    configureFakeMetadataSdk("@string/sentry_debug")
+    configureFakeMetadataSdk("@string/sentry_debug", "android:resource")
     File(testProjectDir.root, "app/src/main/res/values/strings.xml").apply {
       parentFile.mkdirs()
       writeText("<resources><string name=\"sentry_debug\">true</string></resources>")
@@ -1369,7 +1369,7 @@ class SentryPluginTest :
     )
   }
 
-  private fun configureFakeMetadataSdk(value: String) {
+  private fun configureFakeMetadataSdk(value: String, attribute: String = "android:value") {
     File(testProjectDir.root, "settings.gradle")
       .appendText("\nproject(':module').name = 'sentry-android-core'")
     moduleBuildFile.appendText(
@@ -1418,7 +1418,7 @@ class SentryPluginTest :
         """
         <manifest xmlns:android="http://schemas.android.com/apk/res/android">
           <application>
-            <meta-data android:name="$BUILD_TIME_METADATA_KEY" android:value="$value"/>
+            <meta-data android:name="$BUILD_TIME_METADATA_KEY" $attribute="$value"/>
           </application>
         </manifest>
         """


### PR DESCRIPTION
## :scroll: Description

Parse resolved `io.sentry.*` entries from the merged Android manifest and inject
their typed values into `ManifestMetadataReader` during bytecode instrumentation.
The optimization uses the existing `runtimeOptimizations.enabled` flag and only
runs with sentry-android-core 8.54.0 or newer.

Resource references, unresolved placeholders, and unsupported SDK versions keep
using the existing runtime manifest lookup.

Companion SDK PR: https://github.com/getsentry/sentry-java/pull/5963

## :bulb: Motivation and Context

Sentry Android initialization currently retrieves application metadata through
`PackageManager` and lazily unparcels its `Bundle`. Resolving manifest metadata at
build time removes both operations from the startup path.

Refs JAVA-531

## :green_heart: How did you test it?

- `./gradlew spotlessApply`
- Parser and ASM visitor unit tests
- Integration tests for resolved values and resource-reference fallback
- Validated all 98 supported manifest keys in a real app in injected and fallback modes
- Confirmed in Perfetto that both startup `getApplicationInfo` calls disappear when injected
- Compared 24 cold starts per mode; direct-map init median improved from 32.987 ms to 30.835 ms

## :pencil: Checklist

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps

Merge the SDK support in https://github.com/getsentry/sentry-java/pull/5963 before releasing this optimization.
