### PR TITLE
fix(samples): Raise instrumentation sample minSdk

### DIFF
--- a/examples/android-instrumentation-sample/build.gradle.kts
+++ b/examples/android-instrumentation-sample/build.gradle.kts
@@ -24,7 +24,9 @@ if (getKotlinPluginVersion() >= "2.0.0") {
 android {
   compileSdk = LibsVersion.SDK_VERSION
   defaultConfig {
-    minSdk = LibsVersion.MIN_SDK_VERSION
+    // androidx.room:room-runtime-android 2.8.4 and androidx.room3:room3-runtime-android 3.0.2
+    // require minSdk 23.
+    minSdk = 23
     targetSdk = LibsVersion.SDK_VERSION
     versionCode = 1
     versionName = "1.0"


### PR DESCRIPTION
## :scroll: Description

Raise the Android instrumentation sample to minSdk 23 so it remains buildable with androidx.room:room-runtime-android 2.8.4 (bumped in #1427) and androidx.room3:room3-runtime-android 3.0.2 (bumped in #1425).


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Our recently bumped Room versions now declares minSdk 23. The rest of the repo can continue targeting 21 because the requirement comes from the sample dependency rather than from SAGP itself.

Alternative would be to revert #1425 and #1427 (chime in if you have strong opinions and I'll be happy to do so – note that some of our sample apps in sentry-java also apply minSdk 23). 


## :green_heart: How did you test it?

Ran our existing instrumentation tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

#skip-changelog