### PR TITLE
docs(changelog): Add missing entry for snapshot task wiring fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix snapshot task wiring failing with `InvalidUserDataException` on application modules with multiple flavors ([#1431](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1431))
+
 ### Security
 
 - Verify the Kotlin compiler plugin's build dependencies with PGP signatures ([#1423](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1423), [#1430](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1430))


### PR DESCRIPTION
## :scroll: Description

[#1431](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1431) doesn't have a `CHANGELOG.md` entry This adds the missing entry so the fix shows up in the next release notes.

Verified: no `#1431` reference exists anywhere in `CHANGELOG.md` on `main`.

## :bulb: Motivation and Context

missing changelog