### PR TITLE
Fix snapshot task wiring for multi-flavor application modules

### DIFF
--- a/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
+++ b/plugin-build/src/main/kotlin/io/sentry/android/gradle/AndroidComponentsConfig.kt
@@ -535,9 +535,11 @@ private fun ApplicationVariant.configureSnapshotsTasks(
 
     project.afterEvaluate {
       // Not all variants have unit test tasks (e.g. users can disable them),
-      // so skip wiring if the task doesn't exist.
+      // so skip wiring if the task doesn't exist. Filter by Test type because AGP
+      // registers DefaultTask stubs for variants without full unit test support on
+      // multi-flavor application modules, and named(name, Test::class) throws on those.
       val testTaskName = "test${taskSuffix}UnitTest"
-      if (testTaskName !in project.tasks.names) return@afterEvaluate
+      if (testTaskName !in project.tasks.withType(Test::class.java).names) return@afterEvaluate
 
       val testTask = project.tasks.named(testTaskName, Test::class.java)
       uploadTask.configure { task ->


### PR DESCRIPTION
## :scroll: Description

`configureSnapshotsTasks` calls `tasks.named(name, Test::class.java)` for every variant's unit test task. On application modules with multiple flavors, AGP registers DefaultTask stubs for variants without full unit test support, and the typed `named()` overload throws `InvalidUserDataException` on those stubs.

Replace `tasks.names` with `tasks.withType(Test::class.java).names` so the existence check also verifies the type. This filters out DefaultTask stubs without eager task realization and preserves Isolated Projects compatibility.

## :bulb: Motivation and Context
Enabling Sentry Snapshots for our multi-flavor application breaks our build during the configuration phase

```  
A problem occurred configuring project ':app'.
  > Failed to notify project evaluation listener.
     > The task 'test<variantA>DebugUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
     > The task 'test<variantB>ReleaseUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
     > The task 'test<variantA>ReleaseUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
     > The task 'test<variantB>BenchmarkReleaseUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
     > The task 'test<variantA>BenchmarkReleaseUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
     > The task 'test<variantB>NonMinifiedReleaseUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
     > The task 'test<variantA>NonMinifiedReleaseUnitTest' (org.gradle.api.DefaultTask) is not a subclass of the given type (org.gradle.api.tasks.testing.Test).
```

## :green_heart: How did you test it?
Deployed to localMaven and was able to successfully run `:app:sentryUploadSnapshots<Variant>Debug` and upload snapshots.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
