### PR TITLE
build(gradle): Set group so composite substitution works automatically

### DIFF
--- a/sentry-kotlin-compiler-plugin/build.gradle.kts
+++ b/sentry-kotlin-compiler-plugin/build.gradle.kts
@@ -10,6 +10,9 @@ plugins {
   alias(libs.plugins.spotless)
 }
 
+// Composite substitution matches on project.group, which Vanniktech's GROUP does not set.
+group = providers.gradleProperty("GROUP").get()
+
 val kotlin1920: SourceSet by sourceSets.creating
 val kotlin2120: SourceSet by sourceSets.creating
 val kotlin2200: SourceSet by sourceSets.creating

--- a/sentry-snapshots-runtime/build.gradle.kts
+++ b/sentry-snapshots-runtime/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
   alias(libs.plugins.spotless)
 }
 
+// Composite substitution matches on project.group, which Vanniktech's GROUP does not set.
+group = providers.gradleProperty("GROUP").get()
+
 spotless {
   kotlin {
     ktfmt(libs.versions.ktfmt.get()).googleStyle()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,14 +66,6 @@ include(":examples:multi-module-sample:spring-boot-in-multi-module-sample2")
 includeBuild("plugin-build")
 
 // this is needed so we can use kotlin-compiler-plugin directly in the sample app without publishing
-includeBuild("sentry-kotlin-compiler-plugin") {
-  dependencySubstitution {
-    substitute(module("io.sentry:sentry-kotlin-compiler-plugin")).using(project(":"))
-  }
-}
+includeBuild("sentry-kotlin-compiler-plugin")
 
-includeBuild("sentry-snapshots-runtime") {
-  dependencySubstitution {
-    substitute(module("io.sentry:sentry-snapshots-runtime")).using(project(":"))
-  }
-}
+includeBuild("sentry-snapshots-runtime")


### PR DESCRIPTION
For composite builds, dependency substitution works automatically. However because we aren't setting the `group` property in gradle, the dependency substituion doesn't work. This sets the `group` in gradle so that 

This sets the `group` on the two projects using dependency substituion works properly.

This simplifies the code and should hopefully also fix the build error we are getting in renovate `The root project is not yet available for build`

GRADLE-116

#skip-changelog