### PR TITLE
perf(instrumentation): [Generated metadata 1] Generate class availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Avoid resolving the runtime classpath during Gradle configuration when SDK runtime optimizations are enabled ([#1404](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1404))
+
 ### Dependencies
 
 - Bump ComposablePreviewScanner from v0.9.2 to v0.9.3 ([#1408](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1408))

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -21,12 +21,12 @@ import io.sentry.android.gradle.SentryTasksProvider.getMappingFileProvider
 import io.sentry.android.gradle.extensions.SentryPluginExtension
 import io.sentry.android.gradle.instrumentation.SentrySdkOptimizationClassVisitorFactory
 import io.sentry.android.gradle.instrumentation.SpanAddingClassVisitorFactory
-import io.sentry.android.gradle.instrumentation.resolveClassAvailability
 import io.sentry.android.gradle.services.SentryModulesService
 import io.sentry.android.gradle.snapshot.GenerateSnapshotTestsTask
 import io.sentry.android.gradle.sourcecontext.OutputPaths
 import io.sentry.android.gradle.sourcecontext.SourceContext
 import io.sentry.android.gradle.tasks.GenerateDistributionPropertiesTask
+import io.sentry.android.gradle.tasks.GenerateSentryBuildTimeOptionsTask
 import io.sentry.android.gradle.tasks.InjectSentryMetaPropertiesIntoAssetsTask
 import io.sentry.android.gradle.tasks.PropertiesFileOutputTask
 import io.sentry.android.gradle.tasks.SentryGenerateIntegrationListTask
@@ -181,9 +181,8 @@ fun ApplicationAndroidComponentsExtension.configure(
 
       val runtimeOptimizationsEnabled = extension.runtimeOptimizations.enabled.get()
       val tracingInstrumentationEnabled = extension.tracingInstrumentation.enabled.get()
-      // Both visitor factories need the resolved dependency graph.
       val modulesService =
-        if (runtimeOptimizationsEnabled || tracingInstrumentationEnabled) {
+        if (tracingInstrumentationEnabled) {
           SentryModulesService.register(
               project,
               extension.tracingInstrumentation.features,
@@ -200,23 +199,31 @@ fun ApplicationAndroidComponentsExtension.configure(
           null
         }
 
-      val modules =
-        modulesService?.let {
-          project.collectModules("${variant.name}RuntimeClasspath", variant.name, it)
-        }
+      modulesService?.let {
+        project.collectModules("${variant.name}RuntimeClasspath", variant.name, it)
+      }
 
       if (runtimeOptimizationsEnabled) {
-        variant.instrumentation.transformClassesWith(
-          SentrySdkOptimizationClassVisitorFactory::class.java,
-          InstrumentationScope.ALL,
-        ) { params ->
-          params.classAvailability.setDisallowChanges(
-            checkNotNull(modules).map(::resolveClassAvailability).orElse(emptyMap())
+        val buildTimeOptionsTask =
+          GenerateSentryBuildTimeOptionsTask.register(
+            project,
+            "${variant.name}RuntimeClasspath",
+            variant.name.capitalized,
+          )
+        val javaSources = variant.sources.java
+        if (buildTimeOptionsTask != null && javaSources != null) {
+          javaSources.addGeneratedSourceDirectory(
+            buildTimeOptionsTask,
+            GenerateSentryBuildTimeOptionsTask::output,
+          )
+          variant.instrumentation.transformClassesWith(
+            SentrySdkOptimizationClassVisitorFactory::class.java,
+            InstrumentationScope.ALL,
+          ) {}
+          variant.instrumentation.setAsmFramesComputationMode(
+            FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
           )
         }
-        variant.instrumentation.setAsmFramesComputationMode(
-          FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS
-        )
       }
 
       if (tracingInstrumentationEnabled) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/LoadClassClassVisitor.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/LoadClassClassVisitor.kt
@@ -17,18 +17,14 @@ import org.objectweb.asm.Opcodes
  *
  * After instrumentation the generated static initializer is equivalent to:
  * ```java
- * classAvailability = new HashMap<>();
- * classAvailability.put("timber.log.Timber", true);
+ * classAvailability = SentryGeneratedBuildTimeOptions.getClassAvailability();
  * ```
  *
  * Known entries avoid reflection; omitted class names still fall back to it. SDK versions without
  * the field are left unchanged.
  */
-internal class LoadClassClassVisitor(
-  apiVersion: Int,
-  nextClassVisitor: ClassVisitor,
-  private val classAvailability: Map<String, Boolean>,
-) : ClassVisitor(apiVersion, nextClassVisitor) {
+internal class LoadClassClassVisitor(apiVersion: Int, nextClassVisitor: ClassVisitor) :
+  ClassVisitor(apiVersion, nextClassVisitor) {
   private var hasAvailabilityField = false
   private var hasStaticInitializer = false
 
@@ -94,48 +90,27 @@ internal class LoadClassClassVisitor(
   }
 
   private fun injectClassAvailability(visitor: MethodVisitor) {
-    visitor.visitTypeInsn(Opcodes.NEW, HASH_MAP_NAME)
-    visitor.visitInsn(Opcodes.DUP)
-    visitor.visitMethodInsn(Opcodes.INVOKESPECIAL, HASH_MAP_NAME, "<init>", "()V", false)
+    visitor.visitMethodInsn(
+      Opcodes.INVOKESTATIC,
+      GENERATED_OPTIONS_INTERNAL_NAME,
+      "getClassAvailability",
+      "()Ljava/util/Map;",
+      false,
+    )
     visitor.visitFieldInsn(
       Opcodes.PUTSTATIC,
       LOAD_CLASS_INTERNAL_NAME,
       AVAILABILITY_FIELD,
       MAP_DESCRIPTOR,
     )
-
-    classAvailability.forEach { (className, available) ->
-      visitor.visitFieldInsn(
-        Opcodes.GETSTATIC,
-        LOAD_CLASS_INTERNAL_NAME,
-        AVAILABILITY_FIELD,
-        MAP_DESCRIPTOR,
-      )
-      visitor.visitLdcInsn(className)
-      visitor.visitInsn(if (available) Opcodes.ICONST_1 else Opcodes.ICONST_0)
-      visitor.visitMethodInsn(
-        Opcodes.INVOKESTATIC,
-        "java/lang/Boolean",
-        "valueOf",
-        "(Z)Ljava/lang/Boolean;",
-        false,
-      )
-      visitor.visitMethodInsn(
-        Opcodes.INVOKEINTERFACE,
-        "java/util/Map",
-        "put",
-        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-        true,
-      )
-      visitor.visitInsn(Opcodes.POP)
-    }
   }
 
   private companion object {
     const val LOAD_CLASS_INTERNAL_NAME = "io/sentry/util/LoadClass"
+    const val GENERATED_OPTIONS_INTERNAL_NAME =
+      "io/sentry/android/core/SentryGeneratedBuildTimeOptions"
     const val AVAILABILITY_FIELD = "classAvailability"
     const val MAP_DESCRIPTOR = "Ljava/util/Map;"
-    const val HASH_MAP_NAME = "java/util/HashMap"
     const val STATIC_INITIALIZER = "<clinit>"
     const val VOID_METHOD_DESCRIPTOR = "()V"
   }

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SentrySdkOptimizationClassVisitorFactory.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/instrumentation/SentrySdkOptimizationClassVisitorFactory.kt
@@ -7,32 +7,20 @@ import com.android.build.api.instrumentation.InstrumentationParameters
 import io.sentry.android.gradle.util.SentryModules
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.provider.MapProperty
-import org.gradle.api.tasks.Input
 import org.objectweb.asm.ClassVisitor
 
 abstract class SentrySdkOptimizationClassVisitorFactory :
-  AsmClassVisitorFactory<SentrySdkOptimizationClassVisitorFactory.SdkOptimizationParameters> {
-
-  interface SdkOptimizationParameters : InstrumentationParameters {
-    @get:Input val classAvailability: MapProperty<String, Boolean>
-  }
+  AsmClassVisitorFactory<InstrumentationParameters.None> {
 
   override fun createClassVisitor(
     classContext: ClassContext,
     nextClassVisitor: ClassVisitor,
   ): ClassVisitor {
-    return LoadClassClassVisitor(
-      instrumentationContext.apiVersion.get(),
-      nextClassVisitor,
-      parameters.get().classAvailability.get(),
-    )
+    return LoadClassClassVisitor(instrumentationContext.apiVersion.get(), nextClassVisitor)
   }
 
-  // Empty availability means the runtime classpath is unknown. Skip this transformation so
-  // LoadClass falls back to reflection.
   override fun isInstrumentable(classData: ClassData): Boolean =
-    classData.className == LOAD_CLASS_NAME && parameters.get().classAvailability.get().isNotEmpty()
+    classData.className == LOAD_CLASS_NAME
 
   internal companion object {
     const val LOAD_CLASS_NAME = "io.sentry.util.LoadClass"

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/CollectSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/CollectSourcesTask.kt
@@ -74,10 +74,16 @@ internal class SourceCollector {
     sourceDirs.forEach { sourceDir ->
       if (sourceDir.exists()) {
         SentryPlugin.logger.debug { "Collecting sources in ${sourceDir.absolutePath}" }
-        sourceDir.walk().forEach { sourceFile ->
+        for (sourceFile in sourceDir.walk()) {
           val relativePath = sourceFile.toRelativeString(sourceDir)
           val targetFile = outDir.resolve(File(relativePath))
           if (sourceFile.isFile) {
+            if (
+              relativePath.replace(File.separatorChar, '/') ==
+                "io/sentry/android/core/SentryGeneratedBuildTimeOptions.java"
+            ) {
+              continue
+            }
             if (relativePath.isBlank()) {
               SentryPlugin.logger.debug {
                 "Skipping ${sourceFile.absolutePath} as the plugin was unable to determine a relative path for it."

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/CollectSourcesTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/CollectSourcesTask.kt
@@ -74,14 +74,15 @@ internal class SourceCollector {
     sourceDirs.forEach { sourceDir ->
       if (sourceDir.exists()) {
         SentryPlugin.logger.debug { "Collecting sources in ${sourceDir.absolutePath}" }
+        val generatedBuildTimeOptions =
+          sourceDir
+            .resolve("io/sentry/android/core/SentryGeneratedBuildTimeOptions.java")
+            .normalize()
         for (sourceFile in sourceDir.walk()) {
           val relativePath = sourceFile.toRelativeString(sourceDir)
           val targetFile = outDir.resolve(File(relativePath))
           if (sourceFile.isFile) {
-            if (
-              relativePath.replace(File.separatorChar, '/') ==
-                "io/sentry/android/core/SentryGeneratedBuildTimeOptions.java"
-            ) {
+            if (sourceFile.normalize() == generatedBuildTimeOptions) {
               continue
             }
             if (relativePath.isBlank()) {

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTask.kt
@@ -1,0 +1,96 @@
+package io.sentry.android.gradle.tasks
+
+import io.sentry.android.gradle.instrumentation.resolveClassAvailability
+import java.io.File
+import org.gradle.api.Project
+import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+@CacheableTask
+abstract class GenerateSentryBuildTimeOptionsTask : DirectoryOutputTask() {
+
+  @get:Input abstract val moduleIds: SetProperty<String>
+
+  @TaskAction
+  fun generate() {
+    val modules =
+      moduleIds
+        .get()
+        .mapNotNull { coordinate ->
+          val parts = coordinate.split(':', limit = 2)
+          if (parts.size == 2) DefaultModuleIdentifier.newId(parts[0], parts[1]) else null
+        }
+        .toSet()
+    val availability = resolveClassAvailability(modules)
+    val sourceFile = File(output.get().asFile, GENERATED_CLASS_PATH)
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText(
+      """
+      package io.sentry.android.core;
+
+      import java.util.HashMap;
+      import java.util.Map;
+
+      public final class SentryGeneratedBuildTimeOptions {
+        private SentryGeneratedBuildTimeOptions() {}
+
+        public static Map<String, Boolean> getClassAvailability() {
+          Map<String, Boolean> availability = new HashMap<>();
+      ${
+        availability.toSortedMap().entries.joinToString("\n") { (className, available) ->
+          "    availability.put(\"$className\", $available);"
+        }
+      }
+          return availability;
+        }
+      }
+      """
+        .trimIndent() + "\n"
+    )
+  }
+
+  companion object {
+    private const val GENERATED_CLASS_PATH =
+      "io/sentry/android/core/SentryGeneratedBuildTimeOptions.java"
+
+    fun register(
+      project: Project,
+      configurationName: String,
+      taskSuffix: String,
+    ): TaskProvider<GenerateSentryBuildTimeOptionsTask>? {
+      val configuration =
+        try {
+          project.configurations.getByName(configurationName)
+        } catch (e: UnknownDomainObjectException) {
+          project.logger.warn(
+            "Unable to find configuration $configurationName for Sentry build-time options."
+          )
+          return null
+        }
+
+      return project.tasks.register(
+        "generateSentryBuildTimeOptions$taskSuffix",
+        GenerateSentryBuildTimeOptionsTask::class.java,
+      ) { task ->
+        task.moduleIds.set(
+          configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
+            artifacts.mapNotNullTo(mutableSetOf()) { artifact ->
+              (artifact.id.componentIdentifier as? ModuleComponentIdentifier)?.let {
+                "${it.group}:${it.module}"
+              }
+            }
+          }
+        )
+        task.output.set(
+          project.layout.buildDirectory.dir("generated/sentry/buildTimeOptions/$taskSuffix")
+        )
+      }
+    }
+  }
+}

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTask.kt
@@ -1,7 +1,6 @@
 package io.sentry.android.gradle.tasks
 
 import io.sentry.android.gradle.instrumentation.resolveClassAvailability
-import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
@@ -27,7 +26,7 @@ abstract class GenerateSentryBuildTimeOptionsTask : DirectoryOutputTask() {
         }
         .toSet()
     val availability = resolveClassAvailability(modules)
-    val sourceFile = File(output.get().asFile, GENERATED_CLASS_PATH)
+    val sourceFile = output.file(GENERATED_CLASS_PATH).get().asFile
     sourceFile.parentFile.mkdirs()
     sourceFile.writeText(
       """

--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTask.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTask.kt
@@ -4,7 +4,6 @@ import io.sentry.android.gradle.instrumentation.resolveClassAvailability
 import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
@@ -64,9 +63,9 @@ abstract class GenerateSentryBuildTimeOptionsTask : DirectoryOutputTask() {
       configurationName: String,
       taskSuffix: String,
     ): TaskProvider<GenerateSentryBuildTimeOptionsTask>? {
-      val configuration =
+      val configurationProvider =
         try {
-          project.configurations.getByName(configurationName)
+          project.configurations.named(configurationName)
         } catch (e: UnknownDomainObjectException) {
           project.logger.warn(
             "Unable to find configuration $configurationName for Sentry build-time options."
@@ -79,11 +78,10 @@ abstract class GenerateSentryBuildTimeOptionsTask : DirectoryOutputTask() {
         GenerateSentryBuildTimeOptionsTask::class.java,
       ) { task ->
         task.moduleIds.set(
-          configuration.incoming.artifacts.resolvedArtifacts.map { artifacts ->
-            artifacts.mapNotNullTo(mutableSetOf()) { artifact ->
-              (artifact.id.componentIdentifier as? ModuleComponentIdentifier)?.let {
-                "${it.group}:${it.module}"
-              }
+          configurationProvider.map { configuration ->
+            configuration.incoming.resolutionResult.allComponents.mapNotNullTo(mutableSetOf()) {
+              component ->
+              component.moduleVersion?.module?.let { "${it.group}:${it.name}" }
             }
           }
         )

--- a/plugin-build/src/test/kotlin/io/sentry/android/core/SentryGeneratedBuildTimeOptions.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/core/SentryGeneratedBuildTimeOptions.kt
@@ -1,0 +1,7 @@
+package io.sentry.android.core
+
+object SentryGeneratedBuildTimeOptions {
+  var availability: Map<String, Boolean> = emptyMap()
+
+  @JvmStatic fun getClassAvailability(): Map<String, Boolean> = availability
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/LoadClassClassVisitorTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/instrumentation/LoadClassClassVisitorTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.gradle.instrumentation
 
 import com.google.common.truth.Truth.assertThat
+import io.sentry.android.core.SentryGeneratedBuildTimeOptions
 import io.sentry.android.gradle.util.SentryModules
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.junit.Test
@@ -47,8 +48,9 @@ class LoadClassClassVisitorTest {
   @Test
   fun `injects availability map when static initializer is missing`() {
     val availability = mapOf("present.Class" to true, "missing.Class" to false)
+    SentryGeneratedBuildTimeOptions.availability = availability
 
-    val clazz = load(transformClass(hasStaticInitializer = false, availability = availability))
+    val clazz = load(transformClass(hasStaticInitializer = false))
 
     assertThat(readAvailability(clazz)).containsExactlyEntriesIn(availability)
   }
@@ -56,8 +58,9 @@ class LoadClassClassVisitorTest {
   @Test
   fun `injects availability map and preserves existing static initializer`() {
     val availability = mapOf("present.Class" to true)
+    SentryGeneratedBuildTimeOptions.availability = availability
 
-    val clazz = load(transformClass(hasStaticInitializer = true, availability = availability))
+    val clazz = load(transformClass(hasStaticInitializer = true))
 
     assertThat(clazz.getDeclaredField("marker").getInt(null)).isEqualTo(7)
     assertThat(readAvailability(clazz)).containsExactlyEntriesIn(availability)
@@ -73,7 +76,6 @@ class LoadClassClassVisitorTest {
   private fun transformClass(
     hasAvailabilityField: Boolean = true,
     hasStaticInitializer: Boolean = false,
-    availability: Map<String, Boolean> = emptyMap(),
   ): ByteArray {
     val original = ClassWriter(0)
     original.visit(
@@ -112,7 +114,7 @@ class LoadClassClassVisitorTest {
 
     val reader = ClassReader(original.toByteArray())
     val writer = ClassWriter(reader, ClassWriter.COMPUTE_FRAMES or ClassWriter.COMPUTE_MAXS)
-    reader.accept(LoadClassClassVisitor(Opcodes.ASM9, writer, availability), 0)
+    reader.accept(LoadClassClassVisitor(Opcodes.ASM9, writer), 0)
     return writer.toByteArray()
   }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginConfigurationCacheTest.kt
@@ -146,6 +146,10 @@ class SentryPluginConfigurationCacheTest :
       runner.withArguments("--configuration-cache", "--build-cache", ":app:assembleDebug")
 
     val run0 = runner.build()
+    assertEquals(
+      TaskOutcome.SUCCESS,
+      run0.task(":app:generateSentryBuildTimeOptionsDebug")?.outcome,
+    )
     assertFalse(
       "Reusing configuration cache." in run0.output ||
         "Configuration cache entry reused." in run0.output,
@@ -153,6 +157,10 @@ class SentryPluginConfigurationCacheTest :
     )
 
     val run1 = runner.build()
+    assertEquals(
+      TaskOutcome.UP_TO_DATE,
+      run1.task(":app:generateSentryBuildTimeOptionsDebug")?.outcome,
+    )
     assertTrue(
       "Reusing configuration cache." in run1.output ||
         "Configuration cache entry reused." in run1.output,

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -561,12 +561,24 @@ class SentryPluginTest :
 
   @Test
   fun `registers runtime optimizations independently from tracing instrumentation`() {
-    applyTracingInstrumentation(false, appStart = false, logcat = false)
+    applyTracingInstrumentation(
+      tracingInstrumentation = false,
+      appStart = false,
+      logcat = false,
+      dependencies = setOf("com.jakewharton.timber:timber:5.0.1"),
+      sdkVersion = BuildConfig.SdkVersion,
+    )
 
-    val build = runner.appendArguments(":app:assembleRelease", "--info").build()
+    val build =
+      runner.appendArguments(":app:assembleDebug", "--info", "--warning-mode", "all").build()
 
-    assertTrue(":app:transformReleaseClassesWithAsm" in build.output)
-    assertTrue("Detected Sentry modules" in build.output)
+    assertEquals(
+      TaskOutcome.SUCCESS,
+      build.task(":app:generateSentryBuildTimeOptionsDebug")?.outcome,
+      build.output,
+    )
+    assertTrue(":app:transformDebugClassesWithAsm" in build.output)
+    assertFalse("RuntimeClasspath' was resolved during configuration time" in build.output)
   }
 
   @Test

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/integration/SentryPluginTest.kt
@@ -565,19 +565,19 @@ class SentryPluginTest :
       tracingInstrumentation = false,
       appStart = false,
       logcat = false,
-      dependencies = setOf("com.jakewharton.timber:timber:5.0.1"),
+      dependencies = setOf("androidx.compose.ui:ui:1.7.0", "com.jakewharton.timber:timber:5.0.1"),
       sdkVersion = BuildConfig.SdkVersion,
     )
 
     val build =
-      runner.appendArguments(":app:assembleDebug", "--info", "--warning-mode", "all").build()
+      runner.appendArguments(":app:assembleRelease", "--info", "--warning-mode", "all").build()
 
     assertEquals(
       TaskOutcome.SUCCESS,
-      build.task(":app:generateSentryBuildTimeOptionsDebug")?.outcome,
+      build.task(":app:generateSentryBuildTimeOptionsRelease")?.outcome,
       build.output,
     )
-    assertTrue(":app:transformDebugClassesWithAsm" in build.output)
+    assertTrue(":app:transformReleaseClassesWithAsm" in build.output)
     assertFalse("RuntimeClasspath' was resolved during configuration time" in build.output)
   }
 

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/CollectSourcesTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/CollectSourcesTaskTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class CollectSourcesTaskTest {
 
   @Test
-  fun `cli-executable is set correctly`() {
+  fun `collects app sources and skips generated build-time options`() {
     val project = createProject()
 
     project.file("dummy/src/a/TestFile1.java").also {
@@ -24,6 +24,10 @@ class CollectSourcesTaskTest {
     project.file("dummy/src/b/TestFile3.java").also {
       it.parentFile.mkdirs()
       it.writeText("TestFile3")
+    }
+    project.file("dummy/src/a/io/sentry/android/core/SentryGeneratedBuildTimeOptions.java").also {
+      it.parentFile.mkdirs()
+      it.writeText("SentryGeneratedBuildTimeOptions")
     }
 
     val sourceDirs = project.files()

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTaskTest.kt
@@ -1,0 +1,43 @@
+package io.sentry.android.gradle.tasks
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.artifacts.Configuration
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GenerateSentryBuildTimeOptionsTaskTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Test
+  fun `generates class availability source`() {
+    val project = ProjectBuilder.builder().withProjectDir(tempDir.newFolder("project")).build()
+    val outputDir = tempDir.newFolder("generated")
+    val task =
+      project.tasks.register("generateOptions", GenerateSentryBuildTimeOptionsTask::class.java) {
+        it.moduleIds.set(setOf("com.jakewharton.timber:timber", "androidx.core:core"))
+        it.output.set(outputDir)
+      }
+
+    task.get().generate()
+
+    val source =
+      outputDir.resolve("io/sentry/android/core/SentryGeneratedBuildTimeOptions.java").readText()
+    assertThat(source).contains("availability.put(\"timber.log.Timber\", true);")
+    assertThat(source).contains("availability.put(\"androidx.core.view.ScrollingView\", true);")
+    assertThat(source).contains("availability.put(\"androidx.lifecycle.Lifecycle\", false);")
+  }
+
+  @Test
+  fun `register does not resolve runtime classpath`() {
+    val project = ProjectBuilder.builder().withProjectDir(tempDir.newFolder("java-project")).build()
+    project.plugins.apply("java")
+    val runtimeClasspath = project.configurations.getByName("runtimeClasspath")
+
+    GenerateSentryBuildTimeOptionsTask.register(project, "runtimeClasspath", "Test")?.get()
+
+    assertThat(runtimeClasspath.state).isEqualTo(Configuration.State.UNRESOLVED)
+  }
+}

--- a/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTaskTest.kt
+++ b/plugin-build/src/test/kotlin/io/sentry/android/gradle/tasks/GenerateSentryBuildTimeOptionsTaskTest.kt
@@ -40,4 +40,30 @@ class GenerateSentryBuildTimeOptionsTaskTest {
 
     assertThat(runtimeClasspath.state).isEqualTo(Configuration.State.UNRESOLVED)
   }
+
+  @Test
+  fun `register includes project dependencies`() {
+    val root = ProjectBuilder.builder().withProjectDir(tempDir.newFolder("root")).build()
+    val replayDir = root.file("sentry-android-replay").apply { mkdir() }
+    val replay =
+      ProjectBuilder.builder()
+        .withName("sentry-android-replay")
+        .withProjectDir(replayDir)
+        .withParent(root)
+        .build()
+    replay.group = "io.sentry"
+    replay.plugins.apply("java")
+    val appDir = root.file("app").apply { mkdir() }
+    val app =
+      ProjectBuilder.builder().withName("app").withProjectDir(appDir).withParent(root).build()
+    app.plugins.apply("java")
+    app.dependencies.add(
+      "implementation",
+      app.dependencies.project(mapOf("path" to ":sentry-android-replay")),
+    )
+
+    val task = GenerateSentryBuildTimeOptionsTask.register(app, "runtimeClasspath", "Test")!!.get()
+
+    assertThat(task.moduleIds.get()).contains("io.sentry:sentry-android-replay")
+  }
 }


### PR DESCRIPTION
Generate an app-owned Java source containing SDK integration class availability from the variant runtime classpath. The ASM transform now emits a stable symbolic call to that generated class and no longer carries variant-specific inputs.

This moves dependency resolution into a cacheable source-generation task, avoiding runtime classpath resolution during Gradle configuration and keeping the transform isolated and configuration-cache compatible.

The SDK-side availability field shipped in [sentry-java#5875](https://github.com/getsentry/sentry-java/pull/5875). Older SDK versions are detected and left unchanged, retaining reflection as the fallback.
