### PR TITLE
build(develocity): Make build scan publishing opt-in locally

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,10 +15,21 @@ plugins {
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.8.0"
 }
 
+val isCI = System.getenv("CI") != null
+val gradleTOUAgree = "true" == providers.gradleProperty("gradleTOUAgree").orNull
+
 develocity {
   buildScan {
     termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
-    termsOfUseAgree.set("yes")
+    termsOfUseAgree.set(if (isCI || gradleTOUAgree) "yes" else "no")
+    uploadInBackground = !isCI
+    // we can't pass the condition directly inside the onlyIf because of a CC bug in Gradle 8.X (this is fixed in 9.X)
+    if (!isCI && !gradleTOUAgree) {
+      publishing.onlyIf { false }
+    }
+    obfuscation {
+      ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
+    }
   }
 }
 
@@ -30,7 +41,7 @@ dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 }
 
-rootProject.name = ("sentry-android-gradle-plugin-composite-build")
+rootProject.name = "sentry-android-gradle-plugin-composite-build"
 
 include(":examples:android-gradle")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,13 +23,12 @@ develocity {
     termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
     termsOfUseAgree.set(if (isCI || gradleTOUAgree) "yes" else "no")
     uploadInBackground = !isCI
-    // we can't pass the condition directly inside the onlyIf because of a CC bug in Gradle 8.X (this is fixed in 9.X)
+    // we can't pass the condition directly inside the onlyIf because of a CC bug in Gradle 8.X
+    // (this is fixed in 9.X)
     if (!isCI && !gradleTOUAgree) {
       publishing.onlyIf { false }
     }
-    obfuscation {
-      ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
-    }
+    obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
   }
 }
 


### PR DESCRIPTION
## :scroll: Description
Fixes GRADLE-120. This doesn't accept TOS without opting in via a gradle flag.
CI builds will all accept and publish scans.

For local builds, you can add `gradleTOUAgree` to your `gradle.properties` in your Gradle home to opt in.


2 other changes

1. don't use background build scan publication on CI because it can get cut off by the worker
2. don't publish IP address

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes GRADLE-120 (https://linear.app/getsentry/issue/GRADLE-120/please-stop-accepting-build-scan-tos-for-everyone)
Fixes #1398

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps

#skip-changelog
