### PR TITLE
build(develocity): Only publish build scans on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Stop publishing Build Scans by default for local builds of this repo; CI still publishes automatically, and local developers can opt in with `--scan` ([#1412](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1412))
+
 ### Dependencies
 
 - Bump ComposablePreviewScanner from v0.9.2 to v0.9.3 ([#1408](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1408))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,10 +15,26 @@ plugins {
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.8.0"
 }
 
+val isCiBuild =
+  providers
+    .environmentVariable("CI")
+    .orElse(providers.systemProperty("CI"))
+    .map { value ->
+      value.isNotBlank() && !value.equals("false", ignoreCase = true) && value != "0"
+    }
+    .orElse(false)
+    .get()
+val isBuildScanRequested = startParameter.isBuildScan
+val shouldPublishBuildScan = isCiBuild || isBuildScanRequested
+
 develocity {
   buildScan {
     termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
     termsOfUseAgree.set("yes")
+    // Keep local scans opt-in via --scan, while still publishing automatically on CI.
+    if (!shouldPublishBuildScan) {
+      publishing.onlyIf { false }
+    }
   }
 }
 


### PR DESCRIPTION
## :scroll: Description

Make local Build Scans opt-in instead of publishing them by default for anyone who builds the repo.

Keep CI publishing enabled for build diagnostics, and preserve explicit local opt-in via `--scan`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This changes the repo’s Develocity configuration so local builds no longer publish Build Scans by default for anyone who clones the repo and runs Gradle. CI builds still publish scans for diagnostics, and local developers can still opt in explicitly with `--scan`.       

Refs GRADLE-120


## :green_heart: How did you test it?

Clanker ran relevant commands locally and verified scans were or weren't produced.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
